### PR TITLE
Fix R key press handling for shotgun

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/229
-Your prepared branch: issue-229-d91bdd53a4d4
-Your prepared working directory: /tmp/gh-issue-solver-1769072285689
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary
- Skip the R-F-R reload sequence for weapons that use tube magazines (like Shotgun)
- Fixes issue where pressing R while holding a shotgun would break ammo tracking

## Root Cause
The Player's `HandleReloadSequenceInput()` method handles the R-F-R reload sequence designed for magazine-based weapons (Assault Rifle, MiniUzi). When the player pressed R with a shotgun equipped, this method would invoke `BaseWeapon.InstantReload()`, which manipulates the `MagazineInventory`. 

However, the Shotgun tracks ammo separately via `ShellsInTube` and has its own shell-by-shell reload mechanism using RMB drag gestures. The magazine manipulation caused ammo corruption.

## Solution
Added a type check at the beginning of `HandleReloadSequenceInput()` to exit early for Shotgun weapons:

```csharp
// Skip R-F-R reload sequence for weapons that use tube magazines (like Shotgun)
// These weapons have their own reload mechanism (shell-by-shell via RMB gestures)
// Pressing R key should be ignored for these weapons to avoid breaking ammo tracking
if (CurrentWeapon is Shotgun)
{
    return;
}
```

## Test plan
- [ ] Hold shotgun, press R key - should be ignored with no effect on ammo
- [ ] Reload shotgun using RMB drag gestures (existing mechanism) - should work normally
- [ ] Switch to assault rifle, use R-F-R reload - should work normally

## Files changed
- `Scripts/Characters/Player.cs` - Added Shotgun check to skip R-F-R reload sequence

---
Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)