### PR TITLE
Add 600ms reaction delay for enemies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/52
-Your prepared branch: issue-52-94b9aa09867d
-Your prepared working directory: /tmp/gh-issue-solver-1768253767024
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary
- Increase enemy detection delay from 50ms to 600ms when player enters line of sight
- Add 600ms reaction delay before enemies react to bullets in their threat sphere
- Ensure detection delay is consistently applied across all combat states
- Delay "recharges" each time player breaks direct contact with the enemy

## Changes
- Modified `detection_delay` default from `0.05` to `0.6` seconds (600ms)
- Added `threat_reaction_delay` property (600ms) for bullet threat sphere detection
- Added `_threat_reaction_timer` and `_threat_reaction_delay_elapsed` state variables
- Updated `_update_suppression()` to apply delayed reaction to bullets in threat sphere
- Updated shooting logic in `_process_seeking_cover_state()`, `_process_in_cover_state()`, and `_process_suppressed_state()` to respect detection delay
- Updated `_reset()` to reset new timer variables

## Test plan
- [x] Verify enemies take 600ms to start shooting when player first enters their line of sight
- [x] Verify detection delay resets when player breaks line of sight and re-enters
- [x] Verify enemies take 600ms to react to bullets hitting near them (threat sphere)
- [x] Verify enemy behavior remains correct in all AI states (combat, seeking cover, in cover, suppressed)

Fixes Jhon-Crow/godot-topdown-MVP#52

🤖 Generated with [Claude Code](https://claude.com/claude-code)