### PR TITLE
Fix R-F-R reload sequence to allow R restart during sequence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/56
-Your prepared branch: issue-56-fc86b859afd2
-Your prepared working directory: /tmp/gh-issue-solver-1768232032837
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary
- Fixed the R-F-R reload sequence to work correctly when R is pressed multiple times before completing the sequence
- The issue was that pressing R during step 1 (waiting for F) would reset the sequence entirely instead of restarting it

## Root Cause
In the previous implementation, when `_reloadSequenceStep == 1` and the user pressed R, the code would hit the `else` branch that reset the sequence to step 0. This caused sequences like `R -> R -> F -> R` to fail even though `R -> F -> R` was pressed within that sequence.

## Fix
Changed the condition from:
```csharp
if (_reloadSequenceStep == 0)
```
to:
```csharp
if (_reloadSequenceStep == 0 || _reloadSequenceStep == 1)
```

This allows R to restart the sequence (keeping step at 1) when the player is already waiting for F. The behavior is now:
- `R -> F -> R` (normal sequence): ✅ works
- `R -> R -> F -> R` (issue #56 scenario): ✅ works  
- `R -> R -> R -> F -> R` (multiple R presses): ✅ works
- `R -> F -> F -> R` (wrong key mid-sequence): ✅ correctly resets on second F

## Test plan
- [x] Press R, then F, then R - should reload instantly
- [x] Press R, then R again, then F, then R - should reload instantly (this was the broken case)
- [x] Press R, then F, then F (wrong), then R - should NOT reload (sequence resets on wrong key)

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)