### PR TITLE
Fix grenade thrown from activation position instead of player position

### DIFF
--- a/Scripts/Characters/Player.cs
+++ b/Scripts/Characters/Player.cs
@@ -1047,8 +1047,12 @@ public partial class Player : BaseCharacter
     {
         if (_activeGrenade != null && IsInstanceValid(_activeGrenade))
         {
+            // Set position to current player position before unfreezing
+            _activeGrenade.GlobalPosition = GlobalPosition;
+            // Unfreeze the grenade so physics works and it can explode
+            _activeGrenade.Freeze = false;
             // The grenade stays where it is (at player's feet)
-            LogToFile($"[Player.Grenade] Grenade dropped at feet at {_activeGrenade.GlobalPosition}");
+            LogToFile($"[Player.Grenade] Grenade dropped at feet at {_activeGrenade.GlobalPosition} (unfrozen)");
         }
         ResetGrenadeState();
     }

--- a/docs/case-studies/issue-183/README.md
+++ b/docs/case-studies/issue-183/README.md
@@ -1,0 +1,91 @@
+# Issue #183: Fix Grenade Position Bug
+
+## Problem Statement
+
+The grenade is periodically thrown from the **activation position** (where the player pulled the pin) instead of the **player's current position** (where the player is when throwing).
+
+Russian: "сейчас граната периодически бросается с позиции активации, а не с позиции игрока"
+
+## Timeline of Events (from logs)
+
+### Log 1 (game_log_20260121_201747.txt)
+- Player at spawn position (450, 1250)
+- Grenade prepared and dropped at feet (not thrown)
+
+### Log 2 (game_log_20260121_201759.txt)
+- **First throw:** Player at (360.78598, 1163.6112), successful throw
+- **Second throw:** Player at (450, 1250) - spawn position, successful throw
+
+### Log 3 (game_log_20260121_201843.txt)
+- Multiple grenade throws observed
+- Some grenades landing at unexpected positions
+
+## Root Cause Analysis
+
+### Previous Fix (Commit 34b7f68)
+A previous fix addressed a related issue where `global_position` was being set **before** `add_child()`. In Godot, `global_position` only works correctly when the node is already in the scene tree. The fix reordered operations:
+
+```gdscript
+# BEFORE (bug):
+_active_grenade.global_position = global_position  # Doesn't work - node not in tree
+get_tree().current_scene.add_child(_active_grenade)
+
+# AFTER (fix):
+get_tree().current_scene.add_child(_active_grenade)  # Add to tree first
+_active_grenade.global_position = global_position    # Now this works
+```
+
+This fix was applied to both `player.gd` and `Player.cs`.
+
+### Current Root Cause: RigidBody2D Physics Interference
+
+The grenade (`GrenadeBase`) extends `RigidBody2D`. When a `RigidBody2D` is active (not frozen), the physics engine continuously updates its position. This can cause **race conditions**:
+
+1. **Creation phase:**
+   - Grenade is instantiated and added to scene
+   - `global_position` is set to player position
+   - Physics engine might process a step and reset/modify position
+
+2. **Hold phase:**
+   - Player code updates `_active_grenade.global_position = global_position` every frame
+   - Physics engine is also running, potentially causing conflicts
+
+3. **Throw phase:**
+   - Position is set before applying velocity
+   - Physics engine might process differently depending on timing
+
+### Why It's Intermittent
+
+The bug is intermittent because it depends on the **exact timing** of when manual position updates occur relative to physics engine steps. If they happen to align poorly, the physics engine can overwrite or ignore the manual position setting.
+
+## Solution
+
+Freeze the `RigidBody2D` while the grenade is being held by the player. This prevents the physics engine from interfering with manual position updates. Unfreeze it only when thrown.
+
+### Implementation Changes
+
+1. **GrenadeBase (`grenade_base.gd`):**
+   - Add `freeze = true` in `_ready()` to start frozen
+   - Add method to unfreeze when thrown
+
+2. **Player (`player.gd` and `Player.cs`):**
+   - Unfreeze the grenade when calling `throw_grenade()`
+
+This approach ensures:
+- No physics interference while grenade follows player
+- Clean handoff to physics when thrown
+- Position is always accurate at throw time
+
+## Files Changed
+
+- `scripts/projectiles/grenade_base.gd` - Add freeze logic
+- `scripts/characters/player.gd` - Unfreeze on throw
+- `Scripts/Characters/Player.cs` - Unfreeze on throw (C# version)
+
+## Testing
+
+After the fix, the grenade should:
+1. Always be created at the player's current position
+2. Follow the player exactly while held (no jitter/offset)
+3. Be thrown from the player's current position, not the activation position
+4. Have correct physics after being thrown (velocity, friction, etc.)

--- a/docs/case-studies/issue-183/game_log_20260121_201747.txt
+++ b/docs/case-studies/issue-183/game_log_20260121_201747.txt
@@ -1,0 +1,80 @@
+[20:17:47] [INFO] ============================================================
+[20:17:47] [INFO] GAME LOG STARTED
+[20:17:47] [INFO] ============================================================
+[20:17:47] [INFO] Timestamp: 2026-01-21T20:17:47
+[20:17:47] [INFO] Log file: I:/Загрузки/godot exe/game_log_20260121_201747.txt
+[20:17:47] [INFO] Executable: I:/Загрузки/godot exe/Godot-Top-Down-Template.exe
+[20:17:47] [INFO] OS: Windows
+[20:17:47] [INFO] Debug build: false
+[20:17:47] [INFO] Engine version: 4.3-stable (official)
+[20:17:47] [INFO] Project: Godot Top-Down Template
+[20:17:47] [INFO] ------------------------------------------------------------
+[20:17:47] [INFO] [GameManager] GameManager ready
+[20:17:47] [INFO] [ScoreManager] ScoreManager ready
+[20:17:47] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[20:17:47] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:17:47] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[20:17:47] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[20:17:47] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[20:17:47] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[20:17:47] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[20:17:47] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[20:17:47] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:17:47] [INFO] [LastChance] Last chance shader loaded successfully
+[20:17:47] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[20:17:47] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[20:17:47] [INFO] [LastChance]   Sepia intensity: 0.70
+[20:17:47] [INFO] [LastChance]   Brightness: 0.60
+[20:17:47] [INFO] [Player.Grenade] Grenade scene loaded
+[20:17:47] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:17:47] [INFO] [Player] Ready! Grenades: 1/3
+[20:17:47] [INFO] [ScoreManager] Level started with 10 enemies
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[20:17:47] [ENEMY] [Enemy1] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 2, behavior: GUARD, player_found: yes
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[20:17:47] [ENEMY] [Enemy2] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 3, behavior: GUARD, player_found: yes
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[20:17:47] [ENEMY] [Enemy3] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[20:17:47] [ENEMY] [Enemy4] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[20:17:47] [ENEMY] [Enemy5] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[20:17:47] [ENEMY] [Enemy6] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 3, behavior: GUARD, player_found: yes
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[20:17:47] [ENEMY] [Enemy7] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy7] Enemy spawned at (1606.114, 893.8859), health: 4, behavior: PATROL, player_found: yes
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[20:17:47] [ENEMY] [Enemy8] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 2, behavior: GUARD, player_found: yes
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[20:17:47] [ENEMY] [Enemy9] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:17:47] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[20:17:47] [ENEMY] [Enemy10] Registered as sound listener
+[20:17:47] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 3, behavior: PATROL, player_found: yes
+[20:17:47] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:17:47] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:17:47] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:17:47] [INFO] [LastChance] Found player: Player
+[20:17:47] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:17:47] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:17:47] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:17:48] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (355.28433, 1306.7719)
+[20:17:48] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:17:48] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:17:48] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:17:48] [INFO] [Player.Grenade] Step 1 complete! Drag: (637.6494, -70.12988)
+[20:17:49] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:17:50] [INFO] [Player.Grenade] RMB released before G - back to waiting for RMB
+[20:17:50] [INFO] [Player.Grenade] G released - dropping grenade at feet
+[20:17:50] [INFO] [Player.Grenade] Grenade dropped at feet at (450, 1250)
+[20:17:52] [INFO] ------------------------------------------------------------
+[20:17:52] [INFO] GAME LOG ENDED: 2026-01-21T20:17:52
+[20:17:52] [INFO] ============================================================

--- a/docs/case-studies/issue-183/game_log_20260121_201759.txt
+++ b/docs/case-studies/issue-183/game_log_20260121_201759.txt
@@ -1,0 +1,140 @@
+[20:17:59] [INFO] ============================================================
+[20:17:59] [INFO] GAME LOG STARTED
+[20:17:59] [INFO] ============================================================
+[20:17:59] [INFO] Timestamp: 2026-01-21T20:17:59
+[20:17:59] [INFO] Log file: I:/Загрузки/godot exe/game_log_20260121_201759.txt
+[20:17:59] [INFO] Executable: I:/Загрузки/godot exe/Godot-Top-Down-Template.exe
+[20:17:59] [INFO] OS: Windows
+[20:17:59] [INFO] Debug build: false
+[20:17:59] [INFO] Engine version: 4.3-stable (official)
+[20:17:59] [INFO] Project: Godot Top-Down Template
+[20:17:59] [INFO] ------------------------------------------------------------
+[20:17:59] [INFO] [GameManager] GameManager ready
+[20:17:59] [INFO] [ScoreManager] ScoreManager ready
+[20:17:59] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[20:17:59] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:17:59] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[20:17:59] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[20:17:59] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[20:17:59] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[20:17:59] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[20:17:59] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[20:17:59] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:17:59] [INFO] [LastChance] Last chance shader loaded successfully
+[20:17:59] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[20:17:59] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[20:17:59] [INFO] [LastChance]   Sepia intensity: 0.70
+[20:17:59] [INFO] [LastChance]   Brightness: 0.60
+[20:17:59] [INFO] [Player.Grenade] Grenade scene loaded
+[20:17:59] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:17:59] [INFO] [Player] Ready! Grenades: 1/3
+[20:17:59] [INFO] [ScoreManager] Level started with 10 enemies
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[20:17:59] [ENEMY] [Enemy1] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 3, behavior: GUARD, player_found: yes
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[20:17:59] [ENEMY] [Enemy2] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[20:17:59] [ENEMY] [Enemy3] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[20:17:59] [ENEMY] [Enemy4] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[20:17:59] [ENEMY] [Enemy5] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 3, behavior: GUARD, player_found: yes
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[20:17:59] [ENEMY] [Enemy6] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[20:17:59] [ENEMY] [Enemy7] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy7] Enemy spawned at (1606.114, 893.8859), health: 3, behavior: PATROL, player_found: yes
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[20:17:59] [ENEMY] [Enemy8] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 3, behavior: GUARD, player_found: yes
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[20:17:59] [ENEMY] [Enemy9] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 4, behavior: GUARD, player_found: yes
+[20:17:59] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[20:17:59] [ENEMY] [Enemy10] Registered as sound listener
+[20:17:59] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:17:59] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:17:59] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:17:59] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:17:59] [INFO] [LastChance] Found player: Player
+[20:17:59] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:17:59] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:17:59] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:18:03] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (124.2585, 1299.9788)
+[20:18:03] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:18:03] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:18:03] [INFO] [Player.Grenade] Timer started, grenade created at (360.78598, 1163.6112)
+[20:18:03] [INFO] [Player.Grenade] Step 1 complete! Drag: (645.3445, -146.62817)
+[20:18:03] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:18:03] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:18:04] [INFO] [Player.Grenade] Throwing! Direction: (0.3939492, -0.9191322), Drag distance: 435,82025
+[20:18:04] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,165872
+[20:18:04] [INFO] [GrenadeBase] Thrown! Direction: (0.393949, -0.919132), Speed: 871.6
+[20:18:04] [INFO] [Player.Grenade] Thrown! Direction: (0.3939492, -0.9191322), Drag distance: 435,82025
+[20:18:04] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:18:05] [INFO] [GrenadeBase] Grenade landed at (480.0115, 799.1398)
+[20:18:06] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:18:06] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:18:06] [INFO] [Player.Grenade] Grenade scene loaded
+[20:18:06] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:18:06] [INFO] [Player] Ready! Grenades: 1/3
+[20:18:06] [INFO] [ScoreManager] Level started with 10 enemies
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:18:06] [ENEMY] [Enemy1] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:18:06] [ENEMY] [Enemy2] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:18:06] [ENEMY] [Enemy3] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 2, behavior: GUARD, player_found: yes
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:18:06] [ENEMY] [Enemy4] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:18:06] [ENEMY] [Enemy5] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 3, behavior: GUARD, player_found: yes
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:18:06] [ENEMY] [Enemy6] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 3, behavior: GUARD, player_found: yes
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:18:06] [ENEMY] [Enemy7] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 3, behavior: PATROL, player_found: yes
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:18:06] [ENEMY] [Enemy8] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 2, behavior: GUARD, player_found: yes
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:18:06] [ENEMY] [Enemy9] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:18:06] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:18:06] [ENEMY] [Enemy10] Registered as sound listener
+[20:18:06] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 3, behavior: PATROL, player_found: yes
+[20:18:06] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:18:06] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:18:06] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:18:06] [INFO] [LastChance] Found player: Player
+[20:18:06] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:18:06] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:18:06] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:18:07] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (511.4505, 1227.2913)
+[20:18:07] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:18:07] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:18:07] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:18:07] [INFO] [Player.Grenade] Step 1 complete! Drag: (497.31616, -178.3302)
+[20:18:07] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:18:08] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:18:09] [INFO] [Player.Grenade] Throwing! Direction: (0.3517926, -0.936078), Drag distance: 587,7355
+[20:18:09] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,2113109
+[20:18:09] [INFO] [GrenadeBase] Thrown! Direction: (0.351793, -0.936078), Speed: 1175.5
+[20:18:09] [INFO] [Player.Grenade] Thrown! Direction: (0.3517926, -0.936078), Drag distance: 587,7355
+[20:18:09] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:18:09] [INFO] [GrenadeBase] Grenade landed at (532.6486, 1032.396)
+[20:18:10] [INFO] ------------------------------------------------------------
+[20:18:10] [INFO] GAME LOG ENDED: 2026-01-21T20:18:10
+[20:18:10] [INFO] ============================================================

--- a/docs/case-studies/issue-183/game_log_20260121_201843.txt
+++ b/docs/case-studies/issue-183/game_log_20260121_201843.txt
@@ -1,0 +1,2585 @@
+[20:18:43] [INFO] ============================================================
+[20:18:43] [INFO] GAME LOG STARTED
+[20:18:43] [INFO] ============================================================
+[20:18:43] [INFO] Timestamp: 2026-01-21T20:18:43
+[20:18:43] [INFO] Log file: I:/Загрузки/godot exe/game_log_20260121_201843.txt
+[20:18:43] [INFO] Executable: I:/Загрузки/godot exe/Godot-Top-Down-Template.exe
+[20:18:43] [INFO] OS: Windows
+[20:18:43] [INFO] Debug build: false
+[20:18:43] [INFO] Engine version: 4.3-stable (official)
+[20:18:43] [INFO] Project: Godot Top-Down Template
+[20:18:43] [INFO] ------------------------------------------------------------
+[20:18:43] [INFO] [GameManager] GameManager ready
+[20:18:43] [INFO] [ScoreManager] ScoreManager ready
+[20:18:43] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[20:18:43] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:18:43] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[20:18:43] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[20:18:43] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[20:18:43] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[20:18:43] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[20:18:43] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[20:18:43] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:18:43] [INFO] [LastChance] Last chance shader loaded successfully
+[20:18:43] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[20:18:43] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[20:18:43] [INFO] [LastChance]   Sepia intensity: 0.70
+[20:18:43] [INFO] [LastChance]   Brightness: 0.60
+[20:18:43] [INFO] [Player.Grenade] Grenade scene loaded
+[20:18:43] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:18:43] [INFO] [Player] Ready! Grenades: 1/3
+[20:18:43] [INFO] [ScoreManager] Level started with 10 enemies
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[20:18:43] [ENEMY] [Enemy1] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[20:18:43] [ENEMY] [Enemy2] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 3, behavior: GUARD, player_found: yes
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[20:18:43] [ENEMY] [Enemy3] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[20:18:43] [ENEMY] [Enemy4] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[20:18:43] [ENEMY] [Enemy5] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 2, behavior: GUARD, player_found: yes
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[20:18:43] [ENEMY] [Enemy6] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 4, behavior: GUARD, player_found: yes
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[20:18:43] [ENEMY] [Enemy7] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy7] Enemy spawned at (1606.114, 893.8859), health: 3, behavior: PATROL, player_found: yes
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[20:18:43] [ENEMY] [Enemy8] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[20:18:43] [ENEMY] [Enemy9] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 2, behavior: GUARD, player_found: yes
+[20:18:43] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[20:18:43] [ENEMY] [Enemy10] Registered as sound listener
+[20:18:43] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:18:43] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:18:43] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:18:43] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:18:43] [INFO] [LastChance] Found player: Player
+[20:18:43] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:18:43] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:18:43] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:18:44] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (174.05954, 1253.3395)
+[20:18:45] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:18:45] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:18:45] [INFO] [Player.Grenade] Timer started, grenade created at (220.94443, 1250)
+[20:18:45] [INFO] [Player.Grenade] Step 1 complete! Drag: (420.33224, -106.8645)
+[20:18:45] [INFO] [Player.Grenade] G released - dropping grenade at feet
+[20:18:45] [INFO] [Player.Grenade] Grenade dropped at feet at (220.94443, 1250)
+[20:18:46] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:18:46] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:18:46] [INFO] [Player.Grenade] Grenade scene loaded
+[20:18:46] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:18:46] [INFO] [Player] Ready! Grenades: 1/3
+[20:18:46] [INFO] [ScoreManager] Level started with 10 enemies
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:18:46] [ENEMY] [Enemy1] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 2, behavior: GUARD, player_found: yes
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:18:46] [ENEMY] [Enemy2] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 2, behavior: GUARD, player_found: yes
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:18:46] [ENEMY] [Enemy3] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:18:46] [ENEMY] [Enemy4] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:18:46] [ENEMY] [Enemy5] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 3, behavior: GUARD, player_found: yes
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:18:46] [ENEMY] [Enemy6] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 4, behavior: GUARD, player_found: yes
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:18:46] [ENEMY] [Enemy7] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 3, behavior: PATROL, player_found: yes
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:18:46] [ENEMY] [Enemy8] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 3, behavior: GUARD, player_found: yes
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:18:46] [ENEMY] [Enemy9] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 4, behavior: GUARD, player_found: yes
+[20:18:46] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:18:46] [ENEMY] [Enemy10] Registered as sound listener
+[20:18:46] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:18:46] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:18:46] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:18:46] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:18:46] [INFO] [LastChance] Found player: Player
+[20:18:46] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:18:46] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:18:46] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:18:46] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (163.83614, 1368.219)
+[20:18:46] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:18:46] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:18:46] [INFO] [Player.Grenade] Timer started, grenade created at (305.66666, 1250)
+[20:18:46] [INFO] [Player.Grenade] Step 1 complete! Drag: (559.8927, 2.003662)
+[20:18:46] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:18:47] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:18:47] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:48] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=20
+[20:18:48] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[20:18:48] [ENEMY] [Enemy2] Heard gunshot at (700, 750), source_type=1, intensity=0.02, distance=361
+[20:18:48] [ENEMY] [Enemy4] Heard gunshot at (700, 750), source_type=1, intensity=0.08, distance=180
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:18:48] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(700, 750), shooter_id=67662514532, bullet_pos=(508.8332, 796.1848)
+[20:18:48] [INFO] [Bullet] Using shooter_position, distance=196.666702270508
+[20:18:48] [INFO] [Bullet] Distance to wall: 196.666702270508 (13.3913973957759% of viewport)
+[20:18:48] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:48] [INFO] [Bullet] Starting wall penetration at (508.8332, 796.1848)
+[20:18:48] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[20:18:48] [INFO] [Bullet] Exiting penetration at (463.4716, 807.1439) after traveling 41.6666679382324 pixels through wall
+[20:18:48] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:48] [INFO] [Player.Grenade] Throwing! Direction: (0.8024608, -0.5967047), Drag distance: 722,0992
+[20:18:48] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,6393884
+[20:18:48] [INFO] [GrenadeBase] Thrown! Direction: (0.802461, -0.596705), Speed: 1444.2
+[20:18:48] [INFO] [Player.Grenade] Thrown! Direction: (0.8024608, -0.5967047), Drag distance: 722,0992
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(668.6641, 756.467), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:18:48] [INFO] [LastChance] Threat detected: Bullet
+[20:18:48] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:18:48] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(631.7969, 762.3362), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:18:48] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:18:48] [INFO] [LastChance] Threat detected: @Area2D@538
+[20:18:48] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:18:48] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(594.8433, 767.6475), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=1, below_threshold=5
+[20:18:48] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(668.6641, 756.467), shooter_id=67662514532, bullet_pos=(64.64308, 862.9399)
+[20:18:48] [INFO] [Bullet] Using shooter_position, distance=613.333435058594
+[20:18:48] [INFO] [Bullet] Distance to wall: 613.333435058594 (41.763001413878% of viewport)
+[20:18:48] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[20:18:48] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(579.0397, 770.1457), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=1, below_threshold=5
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(573.7767, 771.0086), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=1, below_threshold=5
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(568.5136, 771.8715), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=1, below_threshold=5
+[20:18:48] [INFO] [LastChance] Threat detected: @Area2D@539
+[20:18:48] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:48] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(563.2505, 772.7344), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [ENEMY] [Enemy1] Heard gunshot at (563.2505, 772.7344), source_type=1, intensity=0.01, distance=498
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(557.9875, 773.5974), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:18:48] [INFO] [LastChance] Threat detected: @Area2D@541
+[20:18:48] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:48] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(552.7244, 774.4603), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:18:48] [INFO] [LastChance] Threat detected: @Area2D@542
+[20:18:48] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:48] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(547.4614, 775.3232), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:18:48] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[20:18:48] [INFO] [LastChance] Threat detected: @Area2D@543
+[20:18:48] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:48] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:48] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(542.1983, 776.1861), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:18:48] [INFO] [LastChance] Threat detected: Bullet
+[20:18:48] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:48] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:48] [INFO] [LastChance] Threat detected: @Area2D@544
+[20:18:48] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:48] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:48] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(536.9352, 777.049), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:48] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@545
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(531.9308, 777.2572), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@546
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(527.1727, 775.7162), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(594.8433, 767.6475), shooter_id=67662514532, bullet_pos=(29.7145, 853.8581)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=571.666748046875
+[20:18:49] [INFO] [Bullet] Distance to wall: 571.666748046875 (38.9258400769687% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (29.7145, 853.8581)
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@547
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(521.9096, 775.9975), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 48.9785995483398
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (-16.41846, 860.8957) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@548
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(516.6465, 775.9975), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(579.0397, 770.1457), shooter_id=67662514532, bullet_pos=(56.61131, 859.4116)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=529.999877929688
+[20:18:49] [INFO] [Bullet] Distance to wall: 529.999877929688 (36.0886662720713% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (56.61131, 859.4116)
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@550
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@549
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(511.3835, 775.9975), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 21.6986713409424
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (10.61132, 867.2715) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(573.7767, 771.0086), shooter_id=67662514532, bullet_pos=(52.03236, 864.1913)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=530.000122070313
+[20:18:49] [INFO] [Bullet] Distance to wall: 530.000122070313 (36.0886828960554% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (52.03236, 864.1913)
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@552
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(506.1204, 775.9975), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 26.3173198699951
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (6.092625, 872.3961) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(568.5136, 771.8715), shooter_id=67662514532, bullet_pos=(47.565, 869.4042)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=530.000061035156
+[20:18:49] [INFO] [Bullet] Distance to wall: 530.000061035156 (36.0886787400594% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (47.565, 869.4042)
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@553
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(500.8574, 775.9975), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 30.8312377929688
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (1.695309, 877.9919) after traveling 41.6666717529297 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(563.2505, 772.7344), shooter_id=67662514532, bullet_pos=(43.22622, 875.0814)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=530.000183105469
+[20:18:49] [INFO] [Bullet] Distance to wall: 530.000183105469 (36.0886870520514% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (43.22622, 875.0814)
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@555
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(495.5943, 776.4077), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 35.2250900268555
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (-2.562077, 884.093) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(557.9875, 773.5974), shooter_id=67662514532, bullet_pos=(39.03738, 881.2585)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=530.000061035156
+[20:18:49] [INFO] [Bullet] Distance to wall: 530.000061035156 (36.0886787400594% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (39.03738, 881.2585)
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@557
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(490.3191, 776.4077), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 39.479434967041
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (-6.65633, 890.7381) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(552.7244, 774.4603), shooter_id=67662514532, bullet_pos=(35.02365, 887.976)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=529.999877929688
+[20:18:49] [INFO] [Bullet] Distance to wall: 529.999877929688 (36.0886662720713% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (35.02365, 887.976)
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@559
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(485.0561, 776.4077), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 43.571174621582
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (-10.56006, 897.9711) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(547.4614, 775.3232), shooter_id=67662514532, bullet_pos=(31.21476, 895.2789)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=529.999938964844
+[20:18:49] [INFO] [Bullet] Distance to wall: 529.999938964844 (36.0886704280673% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (31.21476, 895.2789)
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@561
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@563
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(479.793, 776.4077), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 47.4728355407715
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (-14.24092, 905.8411) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(536.9352, 777.049), shooter_id=67662514532, bullet_pos=(64.66016, 901.2493)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=488.333343505859
+[20:18:49] [INFO] [Bullet] Distance to wall: 488.333343505859 (33.2515153251521% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [LastChance] Threat detected: Bullet
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(474.5299, 776.4077), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(531.9308, 777.2572), shooter_id=67662514532, bullet_pos=(62.05543, 910.2482)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=488.333404541016
+[20:18:49] [INFO] [Bullet] Distance to wall: 488.333404541016 (33.2515194811481% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (62.05543, 910.2482)
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@566
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 15.4305820465088
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (17.15267, 922.9572) after traveling 41.6666717529297 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(527.1727, 775.7162), shooter_id=67662514532, bullet_pos=(60.95037, 920.9959)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=488.333282470703
+[20:18:49] [INFO] [Bullet] Distance to wall: 488.333282470703 (33.251511169156% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@568
+[20:18:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(521.9096, 775.9975), shooter_id=67662514532, bullet_pos=(59.06865, 931.7139)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=488.333221435547
+[20:18:49] [INFO] [Bullet] Distance to wall: 488.333221435547 (33.25150701316% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[20:18:49] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[20:18:49] [INFO] [LastChance] Threat detected: @Area2D@548
+[20:18:49] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(516.6465, 775.9975), shooter_id=67662514532, bullet_pos=(57.92736, 943.4675)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=488.333343505859
+[20:18:49] [INFO] [Bullet] Distance to wall: 488.333343505859 (33.2515153251521% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[20:18:49] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[20:18:49] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(511.3835, 775.9975), shooter_id=67662514532, bullet_pos=(57.34838, 955.7797)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=488.333435058594
+[20:18:49] [INFO] [Bullet] Distance to wall: 488.333435058594 (33.2515215591461% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (57.34838, 955.7797)
+[20:18:49] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[20:18:49] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[20:18:49] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[20:18:49] [INFO] [LastChance] Player died
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 19.403450012207
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (13.95937, 972.9603) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(506.1204, 775.9975), shooter_id=67662514532, bullet_pos=(57.39983, 968.6614)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=488.333435058594
+[20:18:49] [INFO] [Bullet] Distance to wall: 488.333435058594 (33.2515215591461% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(500.8574, 775.9975), shooter_id=67662514532, bullet_pos=(58.15588, 982.1161)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=488.333404541016
+[20:18:49] [INFO] [Bullet] Distance to wall: 488.333404541016 (33.2515194811481% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(464.0038, 776.4077), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(495.5943, 776.4077), shooter_id=67662514532, bullet_pos=(59.34868, 995.8594)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=488.333190917969
+[20:18:49] [INFO] [Bullet] Distance to wall: 488.333190917969 (33.251504935162% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [LastChance] Threat detected: Bullet
+[20:18:49] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:18:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:49] [ENEMY] [Enemy3] State: COMBAT -> PURSUING
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(490.3191, 776.4077), shooter_id=67662514532, bullet_pos=(61.0759, 1087.294)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=530
+[20:18:49] [INFO] [Bullet] Distance to wall: 530 (36.0886745840634% of viewport)
+[20:18:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (61.0759, 1087.294)
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 10.765736579895
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (23.28091, 1114.668) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[20:18:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(464.0038, 776.4077), shooter_id=67662514532, bullet_pos=(43.60919, 1223.001)
+[20:18:49] [INFO] [Bullet] Using shooter_position, distance=613.333068847656
+[20:18:49] [INFO] [Bullet] Distance to wall: 613.333068847656 (41.7629764779019% of viewport)
+[20:18:49] [INFO] [Bullet] Distance-based penetration chance: 97.9431941091145%
+[20:18:49] [INFO] [Bullet] Starting wall penetration at (43.60919, 1223.001)
+[20:18:49] [INFO] [Bullet] Raycast backward hit penetrating body at distance 29.7294254302979
+[20:18:49] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:49] [INFO] [Bullet] Exiting penetration at (11.62264, 1256.981) after traveling 41.6666679382324 pixels through wall
+[20:18:49] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:49] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:18:49] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:18:49] [INFO] [Player.Grenade] Grenade scene loaded
+[20:18:49] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:18:49] [INFO] [Player] Ready! Grenades: 1/3
+[20:18:49] [INFO] [ScoreManager] Level started with 10 enemies
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:18:49] [ENEMY] [Enemy1] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 3, behavior: GUARD, player_found: yes
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:18:49] [ENEMY] [Enemy2] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 3, behavior: GUARD, player_found: yes
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:18:49] [ENEMY] [Enemy3] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 2, behavior: GUARD, player_found: yes
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:18:49] [ENEMY] [Enemy4] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 2, behavior: GUARD, player_found: yes
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:18:49] [ENEMY] [Enemy5] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:18:49] [ENEMY] [Enemy6] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 3, behavior: GUARD, player_found: yes
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:18:49] [ENEMY] [Enemy7] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 4, behavior: PATROL, player_found: yes
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:18:49] [ENEMY] [Enemy8] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 2, behavior: GUARD, player_found: yes
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:18:49] [ENEMY] [Enemy9] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:18:49] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:18:49] [ENEMY] [Enemy10] Registered as sound listener
+[20:18:49] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:18:49] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:18:49] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:18:49] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:18:49] [INFO] [LastChance] Found player: Player
+[20:18:49] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:18:49] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:18:49] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:18:50] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (652.57043, 1375.5416)
+[20:18:50] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:18:50] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:18:50] [INFO] [Player.Grenade] Timer started, grenade created at (348.33185, 1135.8549)
+[20:18:50] [INFO] [Player.Grenade] Step 1 complete! Drag: (504.26428, -75.95447)
+[20:18:50] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:18:50] [ENEMY] [Enemy10] State: IDLE -> COMBAT
+[20:18:50] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1200, 1550), source=ENEMY (Enemy10), range=1469, listeners=20
+[20:18:50] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[20:18:50] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:18:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1172.012, 1534.488), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:50] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:18:50] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:18:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1139.969, 1515.335), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:51] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1108.616, 1495.071), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:51] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1077.956, 1473.772), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:51] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:51] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1200, 1550), shooter_id=114554833634, bullet_pos=(32.92698, 929.7217)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=1321.66735839844
+[20:18:51] [INFO] [Bullet] Distance to wall: 1321.66735839844 (89.9947607653205% of viewport)
+[20:18:51] [INFO] [Player.Grenade] Throwing! Direction: (0.4771471, -0.8788235), Drag distance: 708,13196
+[20:18:51] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,0733908
+[20:18:51] [INFO] [GrenadeBase] Thrown! Direction: (0.477147, -0.878824), Speed: 1416.3
+[20:18:51] [INFO] [Player.Grenade] Thrown! Direction: (0.4771471, -0.8788235), Drag distance: 708,13196
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1172.012, 1534.488), shooter_id=114554833634, bullet_pos=(63.54654, 894.4075)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=1279.99975585938
+[20:18:51] [INFO] [Bullet] Distance to wall: 1279.99975585938 (87.1575370884708% of viewport)
+[20:18:51] [INFO] [LastChance] Threat detected: @Area2D@833
+[20:18:51] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:18:51] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1200, 1550), shooter_id=114554833634, bullet_pos=(403.8706, 712.2343)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=1155.71337890625
+[20:18:51] [INFO] [Bullet] Distance to wall: 1155.71337890625 (78.6946491392377% of viewport)
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1139.969, 1515.335), shooter_id=114554833634, bullet_pos=(54.65845, 836.7316)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=1280.00036621094
+[20:18:51] [INFO] [Bullet] Distance to wall: 1280.00036621094 (87.1575786484311% of viewport)
+[20:18:51] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1172.012, 1534.488), shooter_id=114554833634, bullet_pos=(365.9035, 700.5491)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=1159.85583496094
+[20:18:51] [INFO] [Bullet] Distance to wall: 1159.85583496094 (78.9767165893064% of viewport)
+[20:18:51] [INFO] [LastChance] Threat detected: @Area2D@834
+[20:18:51] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:18:51] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1108.616, 1495.071), shooter_id=114554833634, bullet_pos=(47.70524, 778.9221)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=1280.00024414063
+[20:18:51] [INFO] [Bullet] Distance to wall: 1280.00024414063 (87.157570336439% of viewport)
+[20:18:51] [INFO] [Bullet] Distance-based penetration chance: 44.9828346074878%
+[20:18:51] [INFO] [Bullet] Penetration failed (distance roll)
+[20:18:51] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[20:18:51] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1139.969, 1515.335), shooter_id=114554833634, bullet_pos=(312.7584, 708.1995)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=1155.74426269531
+[20:18:51] [INFO] [Bullet] Distance to wall: 1155.74426269531 (78.6967520732252% of viewport)
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1172.012, 1534.488), shooter_id=114554833634, bullet_pos=(522.941, 799.5231)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=980.544250488281
+[20:18:51] [INFO] [Bullet] Distance to wall: 980.544250488281 (66.7670610776338% of viewport)
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1200, 1550), shooter_id=114554833634, bullet_pos=(684.1472, 835.1432)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=881.546508789063
+[20:18:51] [INFO] [Bullet] Distance to wall: 881.546508789063 (60.0261228045389% of viewport)
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1139.969, 1515.335), shooter_id=114554833634, bullet_pos=(501.527, 812.6287)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=949.423034667969
+[20:18:51] [INFO] [Bullet] Distance to wall: 949.423034667969 (64.6479602655589% of viewport)
+[20:18:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1200, 1550), shooter_id=114554833634, bullet_pos=(509.1814, 892.4767)
+[20:18:51] [INFO] [Bullet] Using shooter_position, distance=953.712341308594
+[20:18:51] [INFO] [Bullet] Distance to wall: 953.712341308594 (64.9400270420585% of viewport)
+[20:18:51] [INFO] [Bullet] Distance-based penetration chance: 70.9033017842651%
+[20:18:51] [INFO] [Bullet] Penetration failed (distance roll)
+[20:18:51] [INFO] [LastChance] Threat detected: @Area2D@832
+[20:18:51] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:18:51] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:52] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1172.012, 1534.488), shooter_id=114554833634, bullet_pos=(1101.283, 287.1578)
+[20:18:52] [INFO] [Bullet] Using shooter_position, distance=1249.333984375
+[20:18:52] [INFO] [Bullet] Distance to wall: 1249.333984375 (85.0694483187183% of viewport)
+[20:18:52] [INFO] [GrenadeBase] Grenade landed at (432.9629, 734.9864)
+[20:18:52] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1172.012, 1534.488), shooter_id=114554833634, bullet_pos=(1376.712, 507.9551)
+[20:18:52] [INFO] [Bullet] Using shooter_position, distance=1046.74340820313
+[20:18:52] [INFO] [Bullet] Distance to wall: 1046.74340820313 (71.2746834559547% of viewport)
+[20:18:52] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1172.012, 1534.488), shooter_id=114554833634, bullet_pos=(1114.341, 689.9125)
+[20:18:52] [INFO] [Bullet] Using shooter_position, distance=846.542236328125
+[20:18:52] [INFO] [Bullet] Distance to wall: 846.542236328125 (57.6426175254924% of viewport)
+[20:18:53] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:53] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:53] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:53] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:53] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:53] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:18:53] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:18:53] [INFO] [Player.Grenade] Grenade scene loaded
+[20:18:53] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:18:53] [INFO] [Player] Ready! Grenades: 1/3
+[20:18:53] [INFO] [ScoreManager] Level started with 10 enemies
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:18:53] [ENEMY] [Enemy1] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 2, behavior: GUARD, player_found: yes
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:18:53] [ENEMY] [Enemy2] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 2, behavior: GUARD, player_found: yes
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:18:53] [ENEMY] [Enemy3] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:18:53] [ENEMY] [Enemy4] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:18:53] [ENEMY] [Enemy5] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:18:53] [ENEMY] [Enemy6] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 3, behavior: GUARD, player_found: yes
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:18:53] [ENEMY] [Enemy7] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 4, behavior: PATROL, player_found: yes
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:18:53] [ENEMY] [Enemy8] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 2, behavior: GUARD, player_found: yes
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:18:53] [ENEMY] [Enemy9] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 4, behavior: GUARD, player_found: yes
+[20:18:53] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:18:53] [ENEMY] [Enemy10] Registered as sound listener
+[20:18:53] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:18:53] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:18:53] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:18:53] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:18:53] [INFO] [LastChance] Found player: Player
+[20:18:53] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:18:53] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:18:53] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:18:54] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (565.4511, 1136.6187)
+[20:18:54] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:18:54] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:18:54] [INFO] [Player.Grenade] Timer started, grenade created at (362.78162, 1132.7677)
+[20:18:54] [INFO] [Player.Grenade] Step 1 complete! Drag: (574.6517, -43.673584)
+[20:18:54] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1200, 1550), source=ENEMY (Enemy10), range=1469, listeners=20
+[20:18:54] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[20:18:54] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:18:54] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:18:54] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:18:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1171.936, 1534.627), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:54] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:18:54] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1200, 1550), shooter_id=141750699507, bullet_pos=(915.1542, 1400.561)
+[20:18:54] [INFO] [Bullet] Using shooter_position, distance=321.666320800781
+[20:18:54] [INFO] [Bullet] Distance to wall: 321.666320800781 (21.9028512755327% of viewport)
+[20:18:54] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:54] [INFO] [Bullet] Starting wall penetration at (915.1542, 1400.561)
+[20:18:54] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[20:18:54] [INFO] [Bullet] Exiting penetration at (873.8294, 1378.88) after traveling 41.6666679382324 pixels through wall
+[20:18:54] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1139.809, 1515.614), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:54] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1108.244, 1495.68), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:54] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1076.919, 1475.369), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:54] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:54] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[20:18:54] [INFO] [LastChance] Threat detected: Bullet
+[20:18:54] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:18:54] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:54] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1171.936, 1534.627), shooter_id=141750699507, bullet_pos=(60.5761, 899.5836)
+[20:18:54] [INFO] [Bullet] Using shooter_position, distance=1280.00036621094
+[20:18:54] [INFO] [Bullet] Distance to wall: 1280.00036621094 (87.1575786484311% of viewport)
+[20:18:54] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[20:18:54] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[20:18:54] [INFO] [LastChance] Threat detected: @Area2D@1101
+[20:18:54] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[20:18:54] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:55] [INFO] [LastChance] Threat detected: @Area2D@1102
+[20:18:55] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[20:18:55] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1108.244, 1495.68), shooter_id=141750699507, bullet_pos=(67.75168, 824.2294)
+[20:18:55] [INFO] [Bullet] Using shooter_position, distance=1238.33312988281
+[20:18:55] [INFO] [Bullet] Distance to wall: 1238.33312988281 (84.3203799075575% of viewport)
+[20:18:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1171.936, 1534.627), shooter_id=141750699507, bullet_pos=(487.5846, 714.4449)
+[20:18:55] [INFO] [Bullet] Using shooter_position, distance=1068.19262695313
+[20:18:55] [INFO] [Bullet] Distance to wall: 1068.19262695313 (72.7352002022776% of viewport)
+[20:18:55] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[20:18:55] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[20:18:55] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[20:18:55] [ENEMY] [Enemy3] Hit taken, health: 2/3
+[20:18:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1108.244, 1495.68), shooter_id=141750699507, bullet_pos=(329.8688, 704.1014)
+[20:18:55] [INFO] [Bullet] Using shooter_position, distance=1110.16381835938
+[20:18:55] [INFO] [Bullet] Distance to wall: 1110.16381835938 (75.5930958033447% of viewport)
+[20:18:55] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[20:18:55] [INFO] [Player.Grenade] Throwing! Direction: (0.49929485, -0.86643213), Drag distance: 568,0993
+[20:18:55] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,0480115
+[20:18:55] [INFO] [GrenadeBase] Thrown! Direction: (0.499295, -0.866432), Speed: 1136.2
+[20:18:55] [INFO] [Player.Grenade] Thrown! Direction: (0.49929485, -0.86643213), Drag distance: 568,0993
+[20:18:55] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[20:18:55] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 758.0001), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:55] [ENEMY] [Enemy2] Heard gunshot at (700, 758.0001), source_type=1, intensity=0.02, distance=365
+[20:18:55] [ENEMY] [Enemy4] Heard gunshot at (700, 758.0001), source_type=1, intensity=0.08, distance=174
+[20:18:55] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:18:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1108.244, 1495.68), shooter_id=141750699507, bullet_pos=(695.1418, 857.96)
+[20:18:55] [INFO] [Bullet] Using shooter_position, distance=759.828735351563
+[20:18:55] [INFO] [Bullet] Distance to wall: 759.828735351563 (51.7381357919301% of viewport)
+[20:18:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(700, 758.0001), shooter_id=140341413331, bullet_pos=(520.6861, 838.773)
+[20:18:55] [INFO] [Bullet] Using shooter_position, distance=196.666580200195
+[20:18:55] [INFO] [Bullet] Distance to wall: 196.666580200195 (13.3913890837839% of viewport)
+[20:18:55] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:55] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(701.9575, 770.4777), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:18:55] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:18:55] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:18:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1108.244, 1495.68), shooter_id=141750699507, bullet_pos=(524.5484, 927.2275)
+[20:18:55] [INFO] [Bullet] Using shooter_position, distance=814.762634277344
+[20:18:55] [INFO] [Bullet] Distance to wall: 814.762634277344 (55.4786859843194% of viewport)
+[20:18:55] [INFO] [Bullet] Distance-based penetration chance: 81.941533018294%
+[20:18:55] [INFO] [Bullet] Starting wall penetration at (524.5484, 927.2275)
+[20:18:55] [INFO] [Bullet] Raycast backward hit penetrating body at distance 4.09371709823608
+[20:18:55] [INFO] [Bullet] Max penetration distance exceeded: 51.1770820617676 >= 48
+[20:18:55] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:55] [INFO] [Bullet] Exiting penetration at (472.4984, 948.3619) after traveling 51.1770820617676 pixels through wall
+[20:18:55] [INFO] [Bullet] Damage multiplier after penetration: 0.1125
+[20:18:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(701.9575, 770.4777), shooter_id=140341413331, bullet_pos=(511.6, 819.8925)
+[20:18:55] [INFO] [Bullet] Using shooter_position, distance=196.66667175293
+[20:18:55] [INFO] [Bullet] Distance to wall: 196.66667175293 (13.3913953177779% of viewport)
+[20:18:55] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:55] [INFO] [Bullet] Starting wall penetration at (511.6, 819.8925)
+[20:18:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(700, 758.0001), shooter_id=140341413331, bullet_pos=(696.1689, 887.3535)
+[20:18:55] [INFO] [Bullet] Using shooter_position, distance=129.410110473633
+[20:18:55] [INFO] [Bullet] Distance to wall: 129.410110473633 (8.81177238635967% of viewport)
+[20:18:55] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:55] [INFO] [Bullet] Starting wall penetration at (696.1689, 887.3535)
+[20:18:55] [INFO] [Bullet] Raycast backward hit penetrating body at distance 30.4972229003906
+[20:18:55] [INFO] [Bullet] Raycast backward hit penetrating body at distance 34.6822090148926
+[20:18:55] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:55] [INFO] [Bullet] Exiting penetration at (735.1205, 898.1368) after traveling 35.4166679382324 pixels through wall
+[20:18:55] [INFO] [Bullet] Damage multiplier after penetration: 0.45
+[20:18:55] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:18:55] [INFO] [Bullet] Exiting penetration at (466.4304, 831.618) after traveling 41.6666679382324 pixels through wall
+[20:18:55] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:55] [ENEMY] [Enemy3] State: RETREATING -> IN_COVER
+[20:18:55] [ENEMY] [Enemy3] State: IN_COVER -> SUPPRESSED
+[20:18:55] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:55] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[20:18:55] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:55] [ENEMY] [Enemy4] State: RETREATING -> IN_COVER
+[20:18:55] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[20:18:55] [ENEMY] [Enemy4] State: IN_COVER -> SUPPRESSED
+[20:18:56] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[20:18:56] [INFO] [GrenadeBase] Grenade landed at (432.3276, 721.1446)
+[20:18:57] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:18:57] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:18:57] [INFO] [Player.Grenade] Grenade scene loaded
+[20:18:57] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:18:57] [INFO] [Player] Ready! Grenades: 1/3
+[20:18:57] [INFO] [ScoreManager] Level started with 10 enemies
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:18:57] [ENEMY] [Enemy1] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 3, behavior: GUARD, player_found: yes
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:18:57] [ENEMY] [Enemy2] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:18:57] [ENEMY] [Enemy3] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:18:57] [ENEMY] [Enemy4] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 3, behavior: GUARD, player_found: yes
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:18:57] [ENEMY] [Enemy5] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 2, behavior: GUARD, player_found: yes
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:18:57] [ENEMY] [Enemy6] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 3, behavior: GUARD, player_found: yes
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:18:57] [ENEMY] [Enemy7] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 2, behavior: PATROL, player_found: yes
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:18:57] [ENEMY] [Enemy8] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 3, behavior: GUARD, player_found: yes
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:18:57] [ENEMY] [Enemy9] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 2, behavior: GUARD, player_found: yes
+[20:18:57] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:18:57] [ENEMY] [Enemy10] Registered as sound listener
+[20:18:57] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:18:57] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:18:57] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:18:57] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:18:57] [INFO] [LastChance] Found player: Player
+[20:18:57] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:18:57] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:18:57] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:18:57] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1200, 1550), source=ENEMY (Enemy10), range=1469, listeners=20
+[20:18:57] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[20:18:57] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:18:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1171.98, 1534.547), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:57] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:18:58] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1200, 1550), shooter_id=197467835217, bullet_pos=(915.3889, 1400.114)
+[20:18:58] [INFO] [Bullet] Using shooter_position, distance=321.666473388672
+[20:18:58] [INFO] [Bullet] Distance to wall: 321.666473388672 (21.9028616655228% of viewport)
+[20:18:58] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:58] [INFO] [Bullet] Starting wall penetration at (915.3889, 1400.114)
+[20:18:58] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (609.27246, 1239.6934)
+[20:18:58] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[20:18:58] [INFO] [Bullet] Exiting penetration at (874.0981, 1378.369) after traveling 41.6666679382324 pixels through wall
+[20:18:58] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1139.957, 1515.359), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:58] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:58] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:18:58] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:18:58] [INFO] [Player.Grenade] Timer started, grenade created at (420.6231, 1051.5526)
+[20:18:58] [INFO] [Player.Grenade] Step 1 complete! Drag: (504.9922, -144.02808)
+[20:18:58] [INFO] [Player.Grenade] G released - dropping grenade at feet
+[20:18:58] [INFO] [Player.Grenade] Grenade dropped at feet at (420.6231, 1051.5526)
+[20:18:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1108.696, 1494.955), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:58] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1078.227, 1473.385), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:58] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:58] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[20:18:58] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1171.98, 1534.547), shooter_id=197467835217, bullet_pos=(63.27436, 894.8823)
+[20:18:58] [INFO] [Bullet] Using shooter_position, distance=1279.99963378906
+[20:18:58] [INFO] [Bullet] Distance to wall: 1279.99963378906 (87.1575287764788% of viewport)
+[20:18:58] [INFO] [Bullet] Distance-based penetration chance: 44.9828830941081%
+[20:18:58] [INFO] [Bullet] Penetration failed (distance roll)
+[20:18:58] [INFO] [LastChance] Threat detected: @Area2D@1367
+[20:18:58] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:18:58] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:18:58] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[20:18:58] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[20:18:58] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1108.696, 1494.955), shooter_id=197467835217, bullet_pos=(52.38505, 772.0381)
+[20:18:58] [INFO] [Bullet] Using shooter_position, distance=1280.00061035156
+[20:18:58] [INFO] [Bullet] Distance to wall: 1280.00061035156 (87.1575952724152% of viewport)
+[20:18:58] [INFO] [Bullet] Distance-based penetration chance: 44.9828055155157%
+[20:18:58] [INFO] [Bullet] Penetration failed (distance roll)
+[20:18:58] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:18:58] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:18:58] [INFO] [Player.Grenade] Grenade scene loaded
+[20:18:58] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:18:58] [INFO] [Player] Ready! Grenades: 1/3
+[20:18:58] [INFO] [ScoreManager] Level started with 10 enemies
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:18:58] [ENEMY] [Enemy1] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:18:58] [ENEMY] [Enemy2] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:18:58] [ENEMY] [Enemy3] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 2, behavior: GUARD, player_found: yes
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:18:58] [ENEMY] [Enemy4] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 3, behavior: GUARD, player_found: yes
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:18:58] [ENEMY] [Enemy5] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:18:58] [ENEMY] [Enemy6] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:18:58] [ENEMY] [Enemy7] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 3, behavior: PATROL, player_found: yes
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:18:58] [ENEMY] [Enemy8] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 3, behavior: GUARD, player_found: yes
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:18:58] [ENEMY] [Enemy9] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:18:58] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:18:58] [ENEMY] [Enemy10] Registered as sound listener
+[20:18:58] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 3, behavior: PATROL, player_found: yes
+[20:18:58] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:18:58] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:18:58] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:18:58] [INFO] [LastChance] Found player: Player
+[20:18:58] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:18:58] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:18:58] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:18:59] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:18:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1200, 1550), source=ENEMY (Enemy10), range=1469, listeners=20
+[20:18:59] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[20:18:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:18:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1171.99, 1534.529), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:18:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1200, 1550), shooter_id=220167406896, bullet_pos=(915.3665, 1400.156)
+[20:18:59] [INFO] [Bullet] Using shooter_position, distance=321.666564941406
+[20:18:59] [INFO] [Bullet] Distance to wall: 321.666564941406 (21.9028678995168% of viewport)
+[20:18:59] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:18:59] [INFO] [Bullet] Starting wall penetration at (915.3665, 1400.156)
+[20:18:59] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[20:18:59] [INFO] [Bullet] Exiting penetration at (874.0724, 1378.417) after traveling 41.6666717529297 pixels through wall
+[20:18:59] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:18:59] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (385.46814, 1476.7991)
+[20:18:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1140.006, 1515.278), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:59] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:18:59] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:18:59] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1056.1666)
+[20:18:59] [INFO] [Player.Grenade] Step 1 complete! Drag: (610.3568, -158.94348)
+[20:18:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1108.816, 1494.764), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:18:59] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:18:59] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:18:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1078.466, 1473.029), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:18:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:00] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[20:19:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1171.99, 1534.529), shooter_id=220167406896, bullet_pos=(64.15709, 893.3544)
+[20:19:00] [INFO] [Bullet] Using shooter_position, distance=1279.99975585938
+[20:19:00] [INFO] [Bullet] Distance to wall: 1279.99975585938 (87.1575370884708% of viewport)
+[20:19:00] [INFO] [Bullet] Distance-based penetration chance: 44.982873396784%
+[20:19:00] [INFO] [Bullet] Penetration failed (distance roll)
+[20:19:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1140.006, 1515.278), shooter_id=220167406896, bullet_pos=(58.7139, 830.2917)
+[20:19:00] [INFO] [Bullet] Using shooter_position, distance=1279.99951171875
+[20:19:00] [INFO] [Bullet] Distance to wall: 1279.99951171875 (87.1575204644867% of viewport)
+[20:19:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1140.006, 1515.278), shooter_id=220167406896, bullet_pos=(230.8525, 697.346)
+[20:19:00] [INFO] [Bullet] Using shooter_position, distance=1222.93615722656
+[20:19:00] [INFO] [Bullet] Distance to wall: 1222.93615722656 (83.2719717268573% of viewport)
+[20:19:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1108.816, 1494.764), shooter_id=220167406896, bullet_pos=(55.6586, 767.2637)
+[20:19:00] [INFO] [Bullet] Using shooter_position, distance=1279.99951171875
+[20:19:00] [INFO] [Bullet] Distance to wall: 1279.99951171875 (87.1575204644867% of viewport)
+[20:19:00] [INFO] [Bullet] Distance-based penetration chance: 44.9828927914321%
+[20:19:00] [INFO] [Bullet] Starting wall penetration at (55.6586, 767.2637)
+[20:19:00] [INFO] [Bullet] Raycast backward hit penetrating body at distance 17.9122085571289
+[20:19:00] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:00] [INFO] [Bullet] Exiting penetration at (17.26221, 740.7402) after traveling 41.6666679382324 pixels through wall
+[20:19:00] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1078.466, 1473.029), shooter_id=220167406896, bullet_pos=(54.86711, 704.4935)
+[20:19:00] [INFO] [Bullet] Using shooter_position, distance=1280.00024414063
+[20:19:00] [INFO] [Bullet] Distance to wall: 1280.00024414063 (87.157570336439% of viewport)
+[20:19:00] [INFO] [Bullet] Distance-based penetration chance: 44.9828346074878%
+[20:19:00] [INFO] [Bullet] Starting wall penetration at (54.86711, 704.4935)
+[20:19:00] [INFO] [Bullet] Raycast backward hit penetrating body at distance 18.0715579986572
+[20:19:00] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:00] [INFO] [Bullet] Exiting penetration at (17.5484, 676.474) after traveling 41.6666679382324 pixels through wall
+[20:19:00] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1140.006, 1515.278), shooter_id=220167406896, bullet_pos=(513.6914, 930.0284)
+[20:19:00] [INFO] [Bullet] Using shooter_position, distance=857.197143554688
+[20:19:00] [INFO] [Bullet] Distance to wall: 857.197143554688 (58.3681297511958% of viewport)
+[20:19:00] [INFO] [Bullet] Distance-based penetration chance: 78.5705152902716%
+[20:19:00] [INFO] [Bullet] Starting wall penetration at (513.6914, 930.0284)
+[20:19:00] [INFO] [Bullet] Raycast backward hit penetrating body at distance 21.7555294036865
+[20:19:00] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:00] [INFO] [Bullet] Exiting penetration at (540.8008, 952.3305) after traveling 30.1041698455811 pixels through wall
+[20:19:00] [INFO] [Bullet] Damage multiplier after penetration: 0.225
+[20:19:00] [INFO] [Player.Grenade] Throwing! Direction: (0.20758916, -0.9782162), Drag distance: 631,6554
+[20:19:00] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,3616866
+[20:19:00] [INFO] [GrenadeBase] Thrown! Direction: (0.207589, -0.978216), Speed: 1263.3
+[20:19:00] [INFO] [Player.Grenade] Thrown! Direction: (0.20758916, -0.9782162), Drag distance: 631,6554
+[20:19:00] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:01] [INFO] [GrenadeBase] Grenade landed at (455.5707, 788.6531)
+[20:19:02] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:02] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:02] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:02] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:02] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:02] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:19:02] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:19:02] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 3, behavior: GUARD, player_found: yes
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:19:02] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:19:02] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 3, behavior: GUARD, player_found: yes
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:19:02] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:19:02] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:19:02] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 4, behavior: PATROL, player_found: yes
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:19:02] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 2, behavior: GUARD, player_found: yes
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:19:02] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 2, behavior: GUARD, player_found: yes
+[20:19:02] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:19:02] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:02] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:19:02] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:02] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:02] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:02] [INFO] [LastChance] Found player: Player
+[20:19:02] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:02] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:02] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:02] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (580.1638, 1336.1595)
+[20:19:03] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:03] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:03] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:03] [INFO] [Player.Grenade] Step 1 complete! Drag: (555.6974, -206.3822)
+[20:19:03] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:03] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:04] [INFO] [Player.Grenade] Throwing! Direction: (0.74228066, 0.6700892), Drag distance: 297,68878
+[20:19:04] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,73432887
+[20:19:04] [INFO] [GrenadeBase] Thrown! Direction: (0.742281, 0.670089), Speed: 595.4
+[20:19:04] [INFO] [Player.Grenade] Thrown! Direction: (0.74228066, 0.6700892), Drag distance: 297,68878
+[20:19:05] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:05] [INFO] [GrenadeBase] Grenade landed at (609.3259, 1371.819)
+[20:19:06] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:06] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:06] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:06] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:06] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:06] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 21)
+[20:19:06] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 22)
+[20:19:06] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 3, behavior: GUARD, player_found: yes
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 23)
+[20:19:06] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 24)
+[20:19:06] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 2, behavior: GUARD, player_found: yes
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 25)
+[20:19:06] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 2, behavior: GUARD, player_found: yes
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 26)
+[20:19:06] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 27)
+[20:19:06] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 3, behavior: PATROL, player_found: yes
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 28)
+[20:19:06] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 29)
+[20:19:06] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 2, behavior: GUARD, player_found: yes
+[20:19:06] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 30)
+[20:19:06] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:06] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:19:06] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:06] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:06] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:06] [INFO] [LastChance] Found player: Player
+[20:19:06] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:06] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:06] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:09] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (407.51517, 1139.6282)
+[20:19:09] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:09] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:09] [INFO] [Player.Grenade] Timer started, grenade created at (369.3274, 1058.1375)
+[20:19:09] [INFO] [Player.Grenade] Step 1 complete! Drag: (581.21094, -75.495605)
+[20:19:09] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:09] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:09] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[20:19:09] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=30
+[20:19:09] [INFO] [SoundPropagation] Cleaned up 20 invalid listeners
+[20:19:09] [ENEMY] [Enemy2] Heard gunshot at (700, 750), source_type=1, intensity=0.02, distance=361
+[20:19:09] [ENEMY] [Enemy4] Heard gunshot at (700, 750), source_type=1, intensity=0.08, distance=180
+[20:19:09] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:19:10] [INFO] [LastChance] Threat detected: Bullet
+[20:19:10] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(668.6011, 756.1457), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:19:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:19:10] [INFO] [Player.Grenade] Throwing! Direction: (0.7143258, -0.69981325), Drag distance: 624,7332
+[20:19:10] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,77513605
+[20:19:10] [INFO] [GrenadeBase] Thrown! Direction: (0.714326, -0.699813), Speed: 1249.5
+[20:19:10] [INFO] [Player.Grenade] Thrown! Direction: (0.7143258, -0.69981325), Drag distance: 624,7332
+[20:19:10] [INFO] [LastChance] Threat detected: @Area2D@2135
+[20:19:10] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(631.6263, 761.2822), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:19:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:19:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(700, 750), shooter_id=267730815007, bullet_pos=(62.76392, 901.5103)
+[20:19:10] [INFO] [Bullet] Using shooter_position, distance=655.000122070313
+[20:19:10] [INFO] [Bullet] Distance to wall: 655.000122070313 (44.6001627507873% of viewport)
+[20:19:10] [INFO] [Bullet] Distance-based penetration chance: 94.6331434574148%
+[20:19:10] [INFO] [Bullet] Starting wall penetration at (62.76392, 901.5103)
+[20:19:10] [INFO] [Bullet] Raycast backward hit penetrating body at distance 15.0451517105103
+[20:19:10] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:10] [INFO] [Bullet] Exiting penetration at (17.36287, 912.3049) after traveling 41.6666717529297 pixels through wall
+[20:19:10] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:10] [INFO] [LastChance] Threat detected: @Area2D@2136
+[20:19:10] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(594.5183, 765.378), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:19:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=1, below_threshold=5
+[20:19:10] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(668.6011, 756.1457), shooter_id=267730815007, bullet_pos=(63.04744, 853.5237)
+[20:19:10] [INFO] [Bullet] Using shooter_position, distance=613.333312988281
+[20:19:10] [INFO] [Bullet] Distance to wall: 613.333312988281 (41.762993101886% of viewport)
+[20:19:10] [INFO] [Bullet] Distance-based penetration chance: 97.9431747144664%
+[20:19:10] [INFO] [Bullet] Starting wall penetration at (63.04744, 853.5237)
+[20:19:10] [INFO] [Bullet] Raycast backward hit penetrating body at distance 15.2203578948975
+[20:19:10] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:10] [INFO] [Bullet] Exiting penetration at (16.9727, 860.9329) after traveling 41.6666679382324 pixels through wall
+[20:19:10] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:10] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[20:19:10] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[20:19:10] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[20:19:10] [INFO] [LastChance] Threat detected: Bullet
+[20:19:10] [INFO] [LastChance] Triggering last chance effect!
+[20:19:10] [INFO] [LastChance] Starting last chance effect:
+[20:19:10] [INFO] [LastChance]   - Time will be frozen (except player)
+[20:19:10] [INFO] [LastChance]   - Duration: 6.0 real seconds
+[20:19:10] [INFO] [LastChance]   - Sepia intensity: 0.70
+[20:19:10] [INFO] [LastChance]   - Brightness: 0.60
+[20:19:10] [INFO] [LastChance] Pushed bullet Bullet from distance 145.7 to 200.0
+[20:19:10] [INFO] [LastChance] Pushed 1 threatening bullets away from player
+[20:19:10] [INFO] [LastChance] Set player Player and all 12 children to PROCESS_MODE_ALWAYS
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room1_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room1_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room2_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room2_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room2_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room3_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room3_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room4_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room4_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room5_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room5_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Left' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Right' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBL' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTL' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Desk1' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Desk2' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Table1' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Cabinet1' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Cabinet2' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Desk3' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Desk4' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Table2' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Table3' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'Cabinet3' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'StorageCrate1' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'StorageCrate2' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Set StaticBody2D 'HallTable' to PROCESS_MODE_ALWAYS for collision
+[20:19:10] [INFO] [LastChance] Skipping player node: Player
+[20:19:10] [INFO] [LastChance] Froze all nodes except player and autoloads (including GameManager for quick restart)
+[20:19:10] [INFO] [LastChance] Applied visual effects: sepia=0.70, brightness=0.60, ripple=0.0080
+[20:19:11] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:11] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:11] [INFO] [LastChance] Ending last chance effect
+[20:19:11] [INFO] [LastChance] All process modes restored
+[20:19:11] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:11] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:11] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:11] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:19:11] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 2, behavior: GUARD, player_found: yes
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:19:11] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 3, behavior: GUARD, player_found: yes
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:19:11] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 2, behavior: GUARD, player_found: yes
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:19:11] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 2, behavior: GUARD, player_found: yes
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:19:11] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:19:11] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 4, behavior: GUARD, player_found: yes
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:19:11] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 4, behavior: PATROL, player_found: yes
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:19:11] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:19:11] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:19:11] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:19:11] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:11] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:19:11] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:11] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:11] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:11] [INFO] [LastChance] Found player: Player
+[20:19:11] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:11] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:11] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:12] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (846.30286, 1004.1542)
+[20:19:12] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:12] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:12] [INFO] [Player.Grenade] Timer started, grenade created at (193.75032, 1123.9126)
+[20:19:12] [INFO] [Player.Grenade] Step 1 complete! Drag: (433.6073, -70.30469)
+[20:19:12] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:12] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:13] [INFO] [Player.Grenade] Throwing! Direction: (-0.17348619, -0.9848363), Drag distance: 223,0666
+[20:19:13] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,7451648
+[20:19:13] [INFO] [GrenadeBase] Thrown! Direction: (-0.173486, -0.984836), Speed: 446.1
+[20:19:13] [INFO] [Player.Grenade] Thrown! Direction: (-0.17348619, -0.9848363), Drag distance: 223,0666
+[20:19:13] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:13] [INFO] [GrenadeBase] Grenade landed at (166.3925, 968.6093)
+[20:19:13] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:13] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:13] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:13] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:13] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:13] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 21)
+[20:19:13] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 22)
+[20:19:13] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 23)
+[20:19:13] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 24)
+[20:19:13] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 2, behavior: GUARD, player_found: yes
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 25)
+[20:19:13] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 26)
+[20:19:13] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 3, behavior: GUARD, player_found: yes
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 27)
+[20:19:13] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 2, behavior: PATROL, player_found: yes
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 28)
+[20:19:13] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 29)
+[20:19:13] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 2, behavior: GUARD, player_found: yes
+[20:19:13] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 30)
+[20:19:13] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:13] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:19:14] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:14] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:14] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:14] [INFO] [LastChance] Found player: Player
+[20:19:14] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:14] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:14] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:15] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (628.3878, 1346.846)
+[20:19:15] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:15] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:15] [INFO] [Player.Grenade] Timer started, grenade created at (139.94443, 1250)
+[20:19:15] [INFO] [Player.Grenade] Step 1 complete! Drag: (496.4574, -149.61035)
+[20:19:15] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:15] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:16] [INFO] [Player.Grenade] Throwing! Direction: (0.5733633, -0.8193013), Drag distance: 719,01624
+[20:19:16] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,9601913
+[20:19:16] [INFO] [GrenadeBase] Thrown! Direction: (0.573363, -0.819301), Speed: 1438.0
+[20:19:16] [INFO] [Player.Grenade] Thrown! Direction: (0.5733633, -0.8193013), Drag distance: 719,01624
+[20:19:16] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:17] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:17] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:17] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:17] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:17] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:17] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 31)
+[20:19:17] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 32)
+[20:19:17] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 33)
+[20:19:17] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 34)
+[20:19:17] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 3, behavior: GUARD, player_found: yes
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 35)
+[20:19:17] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 36)
+[20:19:17] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 3, behavior: GUARD, player_found: yes
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 37)
+[20:19:17] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 2, behavior: PATROL, player_found: yes
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 38)
+[20:19:17] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 39)
+[20:19:17] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:19:17] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 40)
+[20:19:17] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:17] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:19:17] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:17] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:17] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:17] [INFO] [LastChance] Found player: Player
+[20:19:17] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:17] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:17] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:17] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (427.05917, 1236.642)
+[20:19:18] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:18] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:18] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:18] [INFO] [Player.Grenade] Step 1 complete! Drag: (737.67346, -346.64197)
+[20:19:18] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:18] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:20] [INFO] [Player.Grenade] Throwing! Direction: (0.8900368, -0.45588863), Drag distance: 722,274
+[20:19:20] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,47337037
+[20:19:20] [INFO] [GrenadeBase] Thrown! Direction: (0.890037, -0.455889), Speed: 1444.5
+[20:19:20] [INFO] [Player.Grenade] Thrown! Direction: (0.8900368, -0.45588863), Drag distance: 722,274
+[20:19:20] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:20] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:20] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:20] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:20] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:20] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:20] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 41)
+[20:19:20] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 42)
+[20:19:20] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 43)
+[20:19:20] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 44)
+[20:19:20] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 2, behavior: GUARD, player_found: yes
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 45)
+[20:19:20] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 46)
+[20:19:20] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 47)
+[20:19:20] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 4, behavior: PATROL, player_found: yes
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 48)
+[20:19:20] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 49)
+[20:19:20] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 4, behavior: GUARD, player_found: yes
+[20:19:20] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 50)
+[20:19:20] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:20] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:19:20] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:20] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:20] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:20] [INFO] [LastChance] Found player: Player
+[20:19:20] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:20] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:20] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:21] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (322.8305, 1390.9276)
+[20:19:21] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:21] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:21] [INFO] [Player.Grenade] Timer started, grenade created at (277.8333, 1250)
+[20:19:21] [INFO] [Player.Grenade] Step 1 complete! Drag: (383.42358, -260.4823)
+[20:19:21] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:21] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:23] [INFO] [Player.Grenade] Throwing! Direction: (0.9148921, -0.4036985), Drag distance: 623,4121
+[20:19:23] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,4155558
+[20:19:23] [INFO] [GrenadeBase] Thrown! Direction: (0.914892, -0.403699), Speed: 1246.8
+[20:19:23] [INFO] [Player.Grenade] Thrown! Direction: (0.9148921, -0.4036985), Drag distance: 623,4121
+[20:19:23] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:24] [INFO] [GrenadeBase] Grenade landed at (868.701, 1052.349)
+[20:19:25] [INFO] [GrenadeBase] EXPLODED at (871.931, 1053.063)!
+[20:19:25] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(871.931, 1053.063), source=NEUTRAL (FlashbangGrenade), range=2937, listeners=50
+[20:19:25] [INFO] [SoundPropagation] Cleaned up 40 invalid listeners
+[20:19:25] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=8
+[20:19:25] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:25] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:25] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:25] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:25] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:25] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:19:25] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:19:25] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 3, behavior: GUARD, player_found: yes
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:19:25] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 2, behavior: GUARD, player_found: yes
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:19:25] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:19:25] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:19:25] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:19:25] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 4, behavior: PATROL, player_found: yes
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:19:25] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:19:25] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:19:25] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:19:25] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:25] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:19:25] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:25] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:25] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:25] [INFO] [LastChance] Found player: Player
+[20:19:25] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:25] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:25] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:26] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (253.35358, 1356.8645)
+[20:19:26] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:26] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:26] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:26] [INFO] [Player.Grenade] Step 1 complete! Drag: (464.1225, -185.67712)
+[20:19:26] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:26] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:27] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:27] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:27] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:27] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:27] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:27] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1080.498, 1534.509), source=ENEMY (Enemy10), range=1469, listeners=20
+[20:19:28] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1076.199, 1531.352), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1071.9, 1528.196), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1067.601, 1525.039), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1063.302, 1521.883), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1059.003, 1518.726), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [INFO] [LastChance] Threat detected: Bullet
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1054.704, 1515.569), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3399
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1050.406, 1512.413), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3400
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1046.107, 1509.256), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3401
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1041.808, 1506.099), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3403
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3402
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1037.509, 1502.943), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3404
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1033.21, 1499.786), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3405
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1028.911, 1496.63), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3406
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3407
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3408
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3409
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3410
+[20:19:28] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[20:19:28] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[20:19:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1004.291, 1468.764), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3411
+[20:19:28] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1059.003, 1518.726), shooter_id=405773748133, bullet_pos=(509.6304, 1025.445)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=738.333740234375
+[20:19:28] [INFO] [Bullet] Distance to wall: 738.333740234375 (50.2745020485901% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1054.704, 1515.569), shooter_id=405773748133, bullet_pos=(511.1945, 1015.836)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=738.333618164063
+[20:19:28] [INFO] [Bullet] Distance to wall: 738.333618164063 (50.274493736598% of viewport)
+[20:19:28] [INFO] [Bullet] Distance-based penetration chance: 88.0130906406357%
+[20:19:28] [INFO] [Bullet] Starting wall penetration at (511.1945, 1015.836)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1054.704, 1515.569), shooter_id=405773748133, bullet_pos=(507.5138, 1012.452)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=743.333618164063
+[20:19:28] [INFO] [Bullet] Distance to wall: 743.333618164063 (50.6149529307873% of viewport)
+[20:19:28] [INFO] [Bullet] Distance-based penetration chance: 87.6158882474148%
+[20:19:28] [INFO] [Bullet] Already penetrating, cannot start new penetration
+[20:19:28] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[20:19:28] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[20:19:28] [INFO] [Bullet] Exiting penetration at (476.8417, 984.2502) after traveling 41.6666679382324 pixels through wall
+[20:19:28] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1046.107, 1509.256), shooter_id=405773748133, bullet_pos=(545.4965, 1024.762)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=696.667175292969
+[20:19:28] [INFO] [Bullet] Distance to wall: 696.667175292969 (47.4373490236728% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1050.406, 1512.413), shooter_id=405773748133, bullet_pos=(513.1567, 1005.954)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=738.333618164063
+[20:19:28] [INFO] [Bullet] Distance to wall: 738.333618164063 (50.274493736598% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1050.406, 1512.413), shooter_id=405773748133, bullet_pos=(509.077, 1008.845)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=739.335632324219
+[20:19:28] [INFO] [Bullet] Distance to wall: 739.335632324219 (50.3427227233046% of viewport)
+[20:19:28] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[20:19:28] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[20:19:28] [INFO] [Player.Grenade] Throwing! Direction: (0.95775265, 0.2875931), Drag distance: 569,1075
+[20:19:28] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,29171282
+[20:19:28] [INFO] [GrenadeBase] Thrown! Direction: (0.957753, 0.287593), Speed: 1138.2
+[20:19:28] [INFO] [Player.Grenade] Thrown! Direction: (0.95775265, 0.2875931), Drag distance: 569,1075
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1041.808, 1506.099), shooter_id=405773748133, bullet_pos=(547.9666, 1014.709)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=696.666381835938
+[20:19:28] [INFO] [Bullet] Distance to wall: 696.666381835938 (47.4372949957245% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1033.21, 1499.786), shooter_id=405773748133, bullet_pos=(583.0703, 1023.972)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=654.999694824219
+[20:19:28] [INFO] [Bullet] Distance to wall: 654.999694824219 (44.6001336588152% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1037.509, 1502.943), shooter_id=405773748133, bullet_pos=(550.9305, 1004.359)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=696.666137695313
+[20:19:28] [INFO] [Bullet] Distance to wall: 696.666137695313 (47.4372783717404% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1080.498, 1534.509), shooter_id=405773748133, bullet_pos=(53.41811, 702.6984)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1321.66650390625
+[20:19:28] [INFO] [Bullet] Distance to wall: 1321.66650390625 (89.9947025813762% of viewport)
+[20:19:28] [INFO] [Bullet] Distance-based penetration chance: 41.6728469883945%
+[20:19:28] [INFO] [Bullet] Penetration failed (distance roll)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1076.199, 1531.352), shooter_id=405773748133, bullet_pos=(56.83219, 690.1064)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1321.66711425781
+[20:19:28] [INFO] [Bullet] Distance to wall: 1321.66711425781 (89.9947441413364% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1063.302, 1521.883), shooter_id=405773748133, bullet_pos=(132.6728, 704.9381)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1238.33349609375
+[20:19:28] [INFO] [Bullet] Distance to wall: 1238.33349609375 (84.3204048435337% of viewport)
+[20:19:28] [INFO] [Bullet] Distance-based penetration chance: 48.2928610158774%
+[20:19:28] [INFO] [Bullet] Starting wall penetration at (132.6728, 704.9381)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1067.601, 1525.039), shooter_id=405773748133, bullet_pos=(96.70905, 690.9117)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1280.00012207031
+[20:19:28] [INFO] [Bullet] Distance to wall: 1280.00012207031 (87.157562024447% of viewport)
+[20:19:28] [INFO] [Bullet] Distance-based penetration chance: 44.9828443048119%
+[20:19:28] [INFO] [Bullet] Penetration failed (distance roll)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1071.9, 1528.196), shooter_id=405773748133, bullet_pos=(60.71447, 677.1342)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1321.66662597656
+[20:19:28] [INFO] [Bullet] Distance to wall: 1321.66662597656 (89.9947108933682% of viewport)
+[20:19:28] [INFO] [Bullet] Distance-based penetration chance: 41.6728372910704%
+[20:19:28] [INFO] [Bullet] Starting wall penetration at (60.71447, 677.1342)
+[20:19:28] [INFO] [Bullet] Raycast backward hit penetrating body at distance 9.13552379608154
+[20:19:28] [INFO] [Bullet] Raycast backward hit penetrating body at distance 20.9917221069336
+[20:19:28] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:28] [INFO] [Bullet] Exiting penetration at (25.01055, 647.084) after traveling 41.6666679382324 pixels through wall
+[20:19:28] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:28] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:28] [INFO] [Bullet] Exiting penetration at (97.60193, 674.1515) after traveling 41.6666717529297 pixels through wall
+[20:19:28] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:28] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:28] [INFO] [LastChance] Threat detected: @Area2D@3405
+[20:19:28] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[20:19:28] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1046.107, 1509.256), shooter_id=405773748133, bullet_pos=(253.9707, 1387.564)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=801.428894042969
+[20:19:28] [INFO] [Bullet] Distance to wall: 801.428894042969 (54.5707670931745% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1033.21, 1499.786), shooter_id=405773748133, bullet_pos=(243.991, 1392.563)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=796.469055175781
+[20:19:28] [INFO] [Bullet] Distance to wall: 796.469055175781 (54.2330425443683% of viewport)
+[20:19:28] [INFO] [Bullet] Distance-based penetration chance: 83.394783698237%
+[20:19:28] [INFO] [Bullet] Starting wall penetration at (243.991, 1392.563)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1037.509, 1502.943), shooter_id=405773748133, bullet_pos=(232.0648, 1390.57)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=813.245056152344
+[20:19:28] [INFO] [Bullet] Distance to wall: 813.245056152344 (55.3753512992081% of viewport)
+[20:19:28] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[20:19:28] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[20:19:28] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[20:19:28] [INFO] [Bullet] Raycast backward hit penetrating body at distance 14.0057687759399
+[20:19:28] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:28] [INFO] [Bullet] Exiting penetration at (216.6277, 1422.308) after traveling 35.4166679382324 pixels through wall
+[20:19:28] [INFO] [Bullet] Damage multiplier after penetration: 0.45
+[20:19:28] [ENEMY] [Enemy10] State: PURSUING -> COMBAT
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1041.808, 1506.099), shooter_id=405773748133, bullet_pos=(54.72368, 1368.632)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=996.610168457031
+[20:19:28] [INFO] [Bullet] Distance to wall: 996.610168457031 (67.8610189747441% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1076.199, 1531.352), shooter_id=405773748133, bullet_pos=(337.454, 465.9366)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1296.47802734375
+[20:19:28] [INFO] [Bullet] Distance to wall: 1296.47802734375 (88.2795728947113% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1046.107, 1509.256), shooter_id=405773748133, bullet_pos=(62.71376, 1188.661)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1034.33190917969
+[20:19:28] [INFO] [Bullet] Distance to wall: 1034.33190917969 (70.4295616647146% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1037.509, 1502.943), shooter_id=405773748133, bullet_pos=(58.56714, 1216.407)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1020.01428222656
+[20:19:28] [INFO] [Bullet] Distance to wall: 1020.01428222656 (69.4546481176819% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1076.199, 1531.352), shooter_id=405773748133, bullet_pos=(517.6497, 584.5479)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1099.27990722656
+[20:19:28] [INFO] [Bullet] Distance to wall: 1099.27990722656 (74.8519902805637% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1041.808, 1506.099), shooter_id=405773748133, bullet_pos=(300.6019, 1597.844)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=746.862060546875
+[20:19:28] [INFO] [Bullet] Distance to wall: 746.862060546875 (50.8552110608664% of viewport)
+[20:19:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1076.199, 1531.352), shooter_id=405773748133, bullet_pos=(399.8081, 690.5931)
+[20:19:28] [INFO] [Bullet] Using shooter_position, distance=1079.06494140625
+[20:19:28] [INFO] [Bullet] Distance to wall: 1079.06494140625 (73.4755160858143% of viewport)
+[20:19:29] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:29] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:29] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:29] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:29] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:29] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:19:29] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:19:29] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:19:29] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 2, behavior: GUARD, player_found: yes
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:19:29] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 3, behavior: GUARD, player_found: yes
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:19:29] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 2, behavior: GUARD, player_found: yes
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:19:29] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 4, behavior: GUARD, player_found: yes
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:19:29] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 2, behavior: PATROL, player_found: yes
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:19:29] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:19:29] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 2, behavior: GUARD, player_found: yes
+[20:19:29] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:19:29] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:29] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:19:29] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:29] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:29] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:29] [INFO] [LastChance] Found player: Player
+[20:19:29] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:29] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:29] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:30] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (512.7958, 1325.8704)
+[20:19:30] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:30] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:30] [INFO] [Player.Grenade] Timer started, grenade created at (364.07523, 1176.659)
+[20:19:30] [INFO] [Player.Grenade] Step 1 complete! Drag: (441.3014, -43.61267)
+[20:19:30] [INFO] [Player.Grenade] G released - dropping grenade at feet
+[20:19:30] [INFO] [Player.Grenade] Grenade dropped at feet at (364.07523, 1176.659)
+[20:19:30] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:31] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:31] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:31] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:31] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:31] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:31] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 21)
+[20:19:31] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 2, behavior: GUARD, player_found: yes
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 22)
+[20:19:31] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 23)
+[20:19:31] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 24)
+[20:19:31] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 2, behavior: GUARD, player_found: yes
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 25)
+[20:19:31] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 26)
+[20:19:31] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 4, behavior: GUARD, player_found: yes
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 27)
+[20:19:31] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 2, behavior: PATROL, player_found: yes
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 28)
+[20:19:31] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 2, behavior: GUARD, player_found: yes
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 29)
+[20:19:31] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 2, behavior: GUARD, player_found: yes
+[20:19:31] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 30)
+[20:19:31] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:31] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:19:31] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:31] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:31] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:31] [INFO] [LastChance] Found player: Player
+[20:19:31] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:31] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:31] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:31] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (316.37747, 1290.7422)
+[20:19:31] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:31] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:31] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:31] [INFO] [Player.Grenade] Step 1 complete! Drag: (732.02783, -150.27832)
+[20:19:32] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:32] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:32] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1078.561, 1531.103), source=ENEMY (Enemy10), range=1469, listeners=30
+[20:19:33] [INFO] [SoundPropagation] Cleaned up 20 invalid listeners
+[20:19:33] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1074.252, 1527.959), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:33] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1069.944, 1524.816), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:33] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1065.636, 1521.672), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:33] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1061.328, 1518.528), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:33] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:33] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1057.019, 1515.384), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:33] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:33] [INFO] [LastChance] Threat detected: Bullet
+[20:19:33] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:33] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:33] [INFO] [LastChance] Threat detected: @Area2D@3939
+[20:19:33] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:33] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:33] [INFO] [LastChance] Threat detected: @Area2D@3940
+[20:19:33] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:33] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:33] [INFO] [LastChance] Threat detected: @Area2D@3941
+[20:19:33] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:33] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:33] [INFO] [LastChance] Threat detected: @Area2D@3942
+[20:19:33] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:33] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:33] [INFO] [Player.Grenade] Throwing! Direction: (0.5405136, 0.8413353), Drag distance: 496,9571
+[20:19:33] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,9997489
+[20:19:33] [INFO] [GrenadeBase] Thrown! Direction: (0.540514, 0.841335), Speed: 993.9
+[20:19:33] [INFO] [Player.Grenade] Thrown! Direction: (0.5405136, 0.8413353), Drag distance: 496,9571
+[20:19:33] [INFO] [LastChance] Threat detected: @Area2D@3943
+[20:19:33] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:33] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1029.316, 1490.413), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:33] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:33] [INFO] [LastChance] Threat detected: @Area2D@3944
+[20:19:33] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:33] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1003.176, 1463.76), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:33] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:33] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[20:19:33] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[20:19:33] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:33] [INFO] [LastChance] Threat detected: @Area2D@3945
+[20:19:33] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[20:19:33] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:33] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[20:19:33] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[20:19:33] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[20:19:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(977.5449, 1436.616), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:33] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:33] [INFO] [LastChance] Threat detected: @Area2D@3946
+[20:19:33] [INFO] [LastChance] Triggering last chance effect!
+[20:19:33] [INFO] [LastChance] Starting last chance effect:
+[20:19:33] [INFO] [LastChance]   - Time will be frozen (except player)
+[20:19:33] [INFO] [LastChance]   - Duration: 6.0 real seconds
+[20:19:33] [INFO] [LastChance]   - Sepia intensity: 0.70
+[20:19:33] [INFO] [LastChance]   - Brightness: 0.60
+[20:19:33] [INFO] [LastChance] Pushed bullet @Area2D@3946 from distance 148.5 to 200.0
+[20:19:33] [INFO] [LastChance] Pushed 1 threatening bullets away from player
+[20:19:33] [INFO] [LastChance] Set player Player and all 12 children to PROCESS_MODE_ALWAYS
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room1_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room1_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room2_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room2_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room2_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room3_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room3_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room4_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room4_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room5_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room5_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Left' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Right' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBL' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTL' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Desk1' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Desk2' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Table1' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Cabinet1' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Cabinet2' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Desk3' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Desk4' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Table2' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Table3' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'Cabinet3' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'StorageCrate1' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'StorageCrate2' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Set StaticBody2D 'HallTable' to PROCESS_MODE_ALWAYS for collision
+[20:19:33] [INFO] [LastChance] Skipping player node: Player
+[20:19:33] [INFO] [LastChance] Froze all nodes except player and autoloads (including GameManager for quick restart)
+[20:19:33] [INFO] [LastChance] Applied visual effects: sepia=0.70, brightness=0.60, ripple=0.0080
+[20:19:34] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:34] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:34] [INFO] [LastChance] Ending last chance effect
+[20:19:34] [INFO] [LastChance] All process modes restored
+[20:19:34] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:34] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:34] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:34] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:19:34] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 2, behavior: GUARD, player_found: yes
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:19:34] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 2, behavior: GUARD, player_found: yes
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:19:34] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:19:34] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 3, behavior: GUARD, player_found: yes
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:19:34] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:19:34] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 4, behavior: GUARD, player_found: yes
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:19:34] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 4, behavior: PATROL, player_found: yes
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:19:34] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 3, behavior: GUARD, player_found: yes
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:19:34] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 4, behavior: GUARD, player_found: yes
+[20:19:34] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:19:34] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:34] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:19:34] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:34] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:34] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:34] [INFO] [LastChance] Found player: Player
+[20:19:34] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:34] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:34] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:34] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (823.20984, 982.1707)
+[20:19:35] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:35] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:35] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:35] [INFO] [Player.Grenade] Step 1 complete! Drag: (66.197205, 622.486)
+[20:19:35] [INFO] [Player.Grenade] G released - dropping grenade at feet
+[20:19:35] [INFO] [Player.Grenade] Grenade dropped at feet at (450, 1250)
+[20:19:35] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:36] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:36] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:36] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:36] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:36] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:36] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 21)
+[20:19:36] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 22)
+[20:19:36] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 2, behavior: GUARD, player_found: yes
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 23)
+[20:19:36] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 24)
+[20:19:36] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 25)
+[20:19:36] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 2, behavior: GUARD, player_found: yes
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 26)
+[20:19:36] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 27)
+[20:19:36] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 2, behavior: PATROL, player_found: yes
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 28)
+[20:19:36] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 3, behavior: GUARD, player_found: yes
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 29)
+[20:19:36] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 2, behavior: GUARD, player_found: yes
+[20:19:36] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 30)
+[20:19:36] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:36] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:19:36] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:36] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:36] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:36] [INFO] [LastChance] Found player: Player
+[20:19:36] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:36] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:36] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:37] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (522.85583, 1209.9258)
+[20:19:37] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:37] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:37] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:37] [INFO] [Player.Grenade] Step 1 complete! Drag: (648.09924, -180.33398)
+[20:19:37] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:37] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:39] [INFO] [Player.Grenade] Throwing! Direction: (0.96026593, 0.27908653), Drag distance: 253,2178
+[20:19:39] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,28284273
+[20:19:39] [INFO] [GrenadeBase] Thrown! Direction: (0.960266, 0.279087), Speed: 506.4
+[20:19:39] [INFO] [Player.Grenade] Thrown! Direction: (0.96026593, 0.27908653), Drag distance: 253,2178
+[20:19:39] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:39] [INFO] [GrenadeBase] Grenade landed at (634.8173, 1303.715)
+[20:19:40] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:40] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:40] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:40] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:40] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:40] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 31)
+[20:19:40] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 32)
+[20:19:40] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 2, behavior: GUARD, player_found: yes
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 33)
+[20:19:40] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 34)
+[20:19:40] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 3, behavior: GUARD, player_found: yes
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 35)
+[20:19:40] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 36)
+[20:19:40] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 3, behavior: GUARD, player_found: yes
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 37)
+[20:19:40] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 2, behavior: PATROL, player_found: yes
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 38)
+[20:19:40] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 39)
+[20:19:40] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 4, behavior: GUARD, player_found: yes
+[20:19:40] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 40)
+[20:19:40] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:40] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 3, behavior: PATROL, player_found: yes
+[20:19:40] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:40] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:40] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:40] [INFO] [LastChance] Found player: Player
+[20:19:40] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:40] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:40] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:40] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (501.10632, 1511.8181)
+[20:19:40] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:40] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:40] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:40] [INFO] [Player.Grenade] Step 1 complete! Drag: (395.1809, -127.56946)
+[20:19:40] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:41] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:41] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1140.814, 1574.921), source=ENEMY (Enemy10), range=1469, listeners=40
+[20:19:42] [INFO] [SoundPropagation] Cleaned up 30 invalid listeners
+[20:19:42] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:19:42] [INFO] [Player.Grenade] Throwing! Direction: (0.7385149, 0.6742371), Drag distance: 414,59927
+[20:19:42] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,7399312
+[20:19:42] [INFO] [GrenadeBase] Thrown! Direction: (0.738515, 0.674237), Speed: 829.2
+[20:19:42] [INFO] [Player.Grenade] Thrown! Direction: (0.7385149, 0.6742371), Drag distance: 414,59927
+[20:19:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1115.641, 1548.473), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:42] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:42] [INFO] [LastChance] Threat detected: Bullet
+[20:19:42] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:42] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:42] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:42] [INFO] [LastChance] Threat detected: @Area2D@4703
+[20:19:42] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:42] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1086.453, 1525.197), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:42] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:42] [INFO] [LastChance] Threat detected: @Area2D@4704
+[20:19:42] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:42] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:42] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[20:19:42] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1140.814, 1574.921), shooter_id=546249378432, bullet_pos=(46.90426, 693.225)
+[20:19:42] [INFO] [Bullet] Using shooter_position, distance=1405.00024414063
+[20:19:42] [INFO] [Bullet] Distance to wall: 1405.00024414063 (95.6690501911709% of viewport)
+[20:19:42] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1086.453, 1525.197), shooter_id=546249378432, bullet_pos=(38.00005, 720.4922)
+[20:19:42] [INFO] [Bullet] Using shooter_position, distance=1321.66687011719
+[20:19:42] [INFO] [Bullet] Distance to wall: 1321.66687011719 (89.9947275173523% of viewport)
+[20:19:42] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1086.453, 1525.197), shooter_id=546249378432, bullet_pos=(104.6037, 684.234)
+[20:19:42] [INFO] [Bullet] Using shooter_position, distance=1292.76708984375
+[20:19:42] [INFO] [Bullet] Distance to wall: 1292.76708984375 (88.026888336524% of viewport)
+[20:19:42] [INFO] [Bullet] Distance-based penetration chance: 43.9686302740554%
+[20:19:42] [INFO] [Bullet] Penetration failed (distance roll)
+[20:19:43] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1140.814, 1574.921), shooter_id=546249378432, bullet_pos=(505.1944, 351.5045)
+[20:19:43] [INFO] [Bullet] Using shooter_position, distance=1378.68041992188
+[20:19:43] [INFO] [Bullet] Distance to wall: 1378.68041992188 (93.8768849622271% of viewport)
+[20:19:43] [INFO] [GrenadeBase] Grenade landed at (663.429, 1342.803)
+[20:19:43] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1140.814, 1574.921), shooter_id=546249378432, bullet_pos=(321.7061, 238.0536)
+[20:19:43] [INFO] [Bullet] Using shooter_position, distance=1567.84936523438
+[20:19:43] [INFO] [Bullet] Distance to wall: 1567.84936523438 (106.757746299573% of viewport)
+[20:19:43] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:43] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:43] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:43] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:43] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:43] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[20:19:43] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 2, behavior: GUARD, player_found: yes
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[20:19:43] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 3, behavior: GUARD, player_found: yes
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[20:19:43] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[20:19:43] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 2, behavior: GUARD, player_found: yes
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[20:19:43] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[20:19:43] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[20:19:43] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 4, behavior: PATROL, player_found: yes
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[20:19:43] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 2, behavior: GUARD, player_found: yes
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[20:19:43] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 4, behavior: GUARD, player_found: yes
+[20:19:43] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[20:19:43] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:43] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 3, behavior: PATROL, player_found: yes
+[20:19:43] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:43] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:43] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:43] [INFO] [LastChance] Found player: Player
+[20:19:43] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:43] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:43] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:43] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (695.6083, 1304.1002)
+[20:19:44] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:44] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:44] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:44] [INFO] [Player.Grenade] Step 1 complete! Drag: (579.47546, 69.461914)
+[20:19:44] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:44] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:44] [INFO] [Player.Grenade] Throwing! Direction: (0.99993384, 0.011508709), Drag distance: 522,29895
+[20:19:44] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,011508962
+[20:19:44] [INFO] [GrenadeBase] Thrown! Direction: (0.999934, 0.011509), Speed: 1044.6
+[20:19:44] [INFO] [Player.Grenade] Thrown! Direction: (0.99993384, 0.011508709), Drag distance: 522,29895
+[20:19:45] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:45] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:45] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:45] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:45] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:45] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:45] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 21)
+[20:19:45] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 22)
+[20:19:45] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 23)
+[20:19:45] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 24)
+[20:19:45] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 3, behavior: GUARD, player_found: yes
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 25)
+[20:19:45] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 26)
+[20:19:45] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 27)
+[20:19:45] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 2, behavior: PATROL, player_found: yes
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 28)
+[20:19:45] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 3, behavior: GUARD, player_found: yes
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 29)
+[20:19:45] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:19:45] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 30)
+[20:19:45] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:45] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 3, behavior: PATROL, player_found: yes
+[20:19:45] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:45] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:45] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:45] [INFO] [LastChance] Found player: Player
+[20:19:45] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:45] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:45] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:46] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (231.21071, 1473.0798)
+[20:19:46] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:46] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:46] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:46] [INFO] [Player.Grenade] Step 1 complete! Drag: (639.6553, -179.66614)
+[20:19:46] [INFO] [Player.Grenade] G released - dropping grenade at feet
+[20:19:46] [INFO] [Player.Grenade] Grenade dropped at feet at (450, 1250)
+[20:19:47] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:47] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:47] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:47] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:47] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:47] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 31)
+[20:19:47] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 32)
+[20:19:47] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 2, behavior: GUARD, player_found: yes
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 33)
+[20:19:47] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 4, behavior: GUARD, player_found: yes
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 34)
+[20:19:47] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 35)
+[20:19:47] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 36)
+[20:19:47] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 3, behavior: GUARD, player_found: yes
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 37)
+[20:19:47] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 3, behavior: PATROL, player_found: yes
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 38)
+[20:19:47] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 2, behavior: GUARD, player_found: yes
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 39)
+[20:19:47] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:19:47] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 40)
+[20:19:47] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:47] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:19:47] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:47] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:47] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:47] [INFO] [LastChance] Found player: Player
+[20:19:47] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:47] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:47] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:47] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (-17.28964, 1239.3135)
+[20:19:47] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:47] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:47] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:47] [INFO] [Player.Grenade] Step 1 complete! Drag: (895.27783, -139.5918)
+[20:19:47] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:48] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:49] [INFO] [Player.Grenade] Throwing! Direction: (0.5495282, -0.83547515), Drag distance: 617,15967
+[20:19:49] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,9889969
+[20:19:49] [INFO] [GrenadeBase] Thrown! Direction: (0.549528, -0.835475), Speed: 1234.3
+[20:19:49] [INFO] [Player.Grenade] Thrown! Direction: (0.5495282, -0.83547515), Drag distance: 617,15967
+[20:19:49] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:49] [INFO] [GrenadeBase] Grenade landed at (610.0115, 1046.031)
+[20:19:49] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:49] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:49] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:49] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:49] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:49] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 41)
+[20:19:49] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 2, behavior: GUARD, player_found: yes
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 42)
+[20:19:49] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 4, behavior: GUARD, player_found: yes
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 43)
+[20:19:49] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 44)
+[20:19:49] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 4, behavior: GUARD, player_found: yes
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 45)
+[20:19:49] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 4, behavior: GUARD, player_found: yes
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 46)
+[20:19:49] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 4, behavior: GUARD, player_found: yes
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 47)
+[20:19:49] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 3, behavior: PATROL, player_found: yes
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 48)
+[20:19:49] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 49)
+[20:19:49] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 4, behavior: GUARD, player_found: yes
+[20:19:49] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 50)
+[20:19:49] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:49] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:19:49] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:49] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:49] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:49] [INFO] [LastChance] Found player: Player
+[20:19:49] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:49] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:49] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:50] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (261.9414, 1526.5121)
+[20:19:50] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:50] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:50] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[20:19:50] [INFO] [Player.Grenade] Step 1 complete! Drag: (543.4899, -272.50464)
+[20:19:50] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:50] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:52] [INFO] [Player.Grenade] Throwing! Direction: (0.075492226, -0.99714637), Drag distance: 675,7773
+[20:19:52] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,4952322
+[20:19:52] [INFO] [GrenadeBase] Thrown! Direction: (0.075492, -0.997146), Speed: 1351.6
+[20:19:52] [INFO] [Player.Grenade] Thrown! Direction: (0.075492226, -0.99714637), Drag distance: 675,7773
+[20:19:52] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:19:53] [INFO] [GrenadeBase] Grenade landed at (495.7928, 765.4602)
+[20:19:54] [INFO] [GrenadeBase] EXPLODED at (496.2669, 769.2877)!
+[20:19:54] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(496.2669, 769.2877), source=NEUTRAL (FlashbangGrenade), range=2937, listeners=50
+[20:19:54] [INFO] [SoundPropagation] Cleaned up 40 invalid listeners
+[20:19:54] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=0, self=0, below_threshold=6
+[20:19:54] [ENEMY] [Enemy3] Status effect: BLINDED applied
+[20:19:54] [ENEMY] [Enemy3] Status effect: STUNNED applied
+[20:19:56] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(467.4641, 734.5184), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[20:19:56] [ENEMY] [Enemy1] Heard gunshot at (467.4641, 734.5184), source_type=0, intensity=0.01, distance=419
+[20:19:56] [ENEMY] [Enemy2] Heard gunshot at (467.4641, 734.5184), source_type=0, intensity=0.06, distance=196
+[20:19:56] [ENEMY] [Enemy3] Heard gunshot at (467.4641, 734.5184), source_type=0, intensity=0.05, distance=233
+[20:19:56] [ENEMY] [Enemy4] Heard gunshot at (467.4641, 734.5184), source_type=0, intensity=0.02, distance=371
+[20:19:56] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[20:19:56] [ENEMY] [Enemy3] Hit taken, health: 2/3
+[20:19:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(500.4641, 734.5184), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[20:19:56] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[20:19:56] [ENEMY] [Enemy3] Hit taken, health: 1/3
+[20:19:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(535.348, 735.0613), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[20:19:56] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=2, self=0, below_threshold=4
+[20:19:56] [ENEMY] [Enemy3] Hit taken, health: 0/3
+[20:19:56] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[20:19:56] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[20:19:56] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 9)
+[20:19:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(400, 550), source=ENEMY (Enemy2), range=1469, listeners=9
+[20:19:56] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=3, self=1, below_threshold=3
+[20:19:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0652, 811.1209), source=ENEMY (Enemy4), range=1469, listeners=9
+[20:19:56] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=1, below_threshold=6
+[20:19:56] [INFO] [LastChance] Threat detected: Bullet
+[20:19:56] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:56] [INFO] [LastChance] Threat detected: @Area2D@5721
+[20:19:56] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:57] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[20:19:57] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[20:19:57] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[20:19:57] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[20:19:57] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[20:19:57] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[20:19:57] [INFO] [LastChance] Player died
+[20:19:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(400, 550), source=ENEMY (Enemy2), range=1469, listeners=9
+[20:19:57] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=3, self=1, below_threshold=3
+[20:19:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0652, 811.1209), source=ENEMY (Enemy4), range=1469, listeners=9
+[20:19:57] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=1, below_threshold=6
+[20:19:57] [INFO] [LastChance] Threat detected: Bullet
+[20:19:57] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:57] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:57] [INFO] [LastChance] Threat detected: @Area2D@5722
+[20:19:57] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:57] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:57] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[20:19:57] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[20:19:57] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[20:19:57] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[20:19:57] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:57] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:57] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:57] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:57] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:57] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 10)
+[20:19:57] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 2, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 11)
+[20:19:57] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 3, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 12)
+[20:19:57] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 13)
+[20:19:57] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 2, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 14)
+[20:19:57] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 15)
+[20:19:57] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 4, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 16)
+[20:19:57] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 2, behavior: PATROL, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 17)
+[20:19:57] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 4, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 18)
+[20:19:57] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 2, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 19)
+[20:19:57] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 2, behavior: PATROL, player_found: yes
+[20:19:57] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:57] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:57] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:57] [INFO] [LastChance] Found player: Player
+[20:19:57] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:57] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:57] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:57] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:19:57] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:19:57] [INFO] [Player.Grenade] Grenade scene loaded
+[20:19:57] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:19:57] [INFO] [Player] Ready! Grenades: 1/3
+[20:19:57] [INFO] [ScoreManager] Level started with 10 enemies
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 20)
+[20:19:57] [ENEMY] [Enemy1] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy1] Enemy spawned at (300, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 21)
+[20:19:57] [ENEMY] [Enemy2] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy2] Enemy spawned at (400, 550), health: 2, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 22)
+[20:19:57] [ENEMY] [Enemy3] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy3] Enemy spawned at (700, 750), health: 3, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 23)
+[20:19:57] [ENEMY] [Enemy4] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy4] Enemy spawned at (800, 900), health: 2, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 24)
+[20:19:57] [ENEMY] [Enemy5] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy5] Enemy spawned at (1700, 350), health: 3, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 25)
+[20:19:57] [ENEMY] [Enemy6] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy6] Enemy spawned at (1950, 450), health: 2, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 26)
+[20:19:57] [ENEMY] [Enemy7] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy7] Enemy spawned at (1600, 900), health: 4, behavior: PATROL, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 27)
+[20:19:57] [ENEMY] [Enemy8] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy8] Enemy spawned at (1900, 1450), health: 3, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 28)
+[20:19:57] [ENEMY] [Enemy9] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy9] Enemy spawned at (2100, 1550), health: 3, behavior: GUARD, player_found: yes
+[20:19:57] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 29)
+[20:19:57] [ENEMY] [Enemy10] Registered as sound listener
+[20:19:57] [ENEMY] [Enemy10] Enemy spawned at (1200, 1550), health: 4, behavior: PATROL, player_found: yes
+[20:19:57] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:19:57] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:19:57] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:19:57] [INFO] [LastChance] Found player: Player
+[20:19:57] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:19:57] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:19:57] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:19:58] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (489.9029, 890.90094)
+[20:19:58] [INFO] [GrenadeBase] Grenade created at (0, 0)
+[20:19:58] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:19:58] [INFO] [Player.Grenade] Timer started, grenade created at (327.95862, 1121.4432)
+[20:19:58] [INFO] [Player.Grenade] Step 1 complete! Drag: (595.0278, -73.918274)
+[20:19:59] [INFO] [Player.Grenade] Step 2 part 1: G+RMB held - now release G to ready the throw
+[20:19:59] [ENEMY] [Enemy10] Player distracted - priority attack triggered
+[20:19:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1200, 1550), source=ENEMY (Enemy10), range=1469, listeners=29
+[20:19:59] [INFO] [SoundPropagation] Cleaned up 19 invalid listeners
+[20:19:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:19:59] [INFO] [Player.Grenade] Step 2 complete: G released, RMB held - now aiming, drag and release RMB to throw
+[20:19:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1171.905, 1534.683), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=8
+[20:19:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1200, 1550), shooter_id=708082404324, bullet_pos=(914.96, 1400.931)
+[20:19:59] [INFO] [Bullet] Using shooter_position, distance=321.66650390625
+[20:19:59] [INFO] [Bullet] Distance to wall: 321.66650390625 (21.9028637435208% of viewport)
+[20:19:59] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:19:59] [INFO] [Bullet] Starting wall penetration at (914.96, 1400.931)
+[20:19:59] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[20:19:59] [INFO] [Bullet] Exiting penetration at (873.6071, 1379.304) after traveling 41.6666679382324 pixels through wall
+[20:19:59] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1139.719, 1515.77), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1108.136, 1495.865), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1076.917, 1475.391), source=ENEMY (Enemy10), range=1469, listeners=10
+[20:19:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=9
+[20:19:59] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[20:19:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1171.905, 1534.683), shooter_id=708082404324, bullet_pos=(58.84503, 902.6244)
+[20:19:59] [INFO] [Bullet] Using shooter_position, distance=1280.00048828125
+[20:19:59] [INFO] [Bullet] Distance to wall: 1280.00048828125 (87.1575869604231% of viewport)
+[20:19:59] [INFO] [Bullet] Distance-based penetration chance: 44.9828152128397%
+[20:19:59] [INFO] [Bullet] Starting wall penetration at (58.84503, 902.6244)
+[20:19:59] [INFO] [Bullet] Raycast backward hit penetrating body at distance 15.7953691482544
+[20:19:59] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:59] [INFO] [Bullet] Exiting penetration at (18.26469, 879.5806) after traveling 41.6666679382324 pixels through wall
+[20:19:59] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:59] [INFO] [LastChance] Threat detected: @Area2D@6228
+[20:19:59] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:59] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1139.719, 1515.77), shooter_id=708082404324, bullet_pos=(48.97605, 845.9339)
+[20:19:59] [INFO] [Bullet] Using shooter_position, distance=1280.00036621094
+[20:19:59] [INFO] [Bullet] Distance to wall: 1280.00036621094 (87.1575786484311% of viewport)
+[20:19:59] [INFO] [Bullet] Distance-based penetration chance: 44.9828249101638%
+[20:19:59] [INFO] [Bullet] Penetration failed (distance roll)
+[20:19:59] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[20:19:59] [INFO] [LastChance] Threat detected: @Area2D@6229
+[20:19:59] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:19:59] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:19:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1108.136, 1495.865), shooter_id=708082404324, bullet_pos=(34.00317, 799.7037)
+[20:19:59] [INFO] [Bullet] Using shooter_position, distance=1280.00048828125
+[20:19:59] [INFO] [Bullet] Distance to wall: 1280.00048828125 (87.1575869604231% of viewport)
+[20:19:59] [INFO] [Bullet] Distance-based penetration chance: 44.9828152128397%
+[20:19:59] [INFO] [Bullet] Starting wall penetration at (34.00317, 799.7037)
+[20:19:59] [INFO] [Bullet] Raycast backward hit penetrating body at distance 44.2795753479004
+[20:19:59] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:19:59] [INFO] [Bullet] Exiting penetration at (-5.157904, 774.3229) after traveling 41.6666679382324 pixels through wall
+[20:19:59] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[20:19:59] [INFO] [Player.Grenade] Throwing! Direction: (0.6877792, -0.72591996), Drag distance: 734,7226
+[20:19:59] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,812371
+[20:19:59] [INFO] [GrenadeBase] Thrown! Direction: (0.687779, -0.72592), Speed: 1469.4
+[20:19:59] [INFO] [Player.Grenade] Thrown! Direction: (0.6877792, -0.72591996), Drag distance: 734,7226
+[20:20:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1076.917, 1475.391), shooter_id=708082404324, bullet_pos=(45.08744, 790.703)
+[20:20:00] [INFO] [Bullet] Using shooter_position, distance=1238.333984375
+[20:20:00] [INFO] [Bullet] Distance to wall: 1238.333984375 (84.3204380915019% of viewport)
+[20:20:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1076.917, 1475.391), shooter_id=708082404324, bullet_pos=(168.0006, 710.6813)
+[20:20:00] [INFO] [Bullet] Using shooter_position, distance=1187.81774902344
+[20:20:00] [INFO] [Bullet] Distance to wall: 1187.81774902344 (80.8806947352481% of viewport)
+[20:20:00] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(637.2736, 762.6521), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:20:00] [ENEMY] [Enemy2] Heard gunshot at (637.2736, 762.6521), source_type=1, intensity=0.02, distance=319
+[20:20:00] [ENEMY] [Enemy4] Heard gunshot at (637.2736, 762.6521), source_type=1, intensity=0.06, distance=213
+[20:20:00] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:20:00] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:20:00] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(600.4532, 768.8182), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:20:00] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[20:20:00] [INFO] [LastChance] Threat detected: Bullet
+[20:20:00] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[20:20:00] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:20:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1076.917, 1475.391), shooter_id=708082404324, bullet_pos=(500.3813, 864.5068)
+[20:20:00] [INFO] [Bullet] Using shooter_position, distance=839.984313964844
+[20:20:00] [INFO] [Bullet] Distance to wall: 839.984313964844 (57.1960765328207% of viewport)
+[20:20:00] [INFO] [Bullet] Distance-based penetration chance: 79.9379107117092%
+[20:20:00] [INFO] [Bullet] Starting wall penetration at (500.3813, 864.5068)
+[20:20:00] [INFO] [Bullet] Raycast backward hit penetrating body at distance 9.07869434356689
+[20:20:00] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:20:00] [INFO] [Bullet] Exiting penetration at (532.2391, 879.2506) after traveling 30.1041698455811 pixels through wall
+[20:20:00] [INFO] [Bullet] Damage multiplier after penetration: 0.225
+[20:20:00] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[20:20:00] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[20:20:00] [INFO] [LastChance] Threat detected: @Area2D@6235
+[20:20:00] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[20:20:00] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:20:00] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(563.5889, 774.7177), source=ENEMY (Enemy3), range=1469, listeners=10
+[20:20:00] [ENEMY] [Enemy1] Heard gunshot at (563.5889, 774.7177), source_type=1, intensity=0.01, distance=500
+[20:20:00] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=1, below_threshold=4
+[20:20:00] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[20:20:00] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[20:20:00] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[20:20:00] [INFO] [LastChance] Threat detected: Bullet
+[20:20:00] [INFO] [LastChance] Triggering last chance effect!
+[20:20:00] [INFO] [LastChance] Starting last chance effect:
+[20:20:00] [INFO] [LastChance]   - Time will be frozen (except player)
+[20:20:00] [INFO] [LastChance]   - Duration: 6.0 real seconds
+[20:20:00] [INFO] [LastChance]   - Sepia intensity: 0.70
+[20:20:00] [INFO] [LastChance]   - Brightness: 0.60
+[20:20:00] [INFO] [LastChance] Pushed bullet Bullet from distance 126.9 to 200.0
+[20:20:00] [INFO] [LastChance] Pushed 1 threatening bullets away from player
+[20:20:00] [INFO] [LastChance] Set player Player and all 12 children to PROCESS_MODE_ALWAYS
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room1_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room1_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room2_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room2_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room2_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room3_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room3_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room4_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room4_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room5_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room5_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Left' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Right' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallRight' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallTop' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBL' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTL' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Desk1' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Desk2' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Table1' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Cabinet1' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Cabinet2' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Desk3' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Desk4' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Table2' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Table3' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'Cabinet3' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'StorageCrate1' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'StorageCrate2' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Set StaticBody2D 'HallTable' to PROCESS_MODE_ALWAYS for collision
+[20:20:00] [INFO] [LastChance] Skipping player node: Player
+[20:20:00] [INFO] [LastChance] Froze all nodes except player and autoloads (including GameManager for quick restart)
+[20:20:00] [INFO] [LastChance] Applied visual effects: sepia=0.70, brightness=0.60, ripple=0.0080
+[20:20:01] [INFO] ------------------------------------------------------------
+[20:20:01] [INFO] GAME LOG ENDED: 2026-01-21T20:20:01
+[20:20:01] [INFO] ============================================================

--- a/scripts/characters/player.gd
+++ b/scripts/characters/player.gd
@@ -843,9 +843,13 @@ func _start_grenade_timer() -> void:
 ## Drop the grenade at player's feet (when G is released before throwing).
 func _drop_grenade_at_feet() -> void:
 	if _active_grenade != null and is_instance_valid(_active_grenade):
+		# Set position to current player position before unfreezing
+		_active_grenade.global_position = global_position
+		# Unfreeze the grenade so physics works and it can explode
+		_active_grenade.freeze = false
 		# Grenade stays where it is (at player's last position)
 		# It will explode when timer runs out
-		FileLogger.info("[Player.Grenade] Grenade dropped at feet at %s" % str(_active_grenade.global_position))
+		FileLogger.info("[Player.Grenade] Grenade dropped at feet at %s (unfrozen)" % str(_active_grenade.global_position))
 	_reset_grenade_state()
 
 

--- a/scripts/projectiles/grenade_base.gd
+++ b/scripts/projectiles/grenade_base.gd
@@ -65,10 +65,16 @@ func _ready() -> void:
 	gravity_scale = 0.0  # Top-down, no gravity
 	linear_damp = 2.0  # Natural slowdown
 
+	# IMPORTANT: Start frozen to prevent physics interference while grenade follows player
+	# This fixes the bug where grenade was thrown from activation position instead of current position
+	# The physics engine can overwrite manual position updates on active RigidBody2D nodes
+	freeze = true
+	freeze_mode = RigidBody2D.FREEZE_MODE_KINEMATIC
+
 	# Connect to body entered for bounce effects
 	body_entered.connect(_on_body_entered)
 
-	FileLogger.info("[GrenadeBase] Grenade created at %s" % str(global_position))
+	FileLogger.info("[GrenadeBase] Grenade created at %s (frozen)" % str(global_position))
 
 
 func _physics_process(delta: float) -> void:
@@ -106,6 +112,10 @@ func activate_timer() -> void:
 ## @param direction: Normalized direction to throw.
 ## @param drag_distance: Distance of the drag in pixels.
 func throw_grenade(direction: Vector2, drag_distance: float) -> void:
+	# Unfreeze the grenade so physics can take over
+	# This must happen before setting velocity, otherwise the velocity won't be applied
+	freeze = false
+
 	# Calculate throw speed based on drag distance
 	var throw_speed := clampf(
 		drag_distance * drag_to_speed_multiplier,
@@ -119,7 +129,7 @@ func throw_grenade(direction: Vector2, drag_distance: float) -> void:
 	# Rotate to face direction
 	rotation = direction.angle()
 
-	FileLogger.info("[GrenadeBase] Thrown! Direction: %s, Speed: %.1f" % [str(direction), throw_speed])
+	FileLogger.info("[GrenadeBase] Thrown! Direction: %s, Speed: %.1f (unfrozen)" % [str(direction), throw_speed])
 
 
 ## Get the explosion effect radius. Override in subclasses.


### PR DESCRIPTION
## Summary

Fixes #183 - The grenade was intermittently being thrown from the activation position (where the pin was pulled) instead of the player's current position.

## Root Cause

The grenade extends `RigidBody2D` and was active (not frozen) while following the player. Godot's physics engine could intermittently overwrite manual `global_position` updates when the physics step and manual updates occurred at conflicting times. This caused a race condition where the grenade position would sometimes "snap back" to a previous position.

## Solution

**Freeze the grenade while it's held by the player, unfreeze when thrown or dropped.**

1. **On creation** (`grenade_base.gd:_ready`): Set `freeze = true` and `freeze_mode = FREEZE_MODE_KINEMATIC`
2. **On throw** (`grenade_base.gd:throw_grenade`): Set `freeze = false` before applying velocity
3. **On drop** (`player.gd` and `Player.cs`): Set `freeze = false` so physics and explosion timer work

This ensures the physics engine doesn't interfere with manual position tracking while the grenade follows the player.

## Files Changed

- `scripts/projectiles/grenade_base.gd` - Freeze grenade on creation, unfreeze on throw
- `scripts/characters/player.gd` - Unfreeze grenade when dropped at feet (GDScript)
- `Scripts/Characters/Player.cs` - Unfreeze grenade when dropped at feet (C#)

## Documentation

- Added case study analysis with log file examination in `docs/case-studies/issue-183/`
- Includes the original log files provided in the issue

## Testing

After this fix, the grenade should:
- Always be created at the player's current position
- Follow the player exactly while held (no jitter/offset)
- Be thrown from the player's current position at throw time, not the activation position
- Have correct physics after being thrown (velocity, friction, bounce)
- Work correctly when dropped at feet (unfreezes and explodes on timer)

---
*This PR was created automatically by the AI issue solver*