### PR TITLE
Fix laser sight to extend to viewport edges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/27
-Your prepared branch: issue-27-9e4cce117de9
-Your prepared working directory: /tmp/gh-issue-solver-1768173999200
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary
This PR fixes the laser sight to appear infinite by making it extend to the viewport edges instead of having a fixed length.

## Problem
The laser sight was previously limited to a fixed 500 pixel length, which meant it could arbitrarily terminate within the viewport without hitting any obstacles. This made the laser appear short and not infinite as intended.

## Solution
Modified the `UpdateLaserSight()` method in `Scripts/Weapons/AssaultRifle.cs` to:
- Calculate maximum laser length dynamically based on viewport size
- Use the viewport diagonal length to ensure the laser reaches the edge in any direction
- Maintain backward compatibility by keeping the `LaserSightLength` property (with updated documentation)

The laser still uses raycasting to properly stop at obstacles, but now it will always extend to the viewport edges before being cut off by an obstacle, making it appear infinite.

## Changes
- **Scripts/Weapons/AssaultRifle.cs**:
  - Updated `UpdateLaserSight()` to calculate max length from viewport size (lines 187-200)
  - Added viewport null check for safety
  - Updated `LaserSightLength` property documentation to note it's no longer used

## Testing
- ✅ All CI checks pass
- ✅ Windows build succeeds
- The laser will now extend across the entire viewport and appear infinite

## Fixes
Closes #27

---
*This PR was created by the AI issue solver*