### PR TITLE
feat: reduce UIZ and M16 ammo by half on Building map

### DIFF
--- a/Scripts/AbstractClasses/BaseWeapon.cs
+++ b/Scripts/AbstractClasses/BaseWeapon.cs
@@ -665,4 +665,25 @@ public abstract partial class BaseWeapon : Node2D
         EmitSignal(SignalName.AmmoChanged, CurrentAmmo, ReserveAmmo);
         EmitMagazinesChanged();
     }
+
+    /// <summary>
+    /// Reinitializes the magazine inventory with a new starting magazine count.
+    /// This method allows level-specific ammunition configuration.
+    /// </summary>
+    /// <param name="magazineCount">Number of magazines to initialize with.</param>
+    /// <param name="fillAllMagazines">If true, all magazines start full. Otherwise, only current is full.</param>
+    public virtual void ReinitializeMagazines(int magazineCount, bool fillAllMagazines = true)
+    {
+        if (WeaponData == null)
+        {
+            GD.PrintErr("[BaseWeapon] Cannot reinitialize magazines: WeaponData is null");
+            return;
+        }
+
+        MagazineInventory.Initialize(magazineCount, WeaponData.MagazineSize, fillAllMagazines);
+        EmitSignal(SignalName.AmmoChanged, CurrentAmmo, ReserveAmmo);
+        EmitMagazinesChanged();
+
+        GD.Print($"[BaseWeapon] Magazines reinitialized: {magazineCount} magazines, fillAll={fillAllMagazines}");
+    }
 }

--- a/docs/case-studies/issue-413/README.md
+++ b/docs/case-studies/issue-413/README.md
@@ -1,0 +1,209 @@
+# Issue #413: Reduce UIZ and M16 Ammunition by Half on Building Map
+
+## Issue Description
+
+**Original Request (Russian):** "сделать uiz и m16 у игрока патронов меньше в 2 раза на карте Здание - в смысле меньше магазинов"
+
+**Translation:** Make UIZ and M16 have half the ammunition for the player on the Building map - meaning fewer magazines.
+
+**Issue Link:** https://github.com/Jhon-Crow/godot-topdown-MVP/issues/413
+
+## Problem Analysis
+
+### Initial Investigation
+
+The user reported that after the initial implementation, the M16 still had too many bullets. Specifically, they expected:
+- **M16**: 30 + 30 = 60 rounds total (2 magazines of 30 rounds each)
+
+From the game log analysis (`game_log_20260203_221404.txt`), we observed:
+1. Player starts with "Ammo: 30/30" displayed
+2. Player fires many shots (50+ gunshots logged)
+3. Player performs a reload: "Phase changed to: GrabMagazine" and "InsertMagazine"
+4. This indicates the player had more than 30 bullets available
+
+### Root Cause Analysis
+
+#### Weapon Initialization Flow
+
+The codebase uses a C# BaseWeapon class with the following initialization sequence:
+
+1. **BaseWeapon._Ready()** (line 141-151):
+   ```csharp
+   public override void _Ready()
+   {
+       if (WeaponData != null)
+       {
+           // Initialize magazine inventory with the starting magazines
+           MagazineInventory.Initialize(StartingMagazineCount, WeaponData.MagazineSize, fillAllMagazines: true);
+           EmitMagazinesChanged();
+       }
+   }
+   ```
+
+2. **Default Values**:
+   - `StartingMagazineCount = 4` (default in BaseWeapon.cs:41)
+   - M16 `MagazineSize = 30` (AssaultRifleData.tres:11)
+   - Mini UZI `MagazineSize = 32` (MiniUziData.tres:11)
+
+#### Initial Implementation Problem
+
+The original fix attempted to set `StartingMagazineCount` after the weapon was already initialized:
+
+```gdscript
+var assault_rifle = _player.get_node_or_null("AssaultRifle")
+if assault_rifle:
+    assault_rifle.StartingMagazineCount = 2  # TOO LATE!
+```
+
+**Why this failed:**
+- The AssaultRifle is already in the Player scene
+- When the Player scene loads, AssaultRifle._Ready() is called
+- _Ready() reads `StartingMagazineCount` and calls `MagazineInventory.Initialize(4, 30, true)`
+- By the time building_level.gd runs, the magazines are already initialized with 4×30=120 rounds
+- Setting `StartingMagazineCount = 2` has no effect on already-initialized magazines
+
+#### Timeline of Events
+
+```
+1. Player scene loads
+   ├─> AssaultRifle node instantiated
+   └─> AssaultRifle._Ready() called
+       └─> MagazineInventory.Initialize(4, 30, true)  # 4 magazines created
+
+2. BuildingLevel._ready() runs
+   └─> _setup_selected_weapon() called
+       └─> assault_rifle.StartingMagazineCount = 2  # No effect!
+           (Magazines already initialized)
+```
+
+### Ammunition Calculations
+
+#### M16 (Assault Rifle)
+- Magazine capacity: 30 rounds
+- Default configuration: 4 magazines = 120 rounds total
+- **Target (half)**: 2 magazines = 60 rounds total (30+30) ✓
+
+#### Mini UZI
+- Magazine capacity: 32 rounds
+- Previous configuration: 4 starting + 1 extra = 5 magazines = 160 rounds total
+- **Target (reduced)**: 2 magazines = 64 rounds total ✓
+- Note: 64 is 40% of 160, but this represents "half the magazines"
+
+## Solution Design
+
+### Approach: Add ReinitializeMagazines Method
+
+Since the magazines are already initialized when the level code runs, we need a way to reinitialize them. The solution adds a new public method to BaseWeapon:
+
+```csharp
+public virtual void ReinitializeMagazines(int magazineCount, bool fillAllMagazines = true)
+{
+    if (WeaponData == null)
+    {
+        GD.PrintErr("[BaseWeapon] Cannot reinitialize magazines: WeaponData is null");
+        return;
+    }
+
+    MagazineInventory.Initialize(magazineCount, WeaponData.MagazineSize, fillAllMagazines);
+    EmitSignal(SignalName.AmmoChanged, CurrentAmmo, ReserveAmmo);
+    EmitMagazinesChanged();
+
+    GD.Print($"[BaseWeapon] Magazines reinitialized: {magazineCount} magazines, fillAll={fillAllMagazines}");
+}
+```
+
+### Implementation Details
+
+#### For M16 (Already in Scene)
+Since the M16/AssaultRifle is already in the Player scene and initialized, we call `ReinitializeMagazines`:
+
+```gdscript
+var assault_rifle = _player.get_node_or_null("AssaultRifle")
+if assault_rifle:
+    if assault_rifle.has_method("ReinitializeMagazines"):
+        assault_rifle.ReinitializeMagazines(2, true)
+        print("BuildingLevel: M16 magazines reinitialized to 2 (reduced by half)")
+```
+
+#### For Mini UZI (Dynamically Instantiated)
+For the Mini UZI, which is loaded dynamically, we set `StartingMagazineCount` BEFORE adding to the scene tree:
+
+```gdscript
+var mini_uzi = mini_uzi_scene.instantiate()
+mini_uzi.name = "MiniUzi"
+
+# Set BEFORE add_child() so _Ready() initializes with correct count
+if mini_uzi.get("StartingMagazineCount") != null:
+    mini_uzi.StartingMagazineCount = 2
+
+_player.add_child(mini_uzi)  # Triggers _Ready() which reads StartingMagazineCount
+```
+
+## Changes Made
+
+### Files Modified
+
+1. **Scripts/AbstractClasses/BaseWeapon.cs**
+   - Added `ReinitializeMagazines(int, bool)` method
+   - Location: After `AddAmmo` method (line 668+)
+   - Purpose: Allow runtime reinitialization of magazine inventory
+
+2. **scripts/levels/building_level.gd**
+   - Updated M16 section to call `ReinitializeMagazines(2, true)`
+   - Updated Mini UZI section with clearer comments
+   - Location: `_setup_selected_weapon()` function
+
+### Verification
+
+The fix can be verified by:
+1. Checking game logs for "Magazines reinitialized" message
+2. Observing player can only reload once (2 magazines total)
+3. Total shots fired should not exceed 60 for M16, 64 for Mini UZI
+
+## Testing Performed
+
+### Log Analysis
+From `game_log_20260203_221404.txt` (before fix):
+- Player fired 50+ shots before reloading
+- Player successfully reloaded, indicating spare magazines available
+- This confirmed the original implementation was not working
+
+### Expected Behavior After Fix
+1. M16: Player starts with 30/30 ammo, can reload once to get another 30 bullets
+2. Mini UZI: Player starts with 32/32 ammo, can reload once to get another 32 bullets
+
+## Technical Notes
+
+### Why Not Modify Scene Files?
+
+We could have edited the Player.tscn or AssaultRifle.tscn to set `StartingMagazineCount = 2`, but this would affect ALL levels. The requirement is specifically for the Building level only, so runtime modification is the correct approach.
+
+### Magazine Inventory System
+
+The game uses a sophisticated magazine system:
+- `MagazineInventory` class manages individual `MagazineData` objects
+- Each magazine tracks its current ammo and max capacity independently
+- Reloading swaps to the fullest available magazine
+- This is more realistic than a simple "ammo pool" system
+
+### Alternative Approaches Considered
+
+1. **Modify scene files** - Would affect all levels ❌
+2. **Remove spare magazines after initialization** - No public API available ❌
+3. **Set StartingMagazineCount before _Ready()** - Only works for dynamically instantiated weapons ⚠️
+4. **Add ReinitializeMagazines method** - Works for all cases ✓
+
+## Related Issues
+
+- Issue #266: Magazine system implementation
+- Issue #210: Ammunition management
+- Issue #262: Weapon initialization
+
+## Conclusion
+
+The solution correctly implements level-specific ammunition reduction by:
+1. Adding a new `ReinitializeMagazines` method to BaseWeapon
+2. Calling this method for already-initialized weapons (M16)
+3. Setting `StartingMagazineCount` before initialization for dynamic weapons (Mini UZI)
+
+This approach is maintainable, doesn't affect other levels, and works with the existing magazine inventory system.

--- a/docs/case-studies/issue-413/logs/game_log_20260203_221404.txt
+++ b/docs/case-studies/issue-413/logs/game_log_20260203_221404.txt
@@ -1,0 +1,5486 @@
+[22:14:04] [INFO] ============================================================
+[22:14:04] [INFO] GAME LOG STARTED
+[22:14:04] [INFO] ============================================================
+[22:14:04] [INFO] Timestamp: 2026-02-03T22:14:04
+[22:14:04] [INFO] Log file: I:/Загрузки/godot exe/меньше патр/game_log_20260203_221404.txt
+[22:14:04] [INFO] Executable: I:/Загрузки/godot exe/меньше патр/Godot-Top-Down-Template.exe
+[22:14:04] [INFO] OS: Windows
+[22:14:04] [INFO] Debug build: false
+[22:14:04] [INFO] Engine version: 4.3-stable (official)
+[22:14:04] [INFO] Project: Godot Top-Down Template
+[22:14:04] [INFO] ------------------------------------------------------------
+[22:14:04] [INFO] [GameManager] GameManager ready
+[22:14:04] [INFO] [ScoreManager] ScoreManager ready
+[22:14:04] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[22:14:04] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[22:14:04] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[22:14:04] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[22:14:04] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:04] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[22:14:04] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[22:14:04] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[22:14:04] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[22:14:04] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[22:14:04] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[22:14:04] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[22:14:04] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:04] [INFO] [LastChance] Last chance shader loaded successfully
+[22:14:04] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[22:14:04] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[22:14:04] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[22:14:04] [INFO] [LastChance]   Sepia intensity: 0.70
+[22:14:04] [INFO] [LastChance]   Brightness: 0.60
+[22:14:04] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[22:14:04] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[22:14:04] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV enabled: true
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:04] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:04] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:04] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:04] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:04] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:04] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:04] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:04] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:04] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:04] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:04] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:04] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:04] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:04] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:04] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:04] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:04] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:04] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:04] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:04] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:04] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:04] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:04] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[22:14:04] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:04] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[22:14:04] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:04] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:04] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:04] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[22:14:04] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[22:14:04] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[22:14:04] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:14:04] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[22:14:04] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:14:04] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[22:14:04] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[22:14:04] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[22:14:04] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 3, behavior: GUARD
+[22:14:04] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[22:14:04] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[22:14:04] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[22:14:04] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy7] Spawned at (1606.114, 893.8859), hp: 3, behavior: PATROL
+[22:14:04] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[22:14:04] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:14:04] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[22:14:04] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[22:14:04] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:04] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[22:14:04] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:04] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[22:14:04] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:04] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:04] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:04] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:04] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:04] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:04] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:04] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:04] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:04] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:04] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:14:04] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:14:04] [INFO] [PenultimateHit] Shader warmup complete in 156 ms
+[22:14:04] [INFO] [LastChance] Shader warmup complete in 154 ms
+[22:14:04] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:04] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:04] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:04] [INFO] [LastChance] Found player: Player
+[22:14:04] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:04] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:04] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:05] [INFO] [ImpactEffects] Particle shader warmup complete: 5 effects warmed up in 363 ms
+[22:14:06] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:06] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:14:06] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,973), corner_timer=0.30
+[22:14:06] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,973), corner_timer=0.30
+[22:14:06] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,869), corner_timer=-0.02
+[22:14:06] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:06] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,869), corner_timer=-0.02
+[22:14:06] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:14:06] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,863), corner_timer=0.30
+[22:14:06] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,863), corner_timer=0.30
+[22:14:06] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=164.4°, current=123.7°, player=(450,819), corner_timer=0.00
+[22:14:06] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[22:14:06] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=166.8°, current=-64.9°, player=(450,808), corner_timer=0.00
+[22:14:06] [ENEMY] [Enemy4] Memory: high confidence (0.90) - transitioning to PURSUING
+[22:14:06] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[22:14:06] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-164.5°, current=-101.3°, player=(450,803), corner_timer=0.00
+[22:14:06] [ENEMY] [Enemy4] PURSUING corner check: angle -113.2°
+[22:14:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450, 772.3333), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:06] [ENEMY] [Enemy1] Heard gunshot at (450, 772.3333), source_type=0, intensity=0.01, distance=448
+[22:14:06] [ENEMY] [Enemy2] Heard gunshot at (450, 772.3333), source_type=0, intensity=0.05, distance=228
+[22:14:06] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:06] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=70.2°, current=-157.5°, player=(450,766), corner_timer=0.00
+[22:14:06] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=77.0°, current=-67.5°, player=(450,766), corner_timer=0.00
+[22:14:06] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,762), corner_timer=-0.02
+[22:14:06] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:14:06] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,758), corner_timer=0.30
+[22:14:07] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 3/3 -> 2/3
+[22:14:07] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:07] [INFO] [ImpactEffects] spawn_blood_effect called at (684.4485, 753.7583), dir=(1, 0), lethal=false
+[22:14:07] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:07] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:07] [INFO] [ImpactEffects] Blood effect spawned at (684.4485, 753.7583) (scale=1)
+[22:14:07] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-178.5°, current=180.0°, player=(450,747), corner_timer=0.00
+[22:14:07] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450.6159, 748.3425), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:07] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:07] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 2/3 -> 1/3
+[22:14:07] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:07] [INFO] [ImpactEffects] spawn_blood_effect called at (684.4485, 753.7583), dir=(1, 0), lethal=false
+[22:14:07] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:07] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:07] [INFO] [ImpactEffects] Blood effect spawned at (684.4485, 753.7583) (scale=1)
+[22:14:07] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(445.9378, 734.379), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:07] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:07] [ENEMY] [Enemy4] PURSUING corner check: angle -89.5°
+[22:14:07] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[22:14:07] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 1/3 -> 0/3
+[22:14:07] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:07] [INFO] [ImpactEffects] spawn_blood_effect called at (681.583, 756.9196), dir=(1, 0), lethal=true
+[22:14:07] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:07] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:07] [INFO] [ImpactEffects] Blood effect spawned at (681.583, 756.9196) (scale=1.5)
+[22:14:07] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[22:14:07] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:14:07] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 9)
+[22:14:07] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[22:14:07] [ENEMY] [Enemy3] Death animation started with hit direction: (1, 0)
+[22:14:07] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(429.7856, 784.9421), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:07] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:07] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(424,783), corner_timer=-0.01
+[22:14:07] [ENEMY] [Enemy10] PATROL corner check: angle 3.6°
+[22:14:07] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.6°, current=9.1°, player=(426,787), corner_timer=0.30
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (770.4194, 773.5568) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (735.7159, 758.7477) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (769.4427, 762.8079) (added to group)
+[22:14:07] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(436.2697, 810.0938), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:07] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (758.9047, 755.6971) (added to group)
+[22:14:07] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(436.26968, 810.0938), shooter_id=49928996564, bullet_pos=(527.82874, 805.65344)
+[22:14:07] [INFO] [Bullet] Using shooter_position, distance=91,66666
+[22:14:07] [INFO] [Bullet] Distance to wall: 91,66666 (6,2417517% of viewport)
+[22:14:07] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:07] [INFO] [Bullet] Starting wall penetration at (527.82874, 805.65344)
+[22:14:07] [INFO] [Bullet] Raycast backward hit penetrating body at distance 42,16657
+[22:14:07] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:07] [INFO] [Bullet] Exiting penetration at (566.11707, 803.7966) after traveling 33,333336 pixels through wall
+[22:14:07] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (759.9938, 800.0856) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (740.4176, 790.2332) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (759.3282, 774.5688) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (788.0712, 762.7931) (added to group)
+[22:14:07] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(429.7856, 784.9421), shooter_id=49928996564, bullet_pos=(920.20776, 749.9801)
+[22:14:07] [INFO] [Bullet] Using shooter_position, distance=491,66678
+[22:14:07] [INFO] [Bullet] Distance to wall: 491,66678 (33,478497% of viewport)
+[22:14:07] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:07] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[22:14:07] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[22:14:07] [ENEMY] [Enemy4] PURSUING corner check: angle -89.5°
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (744.5118, 754.0287) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (769.9266, 785.5438) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (741.6626, 789.8967) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (752.045, 741.463) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (792.4055, 762.4425) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (727.9907, 760.0437) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (771.3038, 770.7833) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (794.3085, 751.5497) (added to group)
+[22:14:07] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(430,823), corner_timer=-0.01
+[22:14:07] [ENEMY] [Enemy10] PATROL corner check: angle 1.9°
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (881.1724, 866.6315) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (871.6636, 855.4856) (added to group)
+[22:14:07] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:07] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:07] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:07] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:07] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:07] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:07] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:07] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:07] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:07] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:07] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:07] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:07] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:07] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:07] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:07] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:07] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:07] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:07] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:07] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:07] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:07] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:07] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:07] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:07] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:07] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:07] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:07] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[22:14:07] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:07] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:07] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:07] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (755.691, 772.593) (added to group)
+[22:14:07] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 10)
+[22:14:07] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[22:14:07] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 11)
+[22:14:07] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:14:07] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 12)
+[22:14:07] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[22:14:07] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 13)
+[22:14:07] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[22:14:07] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 14)
+[22:14:07] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[22:14:07] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 15)
+[22:14:07] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[22:14:07] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 16)
+[22:14:07] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[22:14:07] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 17)
+[22:14:07] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:14:07] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 18)
+[22:14:07] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:14:07] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:07] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 19)
+[22:14:07] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:07] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[22:14:07] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:07] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:07] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:07] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:07] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:07] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:07] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:07] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:07] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:07] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:07] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:07] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:07] [INFO] [LastChance] Found player: Player
+[22:14:07] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:07] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:07] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (789.8772, 798.4315) (added to group)
+[22:14:07] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:07] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:14:07] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (844.3993, 865.377) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (862.9006, 845.3958) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (816.8821, 807.248) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (791.2076, 811.4623) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (804.1913, 790.4109) (added to group)
+[22:14:07] [INFO] [BloodDecal] Blood puddle created at (811.9911, 793.5653) (added to group)
+[22:14:08] [INFO] [BloodDecal] Blood puddle created at (887.6775, 893.8502) (added to group)
+[22:14:08] [INFO] [BloodDecal] Blood puddle created at (893.5587, 898.5707) (added to group)
+[22:14:08] [INFO] [BloodDecal] Blood puddle created at (822.2591, 785.7212) (added to group)
+[22:14:08] [INFO] [BloodDecal] Blood puddle created at (849.6515, 834.5737) (added to group)
+[22:14:08] [INFO] [BloodDecal] Blood puddle created at (909.1781, 843.296) (added to group)
+[22:14:09] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:09] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:14:09] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,847), corner_timer=0.30
+[22:14:09] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,847), corner_timer=0.30
+[22:14:09] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=164.4°, current=-168.8°, player=(450,819), corner_timer=0.00
+[22:14:09] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[22:14:09] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=166.5°, current=-9.1°, player=(450,810), corner_timer=0.00
+[22:14:09] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450, 800.4444), source=PLAYER (AssaultRifle), range=1469, listeners=19
+[22:14:09] [INFO] [SoundPropagation] Cleaned up 9 invalid listeners
+[22:14:09] [ENEMY] [Enemy1] Heard gunshot at (450, 800.4444), source_type=0, intensity=0.01, distance=475
+[22:14:09] [ENEMY] [Enemy2] Heard gunshot at (450, 800.4444), source_type=0, intensity=0.04, distance=255
+[22:14:09] [ENEMY] [Enemy4] Heard gunshot at (450, 800.4444), source_type=0, intensity=0.02, distance=364
+[22:14:09] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:09] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=71.4°, current=168.8°, player=(450,794), corner_timer=0.00
+[22:14:09] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=78.4°, current=-101.3°, player=(450,794), corner_timer=0.00
+[22:14:09] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-163.2°, current=168.8°, player=(450,794), corner_timer=0.00
+[22:14:09] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 2/2 -> 1/2
+[22:14:09] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:09] [INFO] [ImpactEffects] spawn_blood_effect called at (684.4684, 753.8406), dir=(1, 0), lethal=false
+[22:14:09] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:09] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:09] [INFO] [ImpactEffects] Blood effect spawned at (684.4684, 753.8406) (scale=1)
+[22:14:09] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=174.2°, current=180.0°, player=(445,778), corner_timer=0.00
+[22:14:09] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(445.079, 780.8822), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:09] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:09] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=57.6°, player=(442,773), corner_timer=-0.01
+[22:14:09] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:09] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=51.7°, player=(442,773), corner_timer=-0.01
+[22:14:09] [ENEMY] [Enemy10] PATROL corner check: angle 14.5°
+[22:14:09] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.3°, player=(442,772), corner_timer=0.30
+[22:14:09] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.5°, current=53.5°, player=(442,772), corner_timer=0.30
+[22:14:09] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 1/2 -> 0/2
+[22:14:09] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:09] [INFO] [ImpactEffects] spawn_blood_effect called at (684.4684, 753.8406), dir=(1, 0), lethal=true
+[22:14:09] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:09] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:09] [INFO] [ImpactEffects] Blood effect spawned at (684.4684, 753.8406) (scale=1.5)
+[22:14:09] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[22:14:09] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:14:09] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 9)
+[22:14:09] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[22:14:09] [ENEMY] [Enemy3] Death animation started with hit direction: (1, 0)
+[22:14:09] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(442.7556, 775.8469), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:09] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:09] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(439.3492, 779.3307), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:09] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(442.75565, 775.8469), shooter_id=117658618907, bullet_pos=(934.3706, 768.7024)
+[22:14:10] [INFO] [Bullet] Using shooter_position, distance=491,66687
+[22:14:10] [INFO] [Bullet] Distance to wall: 491,66687 (33,4785% of viewport)
+[22:14:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:10] [INFO] [Bullet] Starting wall penetration at (934.3706, 768.7024)
+[22:14:10] [INFO] [Bullet] Raycast backward hit penetrating body at distance 36,703766
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (788.8572, 756.584) (added to group)
+[22:14:10] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:10] [INFO] [Bullet] Exiting penetration at (972.6999, 768.1454) after traveling 33,333336 pixels through wall
+[22:14:10] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(433.8698, 776.5337), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (742.23, 772.2142) (added to group)
+[22:14:10] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.3°, player=(430,765), corner_timer=-0.01
+[22:14:10] [ENEMY] [Enemy10] PATROL corner check: angle 7.3°
+[22:14:10] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.3°, current=16.4°, player=(428,769), corner_timer=0.30
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (759.293, 764.5383) (added to group)
+[22:14:10] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[22:14:10] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[22:14:10] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:14:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(439.34924, 779.33075), shooter_id=117658618907, bullet_pos=(930.9058, 768.93896)
+[22:14:10] [INFO] [Bullet] Using shooter_position, distance=491,6664
+[22:14:10] [INFO] [Bullet] Distance to wall: 491,6664 (33,47847% of viewport)
+[22:14:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:10] [INFO] [Bullet] Starting wall penetration at (930.9058, 768.93896)
+[22:14:10] [INFO] [Bullet] Raycast backward hit penetrating body at distance 33,238018
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (778.0164, 804.3237) (added to group)
+[22:14:10] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:10] [INFO] [Bullet] Exiting penetration at (969.2306, 768.1288) after traveling 33,333336 pixels through wall
+[22:14:10] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(415.3044, 806.4648), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (830.2347, 791.1636) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (766.9305, 767.7061) (added to group)
+[22:14:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(415.30438, 806.4648), shooter_id=117658618907, bullet_pos=(506.45932, 796.7923)
+[22:14:10] [INFO] [Bullet] Using shooter_position, distance=91,66667
+[22:14:10] [INFO] [Bullet] Distance to wall: 91,66667 (6,2417526% of viewport)
+[22:14:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (809.7709, 825.9152) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (797.2935, 801.4912) (added to group)
+[22:14:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(433.86978, 776.5337), shooter_id=117658618907, bullet_pos=(925.2445, 759.59875)
+[22:14:10] [INFO] [Bullet] Using shooter_position, distance=491,66647
+[22:14:10] [INFO] [Bullet] Distance to wall: 491,66647 (33,478474% of viewport)
+[22:14:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:10] [INFO] [Bullet] Starting wall penetration at (925.2445, 759.59875)
+[22:14:10] [INFO] [Player] Spawning blood effect at (397.17828, 820.6184), dir=(1, 0), lethal=False (C#)
+[22:14:10] [INFO] [ImpactEffects] spawn_blood_effect called at (397.1783, 820.6184), dir=(1, 0), lethal=false
+[22:14:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:10] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:10] [INFO] [ImpactEffects] Blood effect spawned at (397.1783, 820.6184) (scale=1)
+[22:14:10] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[22:14:10] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[22:14:10] [INFO] [Bullet] Raycast backward hit penetrating body at distance 27,571415
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (834.1505, 762.9745) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (786.0054, 798.2513) (added to group)
+[22:14:10] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:10] [INFO] [Bullet] Exiting penetration at (963.55505, 758.2784) after traveling 33,333336 pixels through wall
+[22:14:10] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (818.868, 828.9052) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (775.7381, 801.8506) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (773.9894, 775.897) (added to group)
+[22:14:10] [ENEMY] [Enemy3] Ragdoll activated
+[22:14:10] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (778.9697, 791.4256) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (797.5562, 802.0737) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (877.7956, 809.9295) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (787.4796, 822.8298) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (807.8132, 802.0428) (added to group)
+[22:14:10] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=7.2°, player=(385,852), corner_timer=-0.01
+[22:14:10] [ENEMY] [Enemy10] PATROL corner check: angle 3.8°
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (873.6287, 775.752) (added to group)
+[22:14:10] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.8°, current=9.4°, player=(385,855), corner_timer=0.30
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (842.7811, 802.7963) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (463.4525, 862.04) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (493.3474, 905.6656) (added to group)
+[22:14:10] [INFO] [BloodDecal] Blood puddle created at (488.0624, 867.6736) (added to group)
+[22:14:10] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.7°, player=(401,875), corner_timer=-0.01
+[22:14:10] [ENEMY] [Enemy10] PATROL corner check: angle 2.0°
+[22:14:10] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=2.0°, current=6.0°, player=(401,875), corner_timer=0.30
+[22:14:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(401.0691, 881.7345), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=3, self=0, below_threshold=4
+[22:14:11] [INFO] [BloodDecal] Blood puddle created at (487.2656, 880.3951) (added to group)
+[22:14:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(401.06912, 881.7345), shooter_id=117658618907, bullet_pos=(515.9977, 832.57733)
+[22:14:11] [INFO] [Bullet] Using shooter_position, distance=125
+[22:14:11] [INFO] [Bullet] Distance to wall: 125 (8,51148% of viewport)
+[22:14:11] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:11] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=2.0°, player=(401,875), corner_timer=-0.01
+[22:14:11] [ENEMY] [Enemy10] PATROL corner check: angle 1.1°
+[22:14:11] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.1°, current=4.2°, player=(402,875), corner_timer=0.30
+[22:14:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(401.06912, 881.7345), shooter_id=117658618907, bullet_pos=(191.44131, 715.58093)
+[22:14:11] [INFO] [Bullet] Using shooter_position, distance=267,48987
+[22:14:11] [INFO] [Bullet] Distance to wall: 267,48987 (18,213877% of viewport)
+[22:14:11] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:11] [INFO] [Bullet] Starting wall penetration at (191.44131, 715.58093)
+[22:14:11] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:14:11] [INFO] [Bullet] Exiting penetration at (160.0832, 704.2769) after traveling 28,333332 pixels through wall
+[22:14:11] [INFO] [Bullet] Damage multiplier after penetration: 0,45
+[22:14:11] [ENEMY] [Enemy3] Death animation completed
+[22:14:11] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.0°, player=(425,876), corner_timer=-0.01
+[22:14:11] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:11] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.6°, current=3.3°, player=(425,876), corner_timer=0.30
+[22:14:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.9°, current=-129.0°, player=(426,878), corner_timer=-0.01
+[22:14:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.9°
+[22:14:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.9°, current=-131.3°, player=(426,878), corner_timer=0.30
+[22:14:12] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:12] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:12] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:12] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:12] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:12] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:12] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:12] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:12] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:12] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:12] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:12] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:12] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:12] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:12] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:12] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:12] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:12] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:12] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:12] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:12] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:12] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:12] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:12] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:12] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:12] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[22:14:12] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:12] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:12] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:12] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:12] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 10)
+[22:14:12] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[22:14:12] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 11)
+[22:14:12] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[22:14:12] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 12)
+[22:14:12] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[22:14:12] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 13)
+[22:14:12] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[22:14:12] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 14)
+[22:14:12] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:14:12] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 15)
+[22:14:12] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[22:14:12] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 16)
+[22:14:12] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[22:14:12] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 17)
+[22:14:12] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[22:14:12] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 18)
+[22:14:12] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[22:14:12] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:12] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 19)
+[22:14:12] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:12] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:14:12] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:12] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:12] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:12] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:12] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:12] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:12] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:12] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=157.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:12] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:12] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:12] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:12] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:12] [INFO] [LastChance] Found player: Player
+[22:14:12] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:12] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:12] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:12] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:12] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:14:12] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:14:13] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:13] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:14:13] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,819), corner_timer=0.30
+[22:14:13] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,819), corner_timer=0.30
+[22:14:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(459.8001, 788.0726), source=PLAYER (AssaultRifle), range=1469, listeners=19
+[22:14:13] [INFO] [SoundPropagation] Cleaned up 9 invalid listeners
+[22:14:13] [ENEMY] [Enemy1] Heard gunshot at (459.8001, 788.0726), source_type=0, intensity=0.01, distance=466
+[22:14:13] [ENEMY] [Enemy2] Heard gunshot at (459.8001, 788.0726), source_type=0, intensity=0.04, distance=245
+[22:14:13] [ENEMY] [Enemy3] Heard gunshot at (459.8001, 788.0726), source_type=0, intensity=0.04, distance=243
+[22:14:13] [ENEMY] [Enemy4] Heard gunshot at (459.8001, 788.0726), source_type=0, intensity=0.02, distance=358
+[22:14:13] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:13] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=69.7°, current=-33.8°, player=(459,782), corner_timer=0.00
+[22:14:13] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=75.6°, current=168.8°, player=(459,782), corner_timer=0.00
+[22:14:13] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=172.4°, current=-78.7°, player=(459,782), corner_timer=0.00
+[22:14:13] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-160.9°, current=-101.3°, player=(459,782), corner_timer=0.00
+[22:14:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(501.8517, 789.9996), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:13] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:13] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(505,779), corner_timer=-0.02
+[22:14:13] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:13] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(505,779), corner_timer=-0.02
+[22:14:13] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:14:13] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(511,778), corner_timer=0.30
+[22:14:13] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(511,778), corner_timer=0.30
+[22:14:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(524.1747, 786.7938), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:13] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=2, self=0, below_threshold=4
+[22:14:13] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[22:14:14] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=23.2°, current=109.1°, player=(523,780), corner_timer=0.00
+[22:14:14] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(529.5449, 787.0189), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:14] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=2, self=0, below_threshold=4
+[22:14:14] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(524.17474, 786.79376), shooter_id=222650436160, bullet_pos=(924.16907, 784.6615)
+[22:14:14] [INFO] [Bullet] Using shooter_position, distance=400
+[22:14:14] [INFO] [Bullet] Distance to wall: 400 (27,236736% of viewport)
+[22:14:14] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:14] [INFO] [Bullet] Starting wall penetration at (924.16907, 784.6615)
+[22:14:14] [INFO] [Bullet] Raycast backward hit penetrating body at distance 34,83558
+[22:14:14] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:14] [INFO] [Bullet] Exiting penetration at (970.8351, 784.4127) after traveling 41,66667 pixels through wall
+[22:14:14] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:14] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 4/4 -> 3/4
+[22:14:14] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:14] [INFO] [ImpactEffects] spawn_blood_effect called at (730.8831, 763.2358), dir=(1, 0), lethal=false
+[22:14:14] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:14] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:14] [INFO] [ImpactEffects] Blood effect spawned at (730.8831, 763.2358) (scale=1)
+[22:14:14] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P1:visible, state=RETREATING, target=174.8°, current=180.0°, player=(530,781), corner_timer=0.00
+[22:14:14] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(533.0574, 788.5957), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:14] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=2, self=0, below_threshold=4
+[22:14:14] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[22:14:14] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[22:14:14] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:14:14] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.1°, player=(530,780), corner_timer=-0.01
+[22:14:14] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:14:14] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:14] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:14] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:14] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:14] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:14] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:14] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:14] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:14] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:14] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:14] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:14] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:14] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:14] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:14] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:14] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:14] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:14] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:14] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:14] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:14] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:14] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:14] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:14] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:14] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:14] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:14] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[22:14:14] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:14] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:14] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:14] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:14] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[22:14:14] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[22:14:14] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[22:14:14] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[22:14:14] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[22:14:14] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:14:14] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[22:14:14] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[22:14:14] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[22:14:14] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 3, behavior: GUARD
+[22:14:14] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[22:14:14] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:14:14] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[22:14:14] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[22:14:14] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[22:14:14] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[22:14:14] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[22:14:14] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[22:14:14] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:14] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[22:14:14] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:14] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:14:14] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:14] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:14] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=45.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:14] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:14] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:14] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:14] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:14] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:14] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:14] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:14] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:14] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:14] [INFO] [LastChance] Found player: Player
+[22:14:14] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:14] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:14] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:14] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:14] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:14:14] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:14:14] [INFO] [BloodDecal] Blood puddle created at (804.4956, 808.4557) (added to group)
+[22:14:14] [INFO] [BloodDecal] Blood puddle created at (819.3307, 755.0258) (added to group)
+[22:14:14] [INFO] [BloodDecal] Blood puddle created at (802.5116, 785.8257) (added to group)
+[22:14:14] [INFO] [BloodDecal] Blood puddle created at (837.6591, 805.6346) (added to group)
+[22:14:14] [INFO] [BloodDecal] Blood puddle created at (783.1108, 788.834) (added to group)
+[22:14:14] [INFO] [BloodDecal] Blood puddle created at (843.6287, 745.9281) (added to group)
+[22:14:14] [INFO] [BloodDecal] Blood puddle created at (834.724, 872.1313) (added to group)
+[22:14:14] [INFO] [BloodDecal] Blood puddle created at (881.564, 792.4709) (added to group)
+[22:14:14] [INFO] [BloodDecal] Blood puddle created at (847.92, 893.8763) (added to group)
+[22:14:15] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:15] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:14:15] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,798), corner_timer=0.30
+[22:14:15] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,798), corner_timer=0.30
+[22:14:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450, 799.8333), source=PLAYER (AssaultRifle), range=1469, listeners=20
+[22:14:15] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[22:14:15] [ENEMY] [Enemy1] Heard gunshot at (450, 799.8333), source_type=0, intensity=0.01, distance=474
+[22:14:15] [ENEMY] [Enemy2] Heard gunshot at (450, 799.8333), source_type=0, intensity=0.04, distance=255
+[22:14:15] [ENEMY] [Enemy3] Heard gunshot at (450, 799.8333), source_type=0, intensity=0.04, distance=255
+[22:14:15] [ENEMY] [Enemy4] Heard gunshot at (450, 799.8333), source_type=0, intensity=0.02, distance=364
+[22:14:15] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:15] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=71.3°, current=33.8°, player=(450,793), corner_timer=0.00
+[22:14:15] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=78.4°, current=45.0°, player=(450,793), corner_timer=0.00
+[22:14:15] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=170.1°, current=-123.8°, player=(450,793), corner_timer=0.00
+[22:14:15] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-163.1°, current=-67.5°, player=(450,793), corner_timer=0.00
+[22:14:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(481.2152, 801.3084), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:15] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:15] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(481.21518, 801.3084), shooter_id=273888053625, bullet_pos=(506.07587, 798.6729)
+[22:14:15] [INFO] [Bullet] Using shooter_position, distance=24,999992
+[22:14:15] [INFO] [Bullet] Distance to wall: 24,999992 (1,7022954% of viewport)
+[22:14:15] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:14:15] [INFO] [Bullet] Starting wall penetration at (506.07587, 798.6729)
+[22:14:15] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:14:15] [INFO] [Bullet] Exiting penetration at (552.4825, 793.7533) after traveling 41,666668 pixels through wall
+[22:14:15] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:16] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(450, 799.83325), shooter_id=273888053625, bullet_pos=(931.40704, 756.72266)
+[22:14:16] [INFO] [Bullet] Using shooter_position, distance=483,33347
+[22:14:16] [INFO] [Bullet] Distance to wall: 483,33347 (32,911064% of viewport)
+[22:14:16] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:16] [INFO] [Bullet] Starting wall penetration at (931.40704, 756.72266)
+[22:14:16] [INFO] [Bullet] Raycast backward hit penetrating body at distance 42,05532
+[22:14:16] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:16] [INFO] [Bullet] Exiting penetration at (977.8877, 752.56024) after traveling 41,666668 pixels through wall
+[22:14:16] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:16] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(472.7895, 829.3074), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:16] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:16] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(472.78952, 829.3074), shooter_id=273888053625, bullet_pos=(515.96, 822.74347)
+[22:14:16] [INFO] [Bullet] Using shooter_position, distance=43,66666
+[22:14:16] [INFO] [Bullet] Distance to wall: 43,66666 (2,9733431% of viewport)
+[22:14:16] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:14:16] [INFO] [Bullet] Starting wall penetration at (515.96, 822.74347)
+[22:14:16] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[22:14:16] [INFO] [Bullet] Raycast backward hit penetrating body at distance 38,53428
+[22:14:16] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:16] [INFO] [Bullet] Exiting penetration at (562.09644, 815.72864) after traveling 41,66667 pixels through wall
+[22:14:16] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:16] [ENEMY] [Enemy3] State: RETREATING -> IN_COVER
+[22:14:16] [ENEMY] [Enemy3] State: IN_COVER -> SUPPRESSED
+[22:14:16] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(464,845), corner_timer=-0.02
+[22:14:16] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:16] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(464,845), corner_timer=-0.02
+[22:14:16] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:14:16] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(463,851), corner_timer=0.30
+[22:14:16] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(463,851), corner_timer=0.30
+[22:14:16] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(461.839, 867.1716), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:16] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=4
+[22:14:16] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(461.83896, 867.17163), shooter_id=273888053625, bullet_pos=(527.3282, 854.69745)
+[22:14:16] [INFO] [Bullet] Using shooter_position, distance=66,666664
+[22:14:16] [INFO] [Bullet] Distance to wall: 66,666664 (4,539456% of viewport)
+[22:14:16] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:14:16] [INFO] [Bullet] Starting wall penetration at (527.3282, 854.69745)
+[22:14:16] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:14:16] [INFO] [Bullet] Exiting penetration at (573.17065, 845.9655) after traveling 41,66667 pixels through wall
+[22:14:16] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:16] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(449.5525, 886.0898), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:16] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=4
+[22:14:16] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(449.55252, 886.0898), shooter_id=273888053625, bullet_pos=(515.01776, 873.4905)
+[22:14:16] [INFO] [Bullet] Using shooter_position, distance=66,66663
+[22:14:16] [INFO] [Bullet] Distance to wall: 66,66663 (4,539454% of viewport)
+[22:14:16] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:14:16] [INFO] [Bullet] Starting wall penetration at (515.01776, 873.4905)
+[22:14:16] [INFO] [Bullet] Raycast backward hit penetrating body at distance 37,519585
+[22:14:16] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:16] [INFO] [Bullet] Exiting penetration at (560.84344, 864.67096) after traveling 41,66667 pixels through wall
+[22:14:16] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:16] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[22:14:16] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[22:14:16] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:14:16] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(440,888), corner_timer=-0.02
+[22:14:16] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:14:16] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:16] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:16] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:16] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:16] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:16] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:16] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:16] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:16] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:16] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:16] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:16] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:16] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:16] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:16] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:16] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:16] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:16] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:16] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:16] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:16] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:16] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:16] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:16] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:16] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:16] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:16] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:16] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[22:14:16] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:16] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:16] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:16] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:16] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[22:14:16] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[22:14:16] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[22:14:16] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:14:16] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[22:14:16] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:14:16] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[22:14:16] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[22:14:16] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[22:14:16] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[22:14:16] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[22:14:16] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[22:14:16] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[22:14:16] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[22:14:16] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[22:14:16] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[22:14:16] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[22:14:16] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[22:14:16] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:16] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[22:14:16] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:16] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[22:14:16] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:16] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:16] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=45.0°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:16] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:16] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:16] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:16] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:16] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:16] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:16] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:16] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:16] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:16] [INFO] [LastChance] Found player: Player
+[22:14:16] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:16] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:16] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:16] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:16] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:14:16] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:14:18] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:18] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:14:18] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,781), corner_timer=0.30
+[22:14:18] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,781), corner_timer=0.30
+[22:14:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450, 777.8333), source=PLAYER (AssaultRifle), range=1469, listeners=20
+[22:14:18] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[22:14:18] [ENEMY] [Enemy1] Heard gunshot at (450, 777.8333), source_type=0, intensity=0.01, distance=453
+[22:14:18] [ENEMY] [Enemy2] Heard gunshot at (450, 777.8333), source_type=0, intensity=0.05, distance=233
+[22:14:18] [ENEMY] [Enemy3] Heard gunshot at (450, 777.8333), source_type=0, intensity=0.04, distance=252
+[22:14:18] [ENEMY] [Enemy4] Heard gunshot at (450, 777.8333), source_type=0, intensity=0.02, distance=371
+[22:14:18] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:18] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=70.4°, current=-33.8°, player=(450,771), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=77.3°, current=45.0°, player=(450,771), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=175.0°, current=-33.8°, player=(450,771), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-159.9°, current=-101.3°, player=(450,771), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=175.9°, current=138.4°, player=(450,768), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 3/3 -> 2/3
+[22:14:18] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:18] [INFO] [ImpactEffects] spawn_blood_effect called at (689.3738, 750.928), dir=(1, 0), lethal=false
+[22:14:18] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:18] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:18] [INFO] [ImpactEffects] Blood effect spawned at (689.3738, 750.928) (scale=1)
+[22:14:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450.7623, 754.0291), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:18] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(448.7224, 737.2725), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:18] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:18] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[22:14:18] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=57.0°, player=(446,732), corner_timer=-0.01
+[22:14:18] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:18] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=52.4°, player=(446,732), corner_timer=-0.01
+[22:14:18] [ENEMY] [Enemy10] PATROL corner check: angle 14.6°
+[22:14:18] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=54.7°, player=(448,731), corner_timer=0.30
+[22:14:18] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.6°, current=54.2°, player=(448,731), corner_timer=0.30
+[22:14:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(450.76227, 754.0291), shooter_id=338664885534, bullet_pos=(938.8131, 694.5079)
+[22:14:18] [INFO] [Bullet] Using shooter_position, distance=491,66696
+[22:14:18] [INFO] [Bullet] Distance to wall: 491,66696 (33,478508% of viewport)
+[22:14:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:18] [INFO] [Bullet] Starting wall penetration at (938.8131, 694.5079)
+[22:14:18] [INFO] [Bullet] Raycast backward hit penetrating body at distance 41,16728
+[22:14:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:18] [INFO] [Bullet] Exiting penetration at (976.8645, 689.86725) after traveling 33,333332 pixels through wall
+[22:14:18] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(450.76227, 754.0291), shooter_id=338664885534, bullet_pos=(976.8645, 689.86725)
+[22:14:18] [INFO] [Bullet] Using shooter_position, distance=530,0003
+[22:14:18] [INFO] [Bullet] Distance to wall: 530,0003 (36,088696% of viewport)
+[22:14:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:18] [INFO] [Bullet] Starting wall penetration at (976.8645, 689.86725)
+[22:14:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(683.4912, 757.1099), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:14:18] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:14:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(455.6934, 734.981), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:18] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:18] [INFO] [Bullet] Raycast backward hit penetrating body at distance 22,909212
+[22:14:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:18] [INFO] [Bullet] Exiting penetration at (1014.9159, 685.2266) after traveling 33,333332 pixels through wall
+[22:14:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(676.138, 764.8372), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:14:18] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:14:18] [INFO] [BloodDecal] Blood puddle created at (747.3895, 760.3791) (added to group)
+[22:14:18] [INFO] [BloodDecal] Blood puddle created at (754.8868, 803.2966) (added to group)
+[22:14:18] [INFO] [BloodDecal] Blood puddle created at (768.4496, 749.5922) (added to group)
+[22:14:18] [INFO] [LastChance] Threat detected: Bullet
+[22:14:18] [INFO] [LastChance] Not in hard mode - effect disabled
+[22:14:18] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(463.5597, 734.0598), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:18] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:18] [INFO] [BloodDecal] Blood puddle created at (784.087, 763.7475) (added to group)
+[22:14:18] [INFO] [BloodDecal] Blood puddle created at (775.8036, 775.7498) (added to group)
+[22:14:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(448.72244, 737.27246), shooter_id=338664885534, bullet_pos=(1039.9749, 715.12396)
+[22:14:18] [INFO] [Bullet] Using shooter_position, distance=591,6671
+[22:14:18] [INFO] [Bullet] Distance to wall: 591,6671 (40,287704% of viewport)
+[22:14:18] [INFO] [Bullet] Distance-based penetration chance: 99,664345%
+[22:14:18] [INFO] [Bullet] Starting wall penetration at (1039.9749, 715.12396)
+[22:14:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(668.7849, 772.5646), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:14:18] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:14:18] [INFO] [Bullet] Raycast forward hit penetrating body at distance 45,118416
+[22:14:18] [INFO] [LastChance] Threat detected: @Area2D@1465
+[22:14:18] [INFO] [LastChance] Not in hard mode - effect disabled
+[22:14:18] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:18] [INFO] [Bullet] Max penetration distance exceeded: 66,66667 >= 48
+[22:14:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:18] [INFO] [Bullet] Exiting penetration at (1111.5912, 712.44116) after traveling 66,66667 pixels through wall
+[22:14:18] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(455.6934, 734.98096), shooter_id=338664885534, bullet_pos=(914.01385, 738.4344)
+[22:14:18] [INFO] [Bullet] Using shooter_position, distance=458,33347
+[22:14:18] [INFO] [Bullet] Distance to wall: 458,33347 (31,208769% of viewport)
+[22:14:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:18] [INFO] [Bullet] Starting wall penetration at (914.01385, 738.4344)
+[22:14:18] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[22:14:18] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[22:14:18] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:14:18] [INFO] [Bullet] Raycast backward hit penetrating body at distance 16,346594
+[22:14:18] [INFO] [BloodDecal] Blood puddle created at (803.5704, 791.7163) (added to group)
+[22:14:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:18] [INFO] [Bullet] Exiting penetration at (952.3461, 738.7232) after traveling 33,333332 pixels through wall
+[22:14:18] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(661.4317, 780.2919), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:14:18] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:14:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(601.0574, 765.9627), shooter_id=335712095144, bullet_pos=(444.657, 708.3718)
+[22:14:18] [INFO] [Bullet] Using shooter_position, distance=166.666702270508
+[22:14:18] [INFO] [Bullet] Distance to wall: 166.666702270508 (11.3486422306402% of viewport)
+[22:14:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:18] [INFO] [LastChance] Threat detected: @Area2D@1478
+[22:14:18] [INFO] [LastChance] Not in hard mode - effect disabled
+[22:14:18] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:18] [INFO] [Player] Spawning blood effect at (572.3033, 789.4314), dir=(1, 0), lethal=False (C#)
+[22:14:18] [INFO] [ImpactEffects] spawn_blood_effect called at (572.3033, 789.4314), dir=(1, 0), lethal=false
+[22:14:18] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:18] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:18] [INFO] [ImpactEffects] Blood effect spawned at (572.3033, 789.4314) (scale=1)
+[22:14:18] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[22:14:18] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[22:14:18] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=54.3°, current=57.8°, player=(572,789), corner_timer=0.00
+[22:14:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(615.4431, 756.871), shooter_id=335712095144, bullet_pos=(53.95337, 833.2942)
+[22:14:18] [INFO] [Bullet] Using shooter_position, distance=566.666809082031
+[22:14:18] [INFO] [Bullet] Distance to wall: 566.666809082031 (38.5853850387754% of viewport)
+[22:14:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:18] [INFO] [Bullet] Starting wall penetration at (53.95337, 833.2942)
+[22:14:18] [INFO] [Bullet] Raycast backward hit penetrating body at distance 16.177547454834
+[22:14:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:18] [INFO] [Bullet] Exiting penetration at (15.97025, 838.464) after traveling 33.3333358764648 pixels through wall
+[22:14:18] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:14:18] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P4:velocity, state=RETREATING, target=133.6°, current=167.5°, player=(639,789), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.4°, player=(639,789), corner_timer=-0.01
+[22:14:18] [ENEMY] [Enemy10] PATROL corner check: angle 7.4°
+[22:14:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(463.55972, 734.05975), shooter_id=338664885534, bullet_pos=(921.88776, 736.2166)
+[22:14:18] [INFO] [Bullet] Using shooter_position, distance=458,33313
+[22:14:18] [INFO] [Bullet] Distance to wall: 458,33313 (31,208748% of viewport)
+[22:14:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:18] [INFO] [Bullet] Starting wall penetration at (921.88776, 736.2166)
+[22:14:18] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.4°, current=16.5°, player=(655,789), corner_timer=0.30
+[22:14:18] [INFO] [Bullet] Raycast backward hit penetrating body at distance 24,220911
+[22:14:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(608.1705, 761.5173), shooter_id=335712095144, bullet_pos=(41.95505, 738.9081)
+[22:14:18] [INFO] [Bullet] Using shooter_position, distance=566.666625976563
+[22:14:18] [INFO] [Bullet] Distance to wall: 566.666625976563 (38.5853725707874% of viewport)
+[22:14:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:18] [INFO] [Bullet] Starting wall penetration at (41.95505, 738.9081)
+[22:14:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:18] [INFO] [Bullet] Exiting penetration at (960.22064, 736.39703) after traveling 33,333332 pixels through wall
+[22:14:18] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:18] [INFO] [Bullet] Raycast backward hit penetrating body at distance 28.3703498840332
+[22:14:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:18] [INFO] [Bullet] Exiting penetration at (3.652245, 737.3786) after traveling 33.3333320617676 pixels through wall
+[22:14:18] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:14:18] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:18] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:18] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:18] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:18] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:18] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:18] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:18] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:18] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:18] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:18] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:18] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:18] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:18] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:18] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:18] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:18] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:18] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:18] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:18] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:18] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:18] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:18] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:18] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:18] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:18] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:18] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:18] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[22:14:18] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:18] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:18] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:18] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:18] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[22:14:18] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[22:14:18] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[22:14:18] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:14:18] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[22:14:18] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:14:18] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[22:14:18] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[22:14:18] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[22:14:18] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[22:14:18] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[22:14:18] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[22:14:18] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[22:14:18] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[22:14:18] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[22:14:18] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:14:18] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[22:14:18] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:14:18] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:18] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[22:14:18] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:18] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[22:14:18] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:18] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:18] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:18] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:18] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:18] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:18] [INFO] [LastChance] Found player: Player
+[22:14:18] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:18] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:18] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:18] [INFO] [BloodDecal] Blood puddle created at (851.4213, 744.6848) (added to group)
+[22:14:18] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:18] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:14:18] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:14:18] [INFO] [BloodDecal] Blood puddle created at (836.8422, 785.89) (added to group)
+[22:14:19] [INFO] [BloodDecal] Blood puddle created at (879.9293, 855.3307) (added to group)
+[22:14:19] [INFO] [BloodDecal] Blood puddle created at (895.6687, 917.8694) (added to group)
+[22:14:19] [INFO] [BloodDecal] Blood puddle created at (626.1401, 840.58) (added to group)
+[22:14:19] [INFO] [BloodDecal] Blood puddle created at (669.4484, 830.7914) (added to group)
+[22:14:19] [INFO] [BloodDecal] Blood puddle created at (660.2013, 799.223) (added to group)
+[22:14:19] [INFO] [BloodDecal] Blood puddle created at (650.0814, 858.5147) (added to group)
+[22:14:19] [INFO] [BloodDecal] Blood puddle created at (665.8568, 889.9913) (added to group)
+[22:14:19] [INFO] [BloodDecal] Blood puddle created at (670.4896, 863.1295) (added to group)
+[22:14:20] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:20] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:14:20] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,819), corner_timer=0.30
+[22:14:20] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,819), corner_timer=0.30
+[22:14:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(436.768, 782.7252), source=PLAYER (AssaultRifle), range=1469, listeners=20
+[22:14:20] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[22:14:20] [ENEMY] [Enemy1] Heard gunshot at (436.768, 782.7252), source_type=0, intensity=0.01, distance=454
+[22:14:20] [ENEMY] [Enemy2] Heard gunshot at (436.768, 782.7252), source_type=0, intensity=0.05, distance=236
+[22:14:20] [ENEMY] [Enemy3] Heard gunshot at (436.768, 782.7252), source_type=0, intensity=0.04, distance=265
+[22:14:20] [ENEMY] [Enemy4] Heard gunshot at (436.768, 782.7252), source_type=0, intensity=0.02, distance=382
+[22:14:20] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:20] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=72.2°, current=-33.8°, player=(436,776), corner_timer=0.00
+[22:14:20] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=80.8°, current=-67.5°, player=(436,776), corner_timer=0.00
+[22:14:20] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=174.2°, current=11.3°, player=(436,776), corner_timer=0.00
+[22:14:20] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-161.3°, current=168.8°, player=(436,776), corner_timer=0.00
+[22:14:20] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=175.7°, current=-171.7°, player=(432,770), corner_timer=0.00
+[22:14:20] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 3/3 -> 2/3
+[22:14:20] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:20] [INFO] [ImpactEffects] spawn_blood_effect called at (673.4504, 752.4803), dir=(1, 0), lethal=false
+[22:14:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:20] [INFO] [ImpactEffects] Blood effect spawned at (673.4504, 752.4803) (scale=1)
+[22:14:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(428.6457, 793.3242), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:20] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=56.5°, player=(422,790), corner_timer=-0.00
+[22:14:20] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:20] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=53.0°, player=(422,790), corner_timer=-0.00
+[22:14:20] [ENEMY] [Enemy10] PATROL corner check: angle 14.7°
+[22:14:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=54.2°, player=(421,791), corner_timer=0.30
+[22:14:20] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.7°, current=54.9°, player=(421,791), corner_timer=0.30
+[22:14:20] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 2/3 -> 1/3
+[22:14:20] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:20] [INFO] [ImpactEffects] spawn_blood_effect called at (673.4504, 752.4803), dir=(1, 0), lethal=false
+[22:14:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:20] [INFO] [ImpactEffects] Blood effect spawned at (673.4504, 752.4803) (scale=1)
+[22:14:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(421.0236, 800.5812), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:14:20] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:20] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[22:14:21] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 1/3 -> 0/3
+[22:14:21] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:21] [INFO] [ImpactEffects] spawn_blood_effect called at (666.7787, 757.8006), dir=(1, 0), lethal=true
+[22:14:21] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:21] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:21] [INFO] [ImpactEffects] Blood effect spawned at (666.7787, 757.8006) (scale=1.5)
+[22:14:21] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[22:14:21] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:14:21] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 9)
+[22:14:21] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[22:14:21] [ENEMY] [Enemy3] Death animation started with hit direction: (1, 0)
+[22:14:21] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(416.1509, 798.9846), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:21] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (712.7689, 766.8164) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (801.7527, 798.8033) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (781.742, 767.9954) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (740.838, 756.4022) (added to group)
+[22:14:21] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.5°, player=(414,791), corner_timer=-0.01
+[22:14:21] [ENEMY] [Enemy10] PATROL corner check: angle 7.4°
+[22:14:21] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.4°, current=16.6°, player=(414,791), corner_timer=0.30
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (781.0068, 753.5037) (added to group)
+[22:14:21] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[22:14:21] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[22:14:21] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (732.6569, 752.1456) (added to group)
+[22:14:21] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(416.15094, 798.98456), shooter_id=402216978116, bullet_pos=(939.9865, 764.03735)
+[22:14:21] [INFO] [Bullet] Using shooter_position, distance=525
+[22:14:21] [INFO] [Bullet] Distance to wall: 525 (35,748215% of viewport)
+[22:14:21] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:21] [INFO] [Bullet] Starting wall penetration at (939.9865, 764.03735)
+[22:14:21] [INFO] [Bullet] Raycast backward hit penetrating body at distance 42,32869
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (779.4124, 730.9332) (added to group)
+[22:14:21] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:21] [INFO] [Bullet] Exiting penetration at (978.2348, 761.48566) after traveling 33,333336 pixels through wall
+[22:14:21] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (821.3452, 829.7771) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (711.7493, 783.9157) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (714.5762, 768.9972) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (709.3787, 775.1859) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (849.7881, 798.1478) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (747.8016, 804.1642) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (735.3263, 771.5637) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (728.2663, 790.6035) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (822.5018, 849.9944) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (862.3098, 867.5513) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (840.8607, 791.4488) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (830.4361, 808.1172) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (759.2542, 774.1967) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (730.7175, 772.6077) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (883.1046, 803.113) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (870.7243, 872.6888) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (877.0042, 839.6267) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (746.439, 785.4253) (added to group)
+[22:14:21] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=7.3°, player=(416,735), corner_timer=-0.01
+[22:14:21] [ENEMY] [Enemy10] PATROL corner check: angle 3.8°
+[22:14:21] [ENEMY] [Enemy3] Ragdoll activated
+[22:14:21] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:14:21] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.8°, current=9.5°, player=(417,732), corner_timer=0.30
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (765.0024, 796.8994) (added to group)
+[22:14:21] [INFO] [BloodDecal] Blood puddle created at (867.3607, 853.0492) (added to group)
+[22:14:22] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.8°, player=(488,728), corner_timer=-0.01
+[22:14:22] [ENEMY] [Enemy10] PATROL corner check: angle 2.0°
+[22:14:22] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=2.0°, current=6.0°, player=(492,728), corner_timer=0.30
+[22:14:22] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=57.6°, current=58.6°, player=(512,726), corner_timer=0.00
+[22:14:22] [ENEMY] [Enemy2] State: PURSUING -> COMBAT
+[22:14:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(543.5665, 717.9568), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:22] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:22] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 4/4 -> 3/4
+[22:14:22] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:22] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(1, 0), lethal=false
+[22:14:22] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:22] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:22] [INFO] [ImpactEffects] Wall found for blood splatter at (500, 550) (dist=100 px)
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (499, 550) (added to group)
+[22:14:22] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:14:22] [ENEMY] [Enemy2] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=42.6°, current=180.0°, player=(571,707), corner_timer=0.00
+[22:14:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(576.3503, 710.3416), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:22] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:22] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=2.0°, player=(586,709), corner_timer=-0.01
+[22:14:22] [ENEMY] [Enemy10] PATROL corner check: angle 1.1°
+[22:14:22] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.1°, current=4.3°, player=(588,708), corner_timer=0.30
+[22:14:22] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 3/4 -> 2/4
+[22:14:22] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:22] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(1, 0), lethal=false
+[22:14:22] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:22] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:22] [INFO] [ImpactEffects] Wall found for blood splatter at (500, 550) (dist=100 px)
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (499, 550) (added to group)
+[22:14:22] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:14:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(598.0627, 708.4893), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:22] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:22] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[22:14:22] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=-41.5°, current=173.5°, player=(591,718), corner_timer=0.00
+[22:14:22] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 2/4 -> 1/4
+[22:14:22] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:22] [INFO] [ImpactEffects] spawn_blood_effect called at (406.3905, 544.345), dir=(1, 0), lethal=false
+[22:14:22] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:22] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:22] [INFO] [ImpactEffects] Wall found for blood splatter at (500, 544.345) (dist=93 px)
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (499, 544.345) (added to group)
+[22:14:22] [INFO] [ImpactEffects] Blood effect spawned at (406.3905, 544.345) (scale=1)
+[22:14:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(594.3759, 732.1948), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[22:14:22] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (465.8736, 565.0176) (added to group)
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (488.8804, 542.0331) (added to group)
+[22:14:22] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 1/4 -> 0/4
+[22:14:22] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:22] [INFO] [ImpactEffects] spawn_blood_effect called at (420.7691, 531.6212), dir=(1, 0), lethal=true
+[22:14:22] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:22] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:22] [INFO] [ImpactEffects] Wall found for blood splatter at (500, 531.6212) (dist=79 px)
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (499, 531.6212) (added to group)
+[22:14:22] [INFO] [ImpactEffects] Blood effect spawned at (420.7691, 531.6212) (scale=1.5)
+[22:14:22] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[22:14:22] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[22:14:22] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 8)
+[22:14:22] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[22:14:22] [ENEMY] [Enemy2] Death animation started with hit direction: (1, 0)
+[22:14:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(608.9737, 754.6125), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[22:14:22] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:22] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.1°, player=(620,752), corner_timer=-0.01
+[22:14:22] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:22] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.6°, current=3.3°, player=(620,756), corner_timer=0.30
+[22:14:22] [ENEMY] [Enemy3] Death animation completed
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (503.9904, 606.1916) (added to group)
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (484.7488, 598.4642) (added to group)
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (476.2875, 555.1357) (added to group)
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (463.2833, 549.9315) (added to group)
+[22:14:22] [INFO] [BloodDecal] Blood puddle created at (497.0109, 529.9106) (added to group)
+[22:14:22] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(608.9737, 754.6125), shooter_id=402216978116, bullet_pos=(300.0547, 462.73212)
+[22:14:22] [INFO] [Bullet] Using shooter_position, distance=425,00012
+[22:14:22] [INFO] [Bullet] Distance to wall: 425,00012 (28,939041% of viewport)
+[22:14:22] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (482.0994, 576.0615) (added to group)
+[22:14:23] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:14:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.9°, current=-126.7°, player=(620,830), corner_timer=-0.01
+[22:14:23] [ENEMY] [Enemy7] PATROL corner check: angle 89.9°
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (574.6339, 666.6719) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (491.0017, 538.8881) (added to group)
+[22:14:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.9°, current=-129.0°, player=(620,835), corner_timer=0.30
+[22:14:23] [ENEMY] [Enemy1] PURSUING corner check: angle -138.8°
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (479.8876, 582.2947) (added to group)
+[22:14:23] [ENEMY] [Enemy4] PURSUING corner check: angle -38.0°
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (557.1351, 721.1462) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (528.4434, 638.2577) (added to group)
+[22:14:23] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(608.9737, 754.6125), shooter_id=402216978116, bullet_pos=(48.33247, 698.6579)
+[22:14:23] [INFO] [Bullet] Using shooter_position, distance=563,4266
+[22:14:23] [INFO] [Bullet] Distance to wall: 563,4266 (38,364754% of viewport)
+[22:14:23] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (487.1646, 617.2657) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (476.6059, 555.6742) (added to group)
+[22:14:23] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:23] [ENEMY] [Enemy1] State: PURSUING -> RETREATING
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (477.2978, 578.7556) (added to group)
+[22:14:23] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P3:corner, state=RETREATING, target=-138.8°, current=-28.5°, player=(620,866), corner_timer=0.25
+[22:14:23] [ENEMY] [Enemy1] State: RETREATING -> IN_COVER
+[22:14:23] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-163.2°, current=-173.0°, player=(620,866), corner_timer=0.25
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (501.6156, 621.9244) (added to group)
+[22:14:23] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[22:14:23] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (593.0898, 730.4004) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (515.369, 659.4599) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (512.6379, 679.6182) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (550.5101, 678.3923) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (497.7957, 585.9733) (added to group)
+[22:14:23] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(620.5675, 911.6923), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[22:14:23] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:23] [ENEMY] [Enemy2] Ragdoll activated
+[22:14:23] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (513.0701, 620.1208) (added to group)
+[22:14:23] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(620.5675, 911.6923), shooter_id=402216978116, bullet_pos=(708.41156, 885.49664)
+[22:14:23] [INFO] [Bullet] Using shooter_position, distance=91,66674
+[22:14:23] [INFO] [Bullet] Distance to wall: 91,66674 (6,241757% of viewport)
+[22:14:23] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:23] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 4/4 -> 3/4
+[22:14:23] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:23] [INFO] [ImpactEffects] spawn_blood_effect called at (764.5432, 914.0364), dir=(1, 0), lethal=false
+[22:14:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:23] [INFO] [ImpactEffects] Blood effect spawned at (764.5432, 914.0364) (scale=1)
+[22:14:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.0°, current=178.1°, player=(618,932), corner_timer=-0.01
+[22:14:23] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[22:14:23] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.6712, 942.2859), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[22:14:23] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=179.0°, player=(619,936), corner_timer=0.30
+[22:14:23] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 3/4 -> 2/4
+[22:14:23] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:23] [INFO] [ImpactEffects] spawn_blood_effect called at (764.5432, 914.0364), dir=(1, 0), lethal=false
+[22:14:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:23] [INFO] [ImpactEffects] Blood effect spawned at (764.5432, 914.0364) (scale=1)
+[22:14:23] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (574.6429, 708.9919) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (551.5251, 676.9303) (added to group)
+[22:14:23] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[22:14:23] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(641.7568, 968.1654), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[22:14:23] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (555.0518, 705.6519) (added to group)
+[22:14:23] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 2/4 -> 1/4
+[22:14:23] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:23] [INFO] [ImpactEffects] spawn_blood_effect called at (770.5564, 911.8599), dir=(1, 0), lethal=false
+[22:14:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:23] [INFO] [ImpactEffects] Blood effect spawned at (770.5564, 911.8599) (scale=1)
+[22:14:23] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(772.625, 911.3383), source=ENEMY (Enemy4), range=1469, listeners=8
+[22:14:23] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=6
+[22:14:23] [INFO] [Player] Spawning blood effect at (648.7476, 981.7575), dir=(1, 0), lethal=False (C#)
+[22:14:23] [INFO] [ImpactEffects] spawn_blood_effect called at (648.7476, 981.7575), dir=(1, 0), lethal=false
+[22:14:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:23] [INFO] [ImpactEffects] Blood effect spawned at (648.7476, 981.7575) (scale=1)
+[22:14:23] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[22:14:23] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[22:14:23] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(649.9517, 989.9323), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[22:14:23] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:23] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(782.4696, 908.6915), source=ENEMY (Enemy4), range=1469, listeners=8
+[22:14:23] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=7
+[22:14:23] [INFO] [LastChance] Threat detected: Bullet
+[22:14:23] [INFO] [LastChance] Not in hard mode - effect disabled
+[22:14:23] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:23] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P3:corner, state=RETREATING, target=-38.0°, current=-146.7°, player=(642,981), corner_timer=0.23
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (815.2076, 940.1545) (added to group)
+[22:14:23] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 1/4 -> 0/4
+[22:14:23] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:23] [INFO] [ImpactEffects] spawn_blood_effect called at (784.3763, 902.5822), dir=(1, 0), lethal=true
+[22:14:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:23] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:23] [INFO] [ImpactEffects] Blood effect spawned at (784.3763, 902.5822) (scale=1.5)
+[22:14:23] [ENEMY] [Enemy4] Enemy died (ricochet: false, penetration: false)
+[22:14:23] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[22:14:23] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 7)
+[22:14:23] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[22:14:23] [ENEMY] [Enemy4] Death animation started with hit direction: (1, 0)
+[22:14:23] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(721.9834, 947.8076), shooter_id=399566178506, bullet_pos=(635.8857, 998.6721)
+[22:14:23] [INFO] [Bullet] Using shooter_position, distance=100.000022888184
+[22:14:23] [INFO] [Bullet] Distance to wall: 100.000022888184 (6.80918544228405% of viewport)
+[22:14:23] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (825.7451, 959.0725) (added to group)
+[22:14:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.0°, current=126.1°, player=(644,977), corner_timer=-0.01
+[22:14:23] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[22:14:23] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(644.4377, 981.7303), source=PLAYER (AssaultRifle), range=1469, listeners=7
+[22:14:23] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0, below_threshold=6
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (852.1317, 977.9225) (added to group)
+[22:14:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=128.4°, player=(644,975), corner_timer=0.30
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (841.4805, 919.4586) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (841.4716, 899.3502) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (809.2596, 937.2083) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (832.1561, 960.6873) (added to group)
+[22:14:23] [INFO] [BloodDecal] Blood puddle created at (855.7233, 931.1627) (added to group)
+[22:14:24] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (865.3208, 999.0576) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (853.7327, 923.8037) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (814.7096, 908.3829) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (855.5366, 907.5579) (added to group)
+[22:14:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(647.8104, 987.8662), source=PLAYER (AssaultRifle), range=1469, listeners=7
+[22:14:24] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0, below_threshold=6
+[22:14:24] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(644.43774, 981.73035), shooter_id=402216978116, bullet_pos=(932.4948, 831.2379)
+[22:14:24] [INFO] [Bullet] Using shooter_position, distance=324,99976
+[22:14:24] [INFO] [Bullet] Distance to wall: 324,99976 (22,129831% of viewport)
+[22:14:24] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (857.7471, 941.3568) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (888.0757, 979.6104) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (834.203, 945.7096) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (845.519, 947.861) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (861.45, 888.3658) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (894.072, 997.8766) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (860.2716, 954.6296) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (841.8115, 892.0613) (added to group)
+[22:14:24] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(647.8104, 987.8662), shooter_id=402216978116, bullet_pos=(928.2961, 823.6932)
+[22:14:24] [INFO] [Bullet] Using shooter_position, distance=324,99997
+[22:14:24] [INFO] [Bullet] Distance to wall: 324,99997 (22,129845% of viewport)
+[22:14:24] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (874.3785, 971.3788) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (896.5356, 944.6454) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (846.3015, 935.366) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (872.9783, 909.6323) (added to group)
+[22:14:24] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.6°, player=(645,940), corner_timer=-0.01
+[22:14:24] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:14:24] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=91.9°, player=(645,935), corner_timer=0.30
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (898.8652, 946.2231) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (896.094, 932.5655) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (873.3135, 936.8214) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (857.8209, 938.2484) (added to group)
+[22:14:24] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[22:14:24] [ENEMY] [Enemy1] Player reloading: false -> true
+[22:14:24] [ENEMY] [Enemy2] Player reloading: false -> true
+[22:14:24] [ENEMY] [Enemy4] Player reloading: false -> true
+[22:14:24] [ENEMY] [Enemy5] Player reloading: false -> true
+[22:14:24] [ENEMY] [Enemy6] Player reloading: false -> true
+[22:14:24] [ENEMY] [Enemy7] Player reloading: false -> true
+[22:14:24] [ENEMY] [Enemy8] Player reloading: false -> true
+[22:14:24] [ENEMY] [Enemy9] Player reloading: false -> true
+[22:14:24] [ENEMY] [Enemy10] Player reloading: false -> true
+[22:14:24] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(645.4914, 922.7586), source=PLAYER (Player), range=900, listeners=7
+[22:14:24] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[22:14:24] [ENEMY] [Enemy1] Player vulnerable (reloading) but cannot attack: close=false (dist=652), can_see=false
+[22:14:24] [ENEMY] [Enemy5] Player vulnerable (reloading) but cannot attack: close=false (dist=1200), can_see=false
+[22:14:24] [ENEMY] [Enemy6] Player vulnerable (reloading) but cannot attack: close=false (dist=1388), can_see=false
+[22:14:24] [ENEMY] [Enemy7] Player vulnerable (reloading) but cannot attack: close=false (dist=966), can_see=false
+[22:14:24] [ENEMY] [Enemy8] Player vulnerable (reloading) but cannot attack: close=false (dist=1361), can_see=false
+[22:14:24] [ENEMY] [Enemy9] Player vulnerable (reloading) but cannot attack: close=false (dist=1584), can_see=false
+[22:14:24] [ENEMY] [Enemy10] Player vulnerable (reloading) but cannot attack: close=false (dist=852), can_see=false
+[22:14:24] [INFO] [Player.Reload.Anim] LeftArm: pos=(19.329529, 4.6666665), target=(4, 2), base=(24, 6)
+[22:14:24] [INFO] [Player.Reload.Anim] RightArm: pos=(-3.996196, 6), target=(-2, 6), base=(-2, 6)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (848.2066, 962.8707) (added to group)
+[22:14:24] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (870.5816, 984.6333) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (899.6844, 969.5045) (added to group)
+[22:14:24] [ENEMY] [Enemy4] Ragdoll activated
+[22:14:24] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:14:24] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[22:14:24] [ENEMY] [Enemy2] Death animation completed
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (910.6891, 961.7006) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (887.5621, 992.1042) (added to group)
+[22:14:24] [INFO] [BloodDecal] Blood puddle created at (910.1958, 982.6765) (added to group)
+[22:14:24] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.1°, current=89.5°, player=(645,834), corner_timer=-0.01
+[22:14:24] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:24] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=91.8°, player=(645,830), corner_timer=0.30
+[22:14:24] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[22:14:24] [ENEMY] [Enemy1] Player reloading: true -> false
+[22:14:24] [ENEMY] [Enemy2] Player reloading: true -> false
+[22:14:24] [ENEMY] [Enemy4] Player reloading: true -> false
+[22:14:24] [ENEMY] [Enemy5] Player reloading: true -> false
+[22:14:24] [ENEMY] [Enemy6] Player reloading: true -> false
+[22:14:24] [ENEMY] [Enemy7] Player reloading: true -> false
+[22:14:24] [ENEMY] [Enemy8] Player reloading: true -> false
+[22:14:24] [ENEMY] [Enemy9] Player reloading: true -> false
+[22:14:24] [ENEMY] [Enemy10] Player reloading: true -> false
+[22:14:24] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[22:14:24] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:25] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[22:14:25] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.9°, current=89.4°, player=(645,729), corner_timer=-0.01
+[22:14:25] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:25] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.7°, player=(645,724), corner_timer=0.30
+[22:14:25] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:25] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.8°, current=89.3°, player=(598,656), corner_timer=-0.01
+[22:14:25] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:25] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(597,654), corner_timer=0.30
+[22:14:25] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:25] [ENEMY] [Enemy4] Death animation completed
+[22:14:25] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.7°, current=89.3°, player=(436,671), corner_timer=-0.01
+[22:14:25] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:25] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(423,671), corner_timer=0.30
+[22:14:26] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:26] [ENEMY] [Enemy1] State: SUPPRESSED -> IN_COVER
+[22:14:26] [ENEMY] [Enemy1] State: IN_COVER -> PURSUING
+[22:14:26] [ENEMY] [Enemy1] ROT_CHANGE: P3:corner -> P2:combat_state, state=PURSUING, target=95.2°, current=-138.8°, player=(244,661), corner_timer=0.25
+[22:14:26] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.3°, player=(182,651), corner_timer=-0.01
+[22:14:26] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:26] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(174,649), corner_timer=0.30
+[22:14:26] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:26] [INFO] [BloodyFeet:Player] Blood ran out - no more footprints
+[22:14:26] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.3°, player=(82,597), corner_timer=-0.01
+[22:14:26] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[22:14:26] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(82,594), corner_timer=0.30
+[22:14:26] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:26] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=141.5°, current=140.4°, player=(82,538), corner_timer=0.25
+[22:14:26] [ENEMY] [Enemy1] State: PURSUING -> COMBAT
+[22:14:27] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=147.0°, current=-150.5°, player=(82,511), corner_timer=0.25
+[22:14:27] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.7°, current=89.2°, player=(82,494), corner_timer=-0.00
+[22:14:27] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:27] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=92.1°, player=(82,489), corner_timer=0.30
+[22:14:27] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(82.54746, 429.3733), source=PLAYER (AssaultRifle), range=1469, listeners=7
+[22:14:27] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[22:14:27] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 3/3 -> 2/3
+[22:14:27] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:27] [INFO] [ImpactEffects] spawn_blood_effect called at (268.8647, 390.4101), dir=(1, 0), lethal=false
+[22:14:27] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:27] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:27] [INFO] [ImpactEffects] Blood effect spawned at (268.8647, 390.4101) (scale=1)
+[22:14:27] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=175.3°, current=180.0°, player=(80,406), corner_timer=0.25
+[22:14:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(80.07563, 397.781), source=PLAYER (AssaultRifle), range=1469, listeners=7
+[22:14:27] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[22:14:27] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.9°, current=89.3°, player=(80,391), corner_timer=-0.01
+[22:14:27] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:27] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(78,383), corner_timer=0.30
+[22:14:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(268.8647, 390.4101), source=ENEMY (Enemy1), range=1469, listeners=7
+[22:14:27] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=4, self=1, below_threshold=2
+[22:14:27] [INFO] [LastChance] Threat detected: @Area2D@1980
+[22:14:27] [INFO] [LastChance] Not in hard mode - effect disabled
+[22:14:27] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:27] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 2/3 -> 1/3
+[22:14:27] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:27] [INFO] [ImpactEffects] spawn_blood_effect called at (278.5804, 390.4101), dir=(1, 0), lethal=false
+[22:14:27] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:27] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:27] [INFO] [ImpactEffects] Blood effect spawned at (278.5804, 390.4101) (scale=1)
+[22:14:27] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:27] [INFO] [ScoreManager] Combo ended at 3. Max combo: 3
+[22:14:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(80.07548, 358.473), source=PLAYER (AssaultRifle), range=1469, listeners=7
+[22:14:27] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[22:14:27] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[22:14:27] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(200.6392, 390.9037), shooter_id=398660209102, bullet_pos=(34.93123, 373.0534)
+[22:14:27] [INFO] [Bullet] Using shooter_position, distance=166.66667175293
+[22:14:27] [INFO] [Bullet] Distance to wall: 166.66667175293 (11.3486401526422% of viewport)
+[22:14:27] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:27] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 1/3 -> 0/3
+[22:14:27] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:27] [INFO] [ImpactEffects] spawn_blood_effect called at (283.2919, 391.3576), dir=(1, 0), lethal=true
+[22:14:27] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:27] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:27] [INFO] [ImpactEffects] Blood effect spawned at (283.2919, 391.3576) (scale=1.5)
+[22:14:27] [ENEMY] [Enemy1] Enemy died (ricochet: false, penetration: false)
+[22:14:27] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:14:27] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 6)
+[22:14:27] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[22:14:27] [ENEMY] [Enemy1] Death animation started with hit direction: (1, 0)
+[22:14:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(80.07229, 325.1971), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[22:14:27] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (346.6647, 376.058) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (322.1398, 409.5932) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (365.2172, 399.0819) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (323.5627, 387.8755) (added to group)
+[22:14:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(80.0141, 300.8023), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[22:14:27] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[22:14:27] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.8°, current=89.3°, player=(80,294), corner_timer=-0.01
+[22:14:27] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:27] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(79,289), corner_timer=0.30
+[22:14:27] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(80.07229, 325.19714), shooter_id=402216978116, bullet_pos=(498.94525, 397.10342)
+[22:14:27] [INFO] [Bullet] Using shooter_position, distance=425,00006
+[22:14:27] [INFO] [Bullet] Distance to wall: 425,00006 (28,939035% of viewport)
+[22:14:27] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:27] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (394.345, 401.1476) (added to group)
+[22:14:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(80.07577, 291.5753), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[22:14:27] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (358.5324, 405.5057) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (359.0977, 426.4668) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (320.7269, 399.8388) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (340.8054, 396.6226) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (318.4219, 421.2811) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (362.3393, 401.7746) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (378.6478, 435.3222) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (352.1266, 419.6732) (added to group)
+[22:14:27] [INFO] [BloodDecal] Blood puddle created at (370.1517, 408.38) (added to group)
+[22:14:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(80.0141, 300.80234), shooter_id=402216978116, bullet_pos=(523.8166, 415.29645)
+[22:14:28] [INFO] [Bullet] Using shooter_position, distance=458,33347
+[22:14:28] [INFO] [Bullet] Distance to wall: 458,33347 (31,208769% of viewport)
+[22:14:28] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (418.8952, 431.3168) (added to group)
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (399.6066, 409.9602) (added to group)
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (384.9958, 367.7584) (added to group)
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (337.3861, 419.0655) (added to group)
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (381.2051, 392.6929) (added to group)
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (395.6213, 416.7275) (added to group)
+[22:14:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(80.0141, 300.80234), shooter_id=402216978116, bullet_pos=(322.92535, 446.7154)
+[22:14:28] [INFO] [Bullet] Using shooter_position, distance=283,36636
+[22:14:28] [INFO] [Bullet] Distance to wall: 283,36636 (19,294937% of viewport)
+[22:14:28] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:28] [INFO] [Bullet] Starting wall penetration at (322.92535, 446.7154)
+[22:14:28] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:14:28] [INFO] [Bullet] Exiting penetration at (289.99237, 451.86603) after traveling 28,333334 pixels through wall
+[22:14:28] [INFO] [Bullet] Damage multiplier after penetration: 0,45
+[22:14:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(80.07577, 291.5753), shooter_id=402216978116, bullet_pos=(515.4919, 434.69144)
+[22:14:28] [INFO] [Bullet] Using shooter_position, distance=458,3333
+[22:14:28] [INFO] [Bullet] Distance to wall: 458,3333 (31,20876% of viewport)
+[22:14:28] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:28] [INFO] [Bullet] Starting wall penetration at (515.4919, 434.69144)
+[22:14:28] [INFO] [Bullet] Raycast backward hit penetrating body at distance 29,377409
+[22:14:28] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:28] [INFO] [Bullet] Exiting penetration at (551.9085, 446.66116) after traveling 33,333336 pixels through wall
+[22:14:28] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:28] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.7°, current=89.3°, player=(80,308), corner_timer=-0.01
+[22:14:28] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:28] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(80,311), corner_timer=0.30
+[22:14:28] [ENEMY] [Enemy1] Ragdoll activated
+[22:14:28] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (410.418, 452.2054) (added to group)
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (439.89, 389.9929) (added to group)
+[22:14:28] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (450.8426, 397.2589) (added to group)
+[22:14:28] [INFO] [BloodDecal] Blood puddle created at (394.161, 429.2162) (added to group)
+[22:14:28] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.3°, player=(136,382), corner_timer=-0.01
+[22:14:28] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:28] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(139,385), corner_timer=0.30
+[22:14:28] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:28] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.3°, player=(203,456), corner_timer=-0.01
+[22:14:28] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[22:14:29] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(203,459), corner_timer=0.30
+[22:14:29] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:29] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(238,531), corner_timer=-0.01
+[22:14:29] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[22:14:29] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(241,534), corner_timer=0.30
+[22:14:29] [ENEMY] [Enemy1] Death animation completed
+[22:14:29] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:29] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(318,593), corner_timer=-0.01
+[22:14:29] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[22:14:29] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(322,593), corner_timer=0.30
+[22:14:29] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:30] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(423,594), corner_timer=-0.01
+[22:14:30] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[22:14:30] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(428,594), corner_timer=0.30
+[22:14:30] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:30] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:14:30] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(511,638), corner_timer=-0.01
+[22:14:30] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[22:14:30] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(514,640), corner_timer=0.30
+[22:14:30] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:30] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.7°, current=89.2°, player=(603,632), corner_timer=-0.01
+[22:14:30] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:30] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=92.1°, player=(607,628), corner_timer=0.30
+[22:14:31] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:31] [INFO] [ScoreManager] Combo ended at 1. Max combo: 3
+[22:14:31] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.9°, current=89.3°, player=(681,554), corner_timer=-0.02
+[22:14:31] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[22:14:31] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=92.2°, player=(685,551), corner_timer=0.30
+[22:14:31] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:31] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.0°, current=89.3°, player=(759,477), corner_timer=-0.02
+[22:14:31] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:31] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.2°, player=(763,473), corner_timer=0.30
+[22:14:31] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:31] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.1°, current=89.4°, player=(844,416), corner_timer=-0.02
+[22:14:31] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:31] [INFO] [BloodyFeet:Player] Blood ran out - no more footprints
+[22:14:31] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.2°, player=(849,415), corner_timer=0.30
+[22:14:32] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:32] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(953,415), corner_timer=-0.02
+[22:14:32] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:32] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.2°, player=(959,415), corner_timer=0.30
+[22:14:32] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:32] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(1063,415), corner_timer=-0.02
+[22:14:32] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:32] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1069,415), corner_timer=0.30
+[22:14:32] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:32] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(1155,372), corner_timer=-0.02
+[22:14:32] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:32] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1159,368), corner_timer=0.30
+[22:14:33] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:33] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(1233,294), corner_timer=-0.02
+[22:14:33] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:33] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1237,290), corner_timer=0.30
+[22:14:33] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:33] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(1311,216), corner_timer=-0.02
+[22:14:33] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:33] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1315,212), corner_timer=0.30
+[22:14:33] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:33] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(1389,138), corner_timer=-0.02
+[22:14:33] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:33] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1393,134), corner_timer=0.30
+[22:14:34] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1446.695, 111.1638), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[22:14:34] [ENEMY] [Enemy5] Heard gunshot at (1446.695, 111.1638), source_type=0, intensity=0.02, distance=348
+[22:14:34] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=3
+[22:14:34] [ENEMY] [Enemy5] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-136.0°, current=-180.0°, player=(1446,105), corner_timer=0.00
+[22:14:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1459.82, 174.795), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[22:14:34] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=4
+[22:14:34] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(1459,168), corner_timer=-0.02
+[22:14:34] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:34] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1460,169), corner_timer=0.30
+[22:14:34] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1459.8198, 174.79497), shooter_id=402216978116, bullet_pos=(1663.8158, 288.0649)
+[22:14:34] [INFO] [Bullet] Using shooter_position, distance=233,33331
+[22:14:34] [INFO] [Bullet] Distance to wall: 233,33331 (15,888095% of viewport)
+[22:14:34] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:34] [ENEMY] [Enemy5] Hit taken, damage: 1, health: 4/4 -> 3/4
+[22:14:34] [ENEMY] [Enemy5] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:34] [INFO] [ImpactEffects] spawn_blood_effect called at (1684.065, 294.1581), dir=(1, 0), lethal=false
+[22:14:34] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:34] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:34] [INFO] [ImpactEffects] Blood effect spawned at (1684.065, 294.1581) (scale=1)
+[22:14:34] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1483.148, 258.2511), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[22:14:34] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=5
+[22:14:34] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1483.148, 258.25107), shooter_id=402216978116, bullet_pos=(1565.8893, 297.7052)
+[22:14:34] [INFO] [Bullet] Using shooter_position, distance=91,66655
+[22:14:34] [INFO] [Bullet] Distance to wall: 91,66655 (6,241744% of viewport)
+[22:14:34] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:34] [ENEMY] [Enemy5] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-179.1°, current=177.0°, player=(1506,274), corner_timer=0.00
+[22:14:34] [ENEMY] [Enemy5] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=172.7°, current=171.8°, player=(1523,294), corner_timer=0.00
+[22:14:34] [ENEMY] [Enemy5] State: COMBAT -> RETREATING
+[22:14:34] [ENEMY] [Enemy5] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=-102.9°, current=166.9°, player=(1523,296), corner_timer=0.00
+[22:14:34] [ENEMY] [Enemy5] State: RETREATING -> IN_COVER
+[22:14:34] [ENEMY] [Enemy5] State: IN_COVER -> SUPPRESSED
+[22:14:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1523.992, 302.9682), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[22:14:34] [ENEMY] [Enemy6] Heard gunshot at (1523.992, 302.9682), source_type=0, intensity=0.01, distance=451
+[22:14:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=4
+[22:14:34] [ENEMY] [Enemy6] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-160.2°, current=56.2°, player=(1523,296), corner_timer=0.00
+[22:14:34] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1483.148, 258.25107), shooter_id=402216978116, bullet_pos=(1381.5989, 383.62112)
+[22:14:34] [INFO] [Bullet] Using shooter_position, distance=161,33774
+[22:14:34] [INFO] [Bullet] Distance to wall: 161,33774 (10,985784% of viewport)
+[22:14:34] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:34] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1523.9922, 302.96817), shooter_id=402216978116, bullet_pos=(1556.7563, 316.19534)
+[22:14:34] [INFO] [Bullet] Using shooter_position, distance=35,33339
+[22:14:34] [INFO] [Bullet] Distance to wall: 35,33339 (2,4059155% of viewport)
+[22:14:34] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:14:34] [INFO] [Bullet] Starting wall penetration at (1556.7563, 316.19534)
+[22:14:34] [INFO] [Bullet] Raycast backward hit penetrating body at distance 17,48491
+[22:14:34] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:34] [INFO] [Bullet] Exiting penetration at (1592.3024, 330.54556) after traveling 33,333336 pixels through wall
+[22:14:34] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:14:34] [ENEMY] [Enemy6] State: COMBAT -> RETREATING
+[22:14:34] [ENEMY] [Enemy6] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=-160.7°, current=-111.3°, player=(1523,305), corner_timer=0.00
+[22:14:34] [ENEMY] [Enemy6] State: RETREATING -> IN_COVER
+[22:14:34] [ENEMY] [Enemy6] ROT_CHANGE: P4:velocity -> P1:visible, state=IN_COVER, target=-162.3°, current=-113.6°, player=(1519,312), corner_timer=0.00
+[22:14:34] [ENEMY] [Enemy6] State: IN_COVER -> SUPPRESSED
+[22:14:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1514.709, 330.6393), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[22:14:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=4
+[22:14:34] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.1°, current=89.4°, player=(1514,324), corner_timer=-0.01
+[22:14:34] [ENEMY] [Enemy7] Memory: high confidence (0.90) - transitioning to PURSUING
+[22:14:34] [ENEMY] [Enemy7] State: IDLE -> PURSUING
+[22:14:34] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1446.6952, 111.16379), shooter_id=402216978116, bullet_pos=(2462.5154, 684.9418)
+[22:14:34] [INFO] [Bullet] Using shooter_position, distance=1166,667
+[22:14:34] [INFO] [Bullet] Distance to wall: 1166,667 (79,440506% of viewport)
+[22:14:34] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P2:combat_state, state=PURSUING, target=-99.7°, current=91.7°, player=(1511,319), corner_timer=-0.01
+[22:14:34] [ENEMY] [Enemy7] PURSUING corner check: angle -11.2°
+[22:14:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1925.881, 441.4186), source=ENEMY (Enemy6), range=1469, listeners=6
+[22:14:34] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:14:34] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:34] [INFO] [BloodDecal] Blood puddle created at (1745.581, 303.6732) (added to group)
+[22:14:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1925.881, 441.4186), source=ENEMY (Enemy6), range=1469, listeners=6
+[22:14:34] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:14:34] [INFO] [BloodDecal] Blood puddle created at (1775.211, 279.3269) (added to group)
+[22:14:34] [INFO] [LastChance] Threat detected: @Area2D@2098
+[22:14:34] [INFO] [LastChance] Not in hard mode - effect disabled
+[22:14:34] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:34] [INFO] [BloodDecal] Blood puddle created at (1785.891, 302.4599) (added to group)
+[22:14:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1925.881, 441.4186), source=ENEMY (Enemy6), range=1469, listeners=6
+[22:14:34] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:14:34] [ENEMY] [Enemy6] State: SUPPRESSED -> SEEKING_COVER
+[22:14:34] [INFO] [Player] Spawning blood effect at (1488.2152, 373.9411), dir=(1, 0), lethal=False (C#)
+[22:14:34] [INFO] [ImpactEffects] spawn_blood_effect called at (1488.215, 373.9411), dir=(1, 0), lethal=false
+[22:14:34] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:34] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:34] [INFO] [ImpactEffects] Blood effect spawned at (1488.215, 373.9411) (scale=1)
+[22:14:34] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[22:14:34] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[22:14:34] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[22:14:34] [INFO] [PenultimateHit]   - Time scale: 0.10
+[22:14:34] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[22:14:34] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[22:14:34] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[22:14:34] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[22:14:34] [INFO] [PenultimateHit] Applying saturation to 6 enemies
+[22:14:34] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[22:14:34] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[22:14:34] [INFO] [LastChance] Threat detected: @Area2D@2101
+[22:14:34] [INFO] [LastChance] Not in hard mode - effect disabled
+[22:14:34] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:34] [ENEMY] [Enemy6] ROT_CHANGE: P1:visible -> P4:velocity, state=SEEKING_COVER, target=-76.6°, current=-70.7°, player=(1486,376), corner_timer=0.00
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1774.483, 356.3404) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1798.498, 308.8677) (added to group)
+[22:14:35] [INFO] [Player] Spawning blood effect at (1482.4882, 384.2339), dir=(1, 0), lethal=True (C#)
+[22:14:35] [INFO] [ImpactEffects] spawn_blood_effect called at (1482.488, 384.2339), dir=(1, 0), lethal=true
+[22:14:35] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:35] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:35] [INFO] [ImpactEffects] Blood effect spawned at (1482.488, 384.2339) (scale=1.5)
+[22:14:35] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[22:14:35] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[22:14:35] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[22:14:35] [INFO] [PenultimateHit] Ending penultimate hit effect
+[22:14:35] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[22:14:35] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[22:14:35] [INFO] [LastChance] Player died
+[22:14:35] [INFO] [LastChance] Threat detected: @Area2D@2105
+[22:14:35] [INFO] [LastChance] Not in hard mode - effect disabled
+[22:14:35] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1810.068, 323.8512) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1846.601, 380.6976) (added to group)
+[22:14:35] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:35] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:35] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:35] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:35] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:35] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:35] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:35] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:35] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:35] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:35] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:35] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:35] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:35] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:35] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:35] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:35] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:35] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:35] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:35] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:35] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:35] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:35] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:35] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:35] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:35] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[22:14:35] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:35] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:35] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:35] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:35] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 7)
+[22:14:35] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[22:14:35] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 8)
+[22:14:35] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[22:14:35] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 9)
+[22:14:35] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[22:14:35] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 10)
+[22:14:35] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[22:14:35] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 11)
+[22:14:35] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:14:35] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 12)
+[22:14:35] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:14:35] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 13)
+[22:14:35] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[22:14:35] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 14)
+[22:14:35] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[22:14:35] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 15)
+[22:14:35] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[22:14:35] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:35] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 16)
+[22:14:35] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:35] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:14:35] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:35] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:35] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:35] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:35] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:35] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:35] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:35] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:35] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:35] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:35] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:14:35] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:14:35] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:35] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:35] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:35] [INFO] [LastChance] Found player: Player
+[22:14:35] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:35] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:35] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1790.828, 353.8573) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1780.051, 361.4662) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1852.03, 373.9675) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1556.707, 384.2246) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1582.645, 359.7575) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1582.817, 390.2857) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1564.946, 368.6455) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1589.756, 417.7585) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1587.037, 449.5565) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1556.75, 433.9142) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1619.315, 466.6918) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1558.674, 464.1047) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1571.912, 454.8191) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1569.256, 403.2308) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1563.027, 421.455) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1579.501, 389.2971) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1598.5, 405.9579) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1637.831, 527.0291) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1604.53, 382.1183) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1631.543, 454.1815) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1588.456, 490.9915) (added to group)
+[22:14:35] [INFO] [BloodDecal] Blood puddle created at (1596.538, 397.1194) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1602.427, 465.2035) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1599.812, 415.8119) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1626.337, 534.8956) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1699, 472.228) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1656.964, 458.7207) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1640.709, 423.1398) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1667.244, 487.4891) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1723.924, 539.1497) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1604.047, 456.7542) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1701.857, 431.8171) (added to group)
+[22:14:36] [INFO] [BloodDecal] Blood puddle created at (1698.786, 598.3176) (added to group)
+[22:14:38] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:38] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:38] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:38] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:38] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:38] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:38] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:38] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:38] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:38] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:38] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:38] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:38] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:38] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:38] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:38] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:38] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:38] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:38] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:38] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:38] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:38] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:38] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:38] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:38] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:38] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:38] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[22:14:38] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:38] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:38] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:38] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 17)
+[22:14:38] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 18)
+[22:14:38] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 19)
+[22:14:38] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 20)
+[22:14:38] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 21)
+[22:14:38] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 22)
+[22:14:38] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 23)
+[22:14:38] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[22:14:38] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 24)
+[22:14:38] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 25)
+[22:14:38] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 26)
+[22:14:38] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:14:38] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:38] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:38] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:38] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:38] [INFO] [LastChance] Found player: Player
+[22:14:38] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:38] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:38] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:38] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:38] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:14:38] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:14:38] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:38] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:38] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:38] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:38] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:38] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:38] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:38] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:38] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:38] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:38] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:38] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:38] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:38] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:38] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:38] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:38] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:38] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:38] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:38] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:38] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:38] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:38] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:38] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:38] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:38] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:38] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[22:14:38] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:38] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:38] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:38] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:38] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 27)
+[22:14:38] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 28)
+[22:14:38] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 29)
+[22:14:38] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 30)
+[22:14:38] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 31)
+[22:14:38] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 32)
+[22:14:38] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 33)
+[22:14:38] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[22:14:38] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 34)
+[22:14:38] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 35)
+[22:14:38] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:14:38] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:38] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 36)
+[22:14:38] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:38] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:14:38] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:38] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:38] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:38] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:38] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:38] [INFO] [LastChance] Found player: Player
+[22:14:38] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:38] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:38] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:38] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:38] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:14:38] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:14:42] [INFO] [PauseMenu] Armory button pressed
+[22:14:42] [INFO] [PauseMenu] Creating new armory menu instance
+[22:14:42] [INFO] [PauseMenu] armory_menu_scene resource path: res://scenes/ui/ArmoryMenu.tscn
+[22:14:42] [INFO] [PauseMenu] Instance created, class: CanvasLayer, name: ArmoryMenu
+[22:14:42] [INFO] [PauseMenu] Script attached: res://scripts/ui/armory_menu.gd
+[22:14:42] [INFO] [PauseMenu] back_pressed signal exists on instance
+[22:14:42] [INFO] [PauseMenu] back_pressed signal connected
+[22:14:42] [INFO] [PauseMenu] Armory menu instance added as child, is_inside_tree: true
+[22:14:42] [INFO] [PauseMenu] _populate_weapon_grid method exists
+[22:14:44] [INFO] [GameManager] Weapon selected: mini_uzi
+[22:14:44] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:44] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:44] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:44] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:44] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:44] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:44] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:44] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:44] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:44] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:44] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:44] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:44] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:44] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:44] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:44] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:44] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:44] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:44] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:44] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:44] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:44] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:44] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:44] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:44] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:44] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:44] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:44] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:44] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:44] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:44] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[22:14:44] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:44] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:44] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:44] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:44] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 37)
+[22:14:44] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[22:14:44] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 38)
+[22:14:44] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:14:44] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 39)
+[22:14:44] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[22:14:44] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 40)
+[22:14:44] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[22:14:44] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 41)
+[22:14:44] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:14:44] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 42)
+[22:14:44] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:14:44] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 43)
+[22:14:44] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[22:14:44] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 44)
+[22:14:44] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:14:44] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 45)
+[22:14:44] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:14:44] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:44] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 46)
+[22:14:44] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:44] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:14:44] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:44] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:44] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:44] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:44] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:44] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:44] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:44] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:44] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:14:44] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:44] [INFO] [Player] Detected weapon: Mini UZI (SMG pose)
+[22:14:44] [INFO] [Player] Applied SMG arm pose: Left=(14, 6), Right=(1, 6)
+[22:14:44] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:44] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:44] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:44] [INFO] [LastChance] Found player: Player
+[22:14:44] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:44] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:44] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:45] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:14:45] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:14:45] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:14:45] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:14:45] [ENEMY] [Enemy1] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:14:45] [ENEMY] [Enemy2] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:14:45] [ENEMY] [Enemy3] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:14:45] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:45] [ENEMY] [Enemy4] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:14:45] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:45] [ENEMY] [Enemy5] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:14:45] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:45] [ENEMY] [Enemy6] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:14:45] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:14:45] [ENEMY] [Enemy7] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:14:45] [ENEMY] [Enemy8] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:14:45] [ENEMY] [Enemy9] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:14:45] [ENEMY] [Enemy10] Death animation component initialized
+[22:14:45] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:14:45] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:14:45] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:14:45] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:14:45] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:14:45] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:14:45] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:14:45] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:14:45] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:14:45] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:14:45] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:14:45] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:14:45] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[22:14:45] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:14:45] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:14:45] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:14:45] [INFO] [ScoreManager] Level started with 10 enemies
+[22:14:45] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 47)
+[22:14:45] [ENEMY] [Enemy1] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[22:14:45] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 48)
+[22:14:45] [ENEMY] [Enemy2] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:14:45] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 49)
+[22:14:45] [ENEMY] [Enemy3] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[22:14:45] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 50)
+[22:14:45] [ENEMY] [Enemy4] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[22:14:45] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 51)
+[22:14:45] [ENEMY] [Enemy5] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[22:14:45] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 52)
+[22:14:45] [ENEMY] [Enemy6] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[22:14:45] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 53)
+[22:14:45] [ENEMY] [Enemy7] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[22:14:45] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 54)
+[22:14:45] [ENEMY] [Enemy8] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[22:14:45] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 55)
+[22:14:45] [ENEMY] [Enemy9] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:14:45] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:14:45] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 56)
+[22:14:45] [ENEMY] [Enemy10] Registered as sound listener
+[22:14:45] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[22:14:45] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:14:45] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:45] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=45.0°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:45] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:45] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:45] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:45] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:45] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:45] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[22:14:45] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:14:45] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:14:45] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:14:45] [INFO] [LastChance] Found player: Player
+[22:14:45] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:14:45] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:14:45] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:14:45] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:14:45] [INFO] [Player] Detected weapon: Mini UZI (SMG pose)
+[22:14:45] [INFO] [Player] Applied SMG arm pose: Left=(14, 6), Right=(1, 6)
+[22:14:47] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:47] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:14:47] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,783), corner_timer=0.30
+[22:14:47] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,783), corner_timer=0.30
+[22:14:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450, 775.9999), source=PLAYER (MiniUzi), range=1469, listeners=56
+[22:14:47] [INFO] [SoundPropagation] Cleaned up 46 invalid listeners
+[22:14:47] [ENEMY] [Enemy1] Heard gunshot at (450, 775.9999), source_type=0, intensity=0.01, distance=452
+[22:14:47] [ENEMY] [Enemy2] Heard gunshot at (450, 775.9999), source_type=0, intensity=0.05, distance=231
+[22:14:47] [ENEMY] [Enemy3] Heard gunshot at (450, 775.9999), source_type=0, intensity=0.04, distance=251
+[22:14:47] [ENEMY] [Enemy4] Heard gunshot at (450, 775.9999), source_type=0, intensity=0.02, distance=371
+[22:14:47] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:47] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=70.6°, current=-157.5°, player=(450,775), corner_timer=0.00
+[22:14:47] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=77.5°, current=45.0°, player=(450,775), corner_timer=0.00
+[22:14:47] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=174.1°, current=-78.7°, player=(450,775), corner_timer=0.00
+[22:14:47] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-160.5°, current=-67.5°, player=(450,775), corner_timer=0.00
+[22:14:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(458.4176, 776.7728), source=PLAYER (MiniUzi), range=1469, listeners=10
+[22:14:47] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(477.802, 789.5529), source=PLAYER (MiniUzi), range=1469, listeners=10
+[22:14:47] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(464.5764, 794.1398), source=PLAYER (MiniUzi), range=1469, listeners=10
+[22:14:47] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:47] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 2/2 -> 1/2
+[22:14:47] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:47] [INFO] [ImpactEffects] spawn_blood_effect called at (689.3905, 751.1034), dir=(0.997993, -0.063323), lethal=false
+[22:14:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:47] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:47] [INFO] [ImpactEffects] Blood effect spawned at (689.3905, 751.1034) (scale=0.9)
+[22:14:47] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=167.8°, current=176.4°, player=(457,801), corner_timer=0.00
+[22:14:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(454.3847, 814.0045), source=PLAYER (MiniUzi), range=1469, listeners=10
+[22:14:47] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:14:47] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 1/2 -> 0/2
+[22:14:47] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:47] [INFO] [ImpactEffects] spawn_blood_effect called at (689.3905, 751.1034), dir=(0.996265, -0.08635), lethal=true
+[22:14:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:47] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:47] [INFO] [ImpactEffects] Blood effect spawned at (689.3905, 751.1034) (scale=1.35)
+[22:14:47] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[22:14:47] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:14:47] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 9)
+[22:14:47] [INFO] [DeathAnim] Started - Angle: -5.0 deg, Index: 11
+[22:14:47] [ENEMY] [Enemy3] Death animation started with hit direction: (0.996265, -0.08635)
+[22:14:47] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(454.3847, 814.0045), shooter_id=839917766978, bullet_pos=(514.379, 814.8301)
+[22:14:47] [INFO] [Bullet] Using shooter_position, distance=59.9999732971191
+[22:14:47] [INFO] [Bullet] Distance to wall: 59.9999732971191 (4.08550851202306% of viewport)
+[22:14:47] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:14:47] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(441.8124, 827.5426), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:47] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:47] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(441.8124, 827.5426), shooter_id=839917766978, bullet_pos=(501.6667, 823.3636)
+[22:14:47] [INFO] [Bullet] Using shooter_position, distance=59.9999885559082
+[22:14:47] [INFO] [Bullet] Distance to wall: 59.9999885559082 (4.08550955102207% of viewport)
+[22:14:47] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:14:47] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:47] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(431,830), corner_timer=-0.02
+[22:14:47] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:14:47] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(431,830), corner_timer=-0.02
+[22:14:47] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:14:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(431.9998, 836.272), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:47] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:47] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(431,836), corner_timer=0.30
+[22:14:47] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(431,836), corner_timer=0.30
+[22:14:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(420.6923, 855.0892), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:47] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[22:14:47] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(431.9998, 836.272), shooter_id=839917766978, bullet_pos=(509.1304, 815.0383)
+[22:14:47] [INFO] [Bullet] Using shooter_position, distance=80
+[22:14:47] [INFO] [Bullet] Distance to wall: 80 (5.44734710702843% of viewport)
+[22:14:47] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:47] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:47] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(420.6923, 855.0892), shooter_id=839917766978, bullet_pos=(500.6614, 857.3114)
+[22:14:47] [INFO] [Bullet] Using shooter_position, distance=79.9999847412109
+[22:14:47] [INFO] [Bullet] Distance to wall: 79.9999847412109 (5.44734606802943% of viewport)
+[22:14:47] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:47] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (734.7336, 763.4892) (added to group)
+[22:14:47] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(477.802, 789.5529), shooter_id=839917766978, bullet_pos=(917.7899, 786.204)
+[22:14:47] [INFO] [Bullet] Using shooter_position, distance=440.000610351563
+[22:14:47] [INFO] [Bullet] Distance to wall: 440.000610351563 (29.9604506486166% of viewport)
+[22:14:47] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:47] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (726.8136, 749.6313) (added to group)
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (730.38, 753.2421) (added to group)
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (774.6556, 746.9719) (added to group)
+[22:14:47] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[22:14:47] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[22:14:47] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (741.2878, 774.5599) (added to group)
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (753.139, 738.5656) (added to group)
+[22:14:47] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(464.5764, 794.1398), shooter_id=839917766978, bullet_pos=(922.0649, 746.1352)
+[22:14:47] [INFO] [Bullet] Using shooter_position, distance=460.000274658203
+[22:14:47] [INFO] [Bullet] Distance to wall: 460.000274658203 (31.3222645673956% of viewport)
+[22:14:47] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:47] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (778.8193, 817.7812) (added to group)
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (739.9323, 797.2452) (added to group)
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (744.0615, 766.4354) (added to group)
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (784.1671, 808.2175) (added to group)
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (806.9972, 747.0997) (added to group)
+[22:14:47] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(429,903), corner_timer=-0.02
+[22:14:47] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:14:47] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(431,905), corner_timer=0.30
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (752.4631, 752.8221) (added to group)
+[22:14:47] [INFO] [BloodDecal] Blood puddle created at (838.6039, 831.6396) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (828.0488, 759.6526) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (826.1907, 746.114) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (777.6039, 768.6613) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (807.9783, 753.7512) (added to group)
+[22:14:48] [ENEMY] [Enemy3] Ragdoll activated
+[22:14:48] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (764.7737, 788.017) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (775.7865, 781.3059) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (818.2181, 806.9435) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (799.5505, 804.6071) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (792.6699, 750.6813) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (873.2317, 743.3622) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (861.3925, 776.4058) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (877.4718, 848.5691) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (864.5609, 792.3086) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (842.8783, 804.2876) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (893.4965, 787.0477) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (858.428, 841.9751) (added to group)
+[22:14:48] [INFO] [BloodDecal] Blood puddle created at (823.6675, 858.9869) (added to group)
+[22:14:48] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(445,897), corner_timer=-0.02
+[22:14:48] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[22:14:48] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(445,893), corner_timer=0.30
+[22:14:48] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(475,810), corner_timer=-0.02
+[22:14:48] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[22:14:48] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(476,807), corner_timer=0.30
+[22:14:48] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=56.4°, current=57.8°, player=(521,733), corner_timer=0.00
+[22:14:48] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(521,733), corner_timer=-0.02
+[22:14:48] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[22:14:48] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(525,729), corner_timer=0.30
+[22:14:49] [ENEMY] [Enemy2] State: PURSUING -> COMBAT
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(560.3096, 694.5176), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:49] [ENEMY] [Enemy3] Death animation completed
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(573.4841, 705.1922), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(586.3105, 706.5172), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(400, 550), source=ENEMY (Enemy2), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:14:49] [INFO] [LastChance] Threat detected: Bullet
+[22:14:49] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:14:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(595.3792, 710.3818), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:49] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 4/4 -> 3/4
+[22:14:49] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:49] [INFO] [ImpactEffects] spawn_blood_effect called at (373.7213, 552.6246), dir=(-0.765309, -0.643663), lethal=false
+[22:14:49] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:49] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:49] [INFO] [ImpactEffects] Blood effect spawned at (373.7213, 552.6246) (scale=0.9)
+[22:14:49] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(601.249, 720.0393), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:49] [INFO] [Player] Spawning blood effect at (601.24896, 720.0393), dir=(1, 0), lethal=False (C#)
+[22:14:49] [INFO] [ImpactEffects] spawn_blood_effect called at (601.249, 720.0393), dir=(1, 0), lethal=false
+[22:14:49] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:49] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:49] [INFO] [ImpactEffects] Blood effect spawned at (601.249, 720.0393) (scale=1)
+[22:14:49] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[22:14:49] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(373.7213, 552.6246), source=ENEMY (Enemy2), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(608.189, 731.2292), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:49] [ENEMY] [Enemy1] PURSUING corner check: angle -138.4°
+[22:14:49] [INFO] [LastChance] Threat detected: Bullet
+[22:14:49] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[22:14:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:49] [ENEMY] [Enemy4] PURSUING corner check: angle -41.1°
+[22:14:49] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(609.9825, 742.4919), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[22:14:49] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 3/4 -> 2/4
+[22:14:49] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:49] [INFO] [ImpactEffects] spawn_blood_effect called at (360.0013, 550.3363), dir=(-0.772502, -0.635012), lethal=false
+[22:14:49] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:49] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:49] [INFO] [ImpactEffects] Blood effect spawned at (360.0013, 550.3363) (scale=0.9)
+[22:14:49] [INFO] [Player] Spawning blood effect at (613.79285, 756.38464), dir=(1, 0), lethal=False (C#)
+[22:14:49] [INFO] [ImpactEffects] spawn_blood_effect called at (613.7928, 756.3846), dir=(1, 0), lethal=false
+[22:14:49] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:49] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:49] [INFO] [ImpactEffects] Blood effect spawned at (613.7928, 756.3846) (scale=1)
+[22:14:49] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[22:14:49] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(613.7928, 759.7604), source=PLAYER (MiniUzi), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=5
+[22:14:49] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 2/4 -> 1/4
+[22:14:49] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:49] [INFO] [ImpactEffects] spawn_blood_effect called at (357.8528, 562.5579), dir=(-0.839144, -0.54391), lethal=false
+[22:14:49] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:49] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:49] [INFO] [ImpactEffects] Blood effect spawned at (357.8528, 562.5579) (scale=0.9)
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(357.8528, 562.5579), source=ENEMY (Enemy2), range=1469, listeners=9
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:14:49] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(619,765), corner_timer=-0.02
+[22:14:49] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[22:14:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(609.9825, 742.4919), shooter_id=839917766978, bullet_pos=(502.3022, 689.5302)
+[22:14:49] [INFO] [Bullet] Using shooter_position, distance=119.999992370605
+[22:14:49] [INFO] [Bullet] Distance to wall: 119.999992370605 (8.17102014104315% of viewport)
+[22:14:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:49] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:49] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(619,769), corner_timer=0.30
+[22:14:49] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 1/4 -> 0/4
+[22:14:49] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:49] [INFO] [ImpactEffects] spawn_blood_effect called at (334.9053, 592.9151), dir=(-0.894867, -0.446333), lethal=true
+[22:14:49] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:49] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:49] [INFO] [ImpactEffects] Blood effect spawned at (334.9053, 592.9151) (scale=1.35)
+[22:14:49] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[22:14:49] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[22:14:49] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 8)
+[22:14:49] [INFO] [DeathAnim] Started - Angle: -153.5 deg, Index: 1
+[22:14:49] [ENEMY] [Enemy2] Death animation started with hit direction: (-0.894867, -0.446333)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (311.3656, 535.1604) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (664.9714, 762.4088) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (321.497, 561.0396) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (646.098, 717.7498) (added to group)
+[22:14:49] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (286.5677, 525.282) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (315.4406, 533.0294) (added to group)
+[22:14:49] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=57.1°, current=33.1°, player=(619,816), corner_timer=0.03
+[22:14:49] [ENEMY] [Enemy1] Player distracted - priority attack triggered
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(336.8803, 381.4922), source=ENEMY (Enemy1), range=1469, listeners=8
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=4, self=1, below_threshold=3
+[22:14:49] [ENEMY] [Enemy1] State: PURSUING -> COMBAT
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (318.6584, 530.2489) (added to group)
+[22:14:49] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-135.6°, current=-140.3°, player=(619,827), corner_timer=0.02
+[22:14:49] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[22:14:49] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(701.793, 914.5683), source=ENEMY (Enemy4), range=1469, listeners=8
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=6
+[22:14:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(406.8369, 610.1422), shooter_id=836662987115, bullet_pos=(934.6132, 858.5978)
+[22:14:49] [INFO] [Bullet] Using shooter_position, distance=583.333435058594
+[22:14:49] [INFO] [Bullet] Distance to wall: 583.333435058594 (39.7202462487424% of viewport)
+[22:14:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:49] [INFO] [LastChance] Threat detected: @Area2D@3597
+[22:14:49] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[22:14:49] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (312.6007, 562.8475) (added to group)
+[22:14:49] [INFO] [Player] Spawning blood effect at (619.02515, 844.4733), dir=(1, 0), lethal=False (C#)
+[22:14:49] [INFO] [ImpactEffects] spawn_blood_effect called at (619.0251, 844.4733), dir=(1, 0), lethal=false
+[22:14:49] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:49] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:49] [INFO] [ImpactEffects] Wall found for blood splatter at (680, 844.4733) (dist=60 px)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (679, 844.4733) (added to group)
+[22:14:49] [INFO] [ImpactEffects] Blood effect spawned at (619.0251, 844.4733) (scale=1)
+[22:14:49] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[22:14:49] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[22:14:49] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (315.7721, 475.356) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (283.6986, 554.3677) (added to group)
+[22:14:49] [ENEMY] [Enemy1] Player distracted - priority attack triggered
+[22:14:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(351.0718, 399.4387), source=ENEMY (Enemy1), range=1469, listeners=8
+[22:14:49] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=1, below_threshold=4
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (297.5759, 521.5444) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (749.1682, 746.4728) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (271.6638, 598.8758) (added to group)
+[22:14:49] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(613.7928, 759.7604), shooter_id=839917766978, bullet_pos=(312.6728, 466.9691)
+[22:14:49] [INFO] [Bullet] Using shooter_position, distance=420.000061035156
+[22:14:49] [INFO] [Bullet] Distance to wall: 420.000061035156 (28.5985764678953% of viewport)
+[22:14:49] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:49] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (251.8448, 596.7213) (added to group)
+[22:14:49] [INFO] [LastChance] Threat detected: @Area2D@3585
+[22:14:49] [INFO] [LastChance] Triggering last chance effect!
+[22:14:49] [INFO] [LastChance] Starting last chance effect:
+[22:14:49] [INFO] [LastChance]   - Time will be frozen (except player)
+[22:14:49] [INFO] [LastChance]   - Duration: 6.0 real seconds
+[22:14:49] [INFO] [LastChance]   - Sepia intensity: 0.70
+[22:14:49] [INFO] [LastChance]   - Brightness: 0.60
+[22:14:49] [INFO] [LastChance] Pushed bullet @Area2D@3585 from distance 124.4 to 200.0
+[22:14:49] [INFO] [LastChance] Pushed 1 threatening bullets away from player
+[22:14:49] [INFO] [LastChance] Set player Player and all 21 children to PROCESS_MODE_ALWAYS
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room1_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room1_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room2_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room2_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room2_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room3_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room3_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room4_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room4_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room5_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room5_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Left' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Right' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBL' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTL' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Desk1' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Desk2' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Table1' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Cabinet1' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Cabinet2' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Desk3' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Desk4' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Table2' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Table3' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'Cabinet3' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'StorageCrate1' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'StorageCrate2' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Set StaticBody2D 'HallTable' to PROCESS_MODE_ALWAYS for collision
+[22:14:49] [INFO] [LastChance] Skipping player node: Player
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: Casing
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3449
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3451
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3453
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3457
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3467
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3474
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3480
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3532
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3534
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3536
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3537
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3539
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3540
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3542
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3544
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3546
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3553
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3586
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3598
+[22:14:49] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@3617
+[22:14:49] [INFO] [LastChance] Froze all nodes except player and autoloads (including GameManager for quick restart)
+[22:14:49] [INFO] [LastChance] Applied visual effects: sepia=0.70, brightness=0.60, ripple=0.0080
+[22:14:49] [INFO] [LastChance] Applied 4.0x saturation to 6 player sprites
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (703.6401, 763.126) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (312.4674, 530.2604) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (244.1406, 571.9902) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (272.3469, 593.2592) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (264.9532, 568.6147) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (769.2744, 799.3845) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (280.2331, 570.9384) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (242.8281, 611.3784) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (315.0477, 563.5799) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (783.4498, 713.3295) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (701.7433, 764.7436) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (241.8078, 620.5488) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (298.3387, 534.0103) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (272.2754, 604.0842) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (228.1281, 479.5483) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (277.4001, 498.0544) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (750.6119, 771.6584) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (241.164, 527.8604) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (255.8462, 540.1788) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (199.2612, 604.9) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (261.7873, 496.6431) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (744.4691, 795.6602) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (244.3366, 521.2534) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (290.429, 584.0923) (added to group)
+[22:14:49] [INFO] [BloodDecal] Blood puddle created at (267.0326, 612.1552) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (815.0936, 827.0383) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (266.6109, 591.9326) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (244.0627, 533.0203) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (269.4961, 601.7877) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (238.1354, 622.7962) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (271.4054, 590.4327) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (194.7137, 546.5353) (added to group)
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: Bullet9mm
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: Bullet9mm
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3657
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3657
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 965.4733), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (285.9621, 570.1741) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (271.8327, 512.7504) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (258.451, 627.1478) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (165.3034, 581.018) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (206.9789, 608.6087) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (769.7351, 809.1176) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (221.4171, 513.8375) (added to group)
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3665
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3665
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3666
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3666
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 981.6956), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (138.9898, 574.6703) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (142.1884, 665.1564) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (218.6309, 629.6804) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (121.9304, 627.4574) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (237.0556, 575.829) (added to group)
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (700.3774, 911.2495) (added to group)
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3673
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3673
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3674
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3674
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 983.994), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (220.3946, 545.7495) (added to group)
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3676
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3676
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3677
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3677
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 983.994), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [BloodDecal] Blood puddle created at (775.1121, 979.6913) (added to group)
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3679
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3679
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3680
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3680
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 983.994), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3681
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3681
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3682
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3682
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 983.994), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3683
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3683
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3684
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3684
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 983.994), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3685
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3685
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3686
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3686
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 983.994), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3687
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3687
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3688
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3688
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 983.5997), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3689
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3689
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3690
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3690
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 980.5997), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3691
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3691
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3692
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3692
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 974.5997), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:50] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3693
+[22:14:50] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3693
+[22:14:50] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3694
+[22:14:50] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3694
+[22:14:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(619.0251, 965.5997), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:50] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[22:14:52] [INFO] [ScoreManager] Combo ended at 2. Max combo: 2
+[22:14:52] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[22:14:52] [ENEMY] [Enemy1] Player reloading: false -> true
+[22:14:52] [ENEMY] [Enemy4] Player reloading: false -> true
+[22:14:52] [ENEMY] [Enemy5] Player reloading: false -> true
+[22:14:52] [ENEMY] [Enemy6] Player reloading: false -> true
+[22:14:52] [ENEMY] [Enemy7] Player reloading: false -> true
+[22:14:52] [ENEMY] [Enemy8] Player reloading: false -> true
+[22:14:52] [ENEMY] [Enemy9] Player reloading: false -> true
+[22:14:52] [ENEMY] [Enemy10] Player reloading: false -> true
+[22:14:52] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(357.1801, 630.6527), source=PLAYER (Player), range=900, listeners=8
+[22:14:52] [ENEMY] [Enemy1] Heard player RELOAD at (357.1801, 630.6527), intensity=0.05, distance=231
+[22:14:52] [ENEMY] [Enemy4] Heard player RELOAD at (357.1801, 630.6527), intensity=0.01, distance=469
+[22:14:52] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=0
+[22:14:53] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[22:14:53] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[22:14:53] [ENEMY] [Enemy1] Player reloading: true -> false
+[22:14:53] [ENEMY] [Enemy4] Player reloading: true -> false
+[22:14:53] [ENEMY] [Enemy5] Player reloading: true -> false
+[22:14:53] [ENEMY] [Enemy6] Player reloading: true -> false
+[22:14:53] [ENEMY] [Enemy7] Player reloading: true -> false
+[22:14:53] [ENEMY] [Enemy8] Player reloading: true -> false
+[22:14:53] [ENEMY] [Enemy9] Player reloading: true -> false
+[22:14:53] [ENEMY] [Enemy10] Player reloading: true -> false
+[22:14:53] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[22:14:53] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[22:14:54] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3695
+[22:14:54] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3695
+[22:14:54] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3696
+[22:14:54] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3696
+[22:14:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(405.3435, 482.4121), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:54] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[22:14:54] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3697
+[22:14:54] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3697
+[22:14:54] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3698
+[22:14:54] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3698
+[22:14:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(405.3435, 482.4121), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:54] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[22:14:54] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3699
+[22:14:54] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3699
+[22:14:54] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3700
+[22:14:54] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3700
+[22:14:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(405.3435, 482.4121), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:54] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[22:14:54] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3701
+[22:14:54] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3701
+[22:14:54] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3702
+[22:14:54] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3702
+[22:14:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(405.3435, 480.4121), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:54] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[22:14:54] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3703
+[22:14:54] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3703
+[22:14:54] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3704
+[22:14:54] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3704
+[22:14:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(405.3435, 475.4121), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:54] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[22:14:54] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@3705
+[22:14:54] [INFO] [LastChance] Registered frozen player bullet: @Area2D@3705
+[22:14:54] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@3706
+[22:14:54] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@3706
+[22:14:54] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(405.3435, 467.4121), source=PLAYER (MiniUzi), range=1469, listeners=8
+[22:14:54] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[22:14:55] [INFO] [LastChance] Effect duration expired after 6.00 real seconds
+[22:14:55] [INFO] [LastChance] Ending last chance effect
+[22:14:55] [ENEMY] [Enemy1] Memory reset: confusion=2.0s, had_target=true
+[22:14:55] [ENEMY] [Enemy1] Search mode: COMBAT -> SEARCHING at (619.0251, 866.4733)
+[22:14:55] [ENEMY] [Enemy1] SEARCHING started: center=(619.0251, 866.4733), radius=100, waypoints=5
+[22:14:55] [ENEMY] [Enemy4] Memory reset: confusion=2.0s, had_target=true
+[22:14:55] [ENEMY] [Enemy4] Search mode: COMBAT -> SEARCHING at (619.0251, 866.4733)
+[22:14:55] [ENEMY] [Enemy4] SEARCHING started: center=(619.0251, 866.4733), radius=100, waypoints=5
+[22:14:55] [ENEMY] [Enemy5] Memory reset: confusion=2.0s, had_target=false
+[22:14:55] [ENEMY] [Enemy6] Memory reset: confusion=2.0s, had_target=false
+[22:14:55] [ENEMY] [Enemy7] Memory reset: confusion=2.0s, had_target=false
+[22:14:55] [ENEMY] [Enemy8] Memory reset: confusion=2.0s, had_target=false
+[22:14:55] [ENEMY] [Enemy9] Memory reset: confusion=2.0s, had_target=false
+[22:14:55] [ENEMY] [Enemy10] Memory reset: confusion=2.0s, had_target=false
+[22:14:55] [INFO] [LastChance] Reset memory for 8 enemies (player teleport effect)
+[22:14:55] [INFO] [LastChance] All process modes restored
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: Bullet9mm
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3665
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3673
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3676
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3679
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3681
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3683
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3685
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3687
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3689
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3691
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3693
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3695
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3697
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3699
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3701
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3703
+[22:14:55] [INFO] [LastChance] Unfroze player bullet: @Area2D@3705
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: Casing
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3449
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3451
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3453
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3457
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3467
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3474
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3480
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3532
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3534
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3536
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3537
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3539
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3540
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3542
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3544
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3546
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3553
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3586
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3598
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3617
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3657
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3666
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3674
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3677
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3680
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3682
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3684
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3686
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3688
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3690
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3692
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3694
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3696
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3698
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3700
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3702
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3704
+[22:14:55] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@3706
+[22:14:55] [INFO] [LastChance] Restored original colors to 5 player sprites
+[22:14:55] [INFO] [LastChance] Called player RefreshHealthVisual (C#)
+[22:14:55] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P2:combat_state, state=SEARCHING, target=-69.2°, current=63.9°, player=(483,124), corner_timer=0.03
+[22:14:55] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=SEARCHING, target=-106.4°, current=-151.0°, player=(483,124), corner_timer=0.02
+[22:14:55] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(483,124), corner_timer=-0.02
+[22:14:55] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[22:14:55] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 3/3 -> 2/3
+[22:14:55] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:55] [INFO] [ImpactEffects] spawn_blood_effect called at (380.932, 405.3455), dir=(-0.4089, -0.912579), lethal=false
+[22:14:55] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:55] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:55] [INFO] [ImpactEffects] Blood effect spawned at (380.932, 405.3455) (scale=0.9)
+[22:14:55] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(488,123), corner_timer=0.30
+[22:14:55] [INFO] [BloodyFeet:Enemy4] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:14:55] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 2/3 -> 1/3
+[22:14:55] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:55] [INFO] [ImpactEffects] spawn_blood_effect called at (382.9788, 410.0532), dir=(-0.537327, -0.843374), lethal=false
+[22:14:55] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:55] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:55] [INFO] [ImpactEffects] Blood effect spawned at (382.9788, 410.0532) (scale=0.9)
+[22:14:55] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 1/3 -> 0/3
+[22:14:55] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:55] [INFO] [ImpactEffects] spawn_blood_effect called at (382.9788, 410.0532), dir=(-0.538434, -0.842668), lethal=true
+[22:14:55] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:55] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:55] [INFO] [ImpactEffects] Blood effect spawned at (382.9788, 410.0532) (scale=1.35)
+[22:14:55] [ENEMY] [Enemy1] Enemy died (ricochet: false, penetration: false)
+[22:14:55] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:14:55] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 7)
+[22:14:55] [INFO] [DeathAnim] Started - Angle: -122.6 deg, Index: 3
+[22:14:55] [ENEMY] [Enemy1] Death animation started with hit direction: (-0.538434, -0.842668)
+[22:14:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(406.8369, 610.1422), shooter_id=836662987115, bullet_pos=(647.5621, 1008.317)
+[22:14:55] [INFO] [Bullet] Using shooter_position, distance=465.287170410156
+[22:14:55] [INFO] [Bullet] Distance to wall: 465.287170410156 (31.6822590208901% of viewport)
+[22:14:55] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(608.189, 731.2292), shooter_id=839917766978, bullet_pos=(54.22278, 452.8025)
+[22:14:55] [INFO] [Bullet] Using shooter_position, distance=620
+[22:14:55] [INFO] [Bullet] Distance to wall: 620 (42.2169400794704% of viewport)
+[22:14:55] [INFO] [Bullet] Distance-based penetration chance: 97.4135699072846%
+[22:14:55] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:55] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 3/3 -> 2/3
+[22:14:55] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:55] [INFO] [ImpactEffects] spawn_blood_effect called at (706.6934, 928.4417), dir=(0.790937, -0.611898), lethal=false
+[22:14:55] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:55] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:55] [INFO] [ImpactEffects] Wall found for blood splatter at (756.3831, 890) (dist=62 px)
+[22:14:55] [INFO] [BloodDecal] Blood puddle created at (756.3831, 891) (added to group)
+[22:14:55] [INFO] [ImpactEffects] Blood effect spawned at (706.6934, 928.4417) (scale=0.9)
+[22:14:55] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 2/3 -> 1/3
+[22:14:55] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:55] [INFO] [ImpactEffects] spawn_blood_effect called at (706.6934, 928.4417), dir=(0.827062, -0.562111), lethal=false
+[22:14:55] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:55] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:55] [INFO] [ImpactEffects] Blood effect spawned at (706.6934, 928.4417) (scale=0.9)
+[22:14:55] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 1/3 -> 0/3
+[22:14:55] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:55] [INFO] [ImpactEffects] spawn_blood_effect called at (706.6934, 928.4417), dir=(0.832145, -0.554558), lethal=true
+[22:14:55] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:55] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:14:55] [INFO] [ImpactEffects] Blood effect spawned at (706.6934, 928.4417) (scale=1.35)
+[22:14:55] [ENEMY] [Enemy4] Enemy died (ricochet: false, penetration: false)
+[22:14:55] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[22:14:55] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 6)
+[22:14:55] [INFO] [DeathAnim] Started - Angle: -33.7 deg, Index: 9
+[22:14:55] [ENEMY] [Enemy4] Death animation started with hit direction: (0.832145, -0.554558)
+[22:14:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(619.0251, 965.5997), shooter_id=839917766978, bullet_pos=(733.4878, 884.9878)
+[22:14:55] [INFO] [Bullet] Using shooter_position, distance=139.999938964844
+[22:14:55] [INFO] [Bullet] Distance to wall: 139.999938964844 (9.53285328130373% of viewport)
+[22:14:55] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:55] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(619.0251, 965.4733), shooter_id=839917766978, bullet_pos=(734.0851, 885.7163)
+[22:14:55] [INFO] [Bullet] Using shooter_position, distance=139.999893188477
+[22:14:55] [INFO] [Bullet] Distance to wall: 139.999893188477 (9.53285016430672% of viewport)
+[22:14:55] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:55] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(406.8369, 610.1422), shooter_id=836662987115, bullet_pos=(505.9875, 943.9482)
+[22:14:55] [INFO] [Bullet] Using shooter_position, distance=348.220153808594
+[22:14:55] [INFO] [Bullet] Distance to wall: 348.220153808594 (23.710950593228% of viewport)
+[22:14:55] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:55] [INFO] [Bullet] Starting wall penetration at (505.9875, 943.9482)
+[22:14:55] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:55] [INFO] [Bullet] Raycast backward hit penetrating body at distance 28.5268230438232
+[22:14:55] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(367.0913, 442.4668), shooter_id=836360996471, bullet_pos=(745.7299, 1002.193)
+[22:14:55] [INFO] [Bullet] Using shooter_position, distance=675.766235351563
+[22:14:55] [INFO] [Bullet] Distance to wall: 675.766235351563 (46.0141655896229% of viewport)
+[22:14:55] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:55] [INFO] [Bullet] Exiting penetration at (474.0313, 929.4188) after traveling 30.1041698455811 pixels through wall
+[22:14:55] [INFO] [Bullet] Damage multiplier after penetration: 0.225
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(405.3435, 475.4121), shooter_id=839917766978, bullet_pos=(313.0154, 275.7236)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=219.999969482422
+[22:14:56] [INFO] [Bullet] Distance to wall: 219.999969482422 (14.9802024663302% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(405.3435, 482.4121), shooter_id=839917766978, bullet_pos=(291.7434, 271)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=240.000137329102
+[22:14:56] [INFO] [Bullet] Distance to wall: 240.000137329102 (16.3420506720764% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(405.3435, 482.4121), shooter_id=839917766978, bullet_pos=(265.411, 263.2799)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=260.000030517578
+[22:14:56] [INFO] [Bullet] Distance to wall: 260.000030517578 (17.7038801758404% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(378.5927, 461.6737), shooter_id=836360996471, bullet_pos=(695.215, 1000.539)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=624.999938964844
+[22:14:56] [INFO] [Bullet] Distance to wall: 624.999938964844 (42.5573951176636% of viewport)
+[22:14:56] [INFO] [Bullet] Distance-based penetration chance: 97.0163723627258%
+[22:14:56] [INFO] [Bullet] Starting wall penetration at (695.215, 1000.539)
+[22:14:56] [INFO] [Bullet] Raycast backward hit penetrating body at distance 19.4550247192383
+[22:14:56] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:56] [INFO] [Bullet] Exiting penetration at (718.8561, 1040.774) after traveling 41.6666679382324 pixels through wall
+[22:14:56] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(619.0251, 980.5997), shooter_id=839917766978, bullet_pos=(914.7187, 812.7756)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=339.999450683594
+[22:14:56] [INFO] [Bullet] Distance to wall: 339.999450683594 (23.1511878009066% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(619.0251, 983.994), shooter_id=839917766978, bullet_pos=(912.1185, 811.6687)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=339.999542236328
+[22:14:56] [INFO] [Bullet] Distance to wall: 339.999542236328 (23.1511940349007% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(619.0251, 983.994), shooter_id=839917766978, bullet_pos=(915.7501, 817.9991)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=339.999938964844
+[22:14:56] [INFO] [Bullet] Distance to wall: 339.999938964844 (23.1512210488748% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(619.0251, 983.994), shooter_id=839917766978, bullet_pos=(912.6788, 812.6243)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=340
+[22:14:56] [INFO] [Bullet] Distance to wall: 340 (23.1512252048708% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(619.0251, 981.6956), shooter_id=839917766978, bullet_pos=(910.5123, 806.6653)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=340.00048828125
+[22:14:56] [INFO] [Bullet] Distance to wall: 340.00048828125 (23.151258452839% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (372.6494, 361.5216) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (345.6818, 395.0275) (added to group)
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(619.0251, 983.994), shooter_id=839917766978, bullet_pos=(915.3154, 779.5142)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=359.999847412109
+[22:14:56] [INFO] [Bullet] Distance to wall: 359.999847412109 (24.5130515916379% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(619.0251, 983.994), shooter_id=839917766978, bullet_pos=(925.9832, 795.9069)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=359.999938964844
+[22:14:56] [INFO] [Bullet] Distance to wall: 359.999938964844 (24.5130578256319% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (350.383, 345.5206) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (725.8389, 903.1814) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (770.7301, 891.8943) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (744.3741, 895.5305) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (758.4476, 916.9112) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (788.5164, 923.2225) (added to group)
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(367.0913, 442.4668), shooter_id=836360996471, bullet_pos=(922.4088, 689.4861)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=607.779602050781
+[22:14:56] [INFO] [Bullet] Distance to wall: 607.779602050781 (41.3848307117777% of viewport)
+[22:14:56] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(591,120), corner_timer=-0.02
+[22:14:56] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (348.9934, 342.868) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (768.2316, 896.9024) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (782.8492, 917.4124) (added to group)
+[22:14:56] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(597,120), corner_timer=0.30
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (329.357, 358.915) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (331.271, 368.8402) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (329.197, 393.3178) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (348.5032, 366.1695) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (325.4597, 398.2364) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (746.5133, 918.0198) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (747.3798, 896.9956) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (799.36, 886.0196) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (344.1077, 377.1315) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (775.0492, 941.3978) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (337.2372, 383.5375) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (770.1533, 941.2515) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (800.6578, 902.1566) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (796.3316, 914.6882) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (268.6796, 369.2095) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (763.077, 943.248) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (777.9238, 952.5856) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (344.5943, 318.1281) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (343.9799, 316.3851) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (738.9509, 902.322) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (288.8, 352.6231) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (737.7671, 910.3045) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (762.8948, 891.9888) (added to group)
+[22:14:56] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (381.0134, 311.364) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (322.2073, 392.5655) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (311.202, 347.2362) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (364.5255, 374.7979) (added to group)
+[22:14:56] [ENEMY] [Enemy1] Ragdoll activated
+[22:14:56] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (346.9797, 295.5983) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (333.5536, 342.5325) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (297.1175, 371.6482) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (358.9221, 301.1309) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (786.5587, 890.0078) (added to group)
+[22:14:56] [ENEMY] [Enemy4] Ragdoll activated
+[22:14:56] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (320.4314, 370.0575) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (837.3306, 904.2021) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (784.383, 934.5386) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (779.7573, 949.493) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (287.9709, 366.6345) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (839.8704, 959.5065) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (781.2647, 927.2374) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (327.4945, 319.0801) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (296.6567, 414.0425) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (345.0931, 302.0052) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (333.2202, 409.6338) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (290.5287, 380.1649) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (310.7558, 334.2107) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (253.6736, 340.0292) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (334.6283, 386.8212) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (820.2544, 958.0256) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (872.1876, 959.4001) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (245.4332, 340.1909) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (346.4335, 361.3139) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (827.8786, 944.9902) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (892.583, 928.4887) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (879.5964, 963.5618) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (800.7936, 901.2327) (added to group)
+[22:14:56] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(701,120), corner_timer=-0.02
+[22:14:56] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (281.1457, 363.4703) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (853.6109, 960.8444) (added to group)
+[22:14:56] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(707,120), corner_timer=0.30
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (378.418, 394.7628) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (858.5147, 929.9904) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (285.9625, 399.5246) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (298.6476, 410.3642) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (235.1445, 337.751) (added to group)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (900.2401, 937.7285) (added to group)
+[22:14:56] [INFO] [BloodyFeet:Enemy1] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:14:56] [INFO] [BloodDecal] Blood puddle created at (778.9771, 959.3611) (added to group)
+[22:14:56] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(367.0913, 442.4668), shooter_id=836360996471, bullet_pos=(414.2501, 48.71178)
+[22:14:56] [INFO] [Bullet] Using shooter_position, distance=396.569030761719
+[22:14:56] [INFO] [Bullet] Distance to wall: 396.569030761719 (27.0031145307115% of viewport)
+[22:14:56] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:56] [INFO] [Bullet] Starting wall penetration at (414.2501, 48.71178)
+[22:14:56] [INFO] [Bullet] Raycast backward hit penetrating body at distance 13.7751512527466
+[22:14:56] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:56] [INFO] [Bullet] Exiting penetration at (392.4376, 21.20687) after traveling 30.1041717529297 pixels through wall
+[22:14:56] [INFO] [Bullet] Damage multiplier after penetration: 0.225
+[22:14:56] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:56] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(811,120), corner_timer=-0.02
+[22:14:56] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:14:56] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(817,120), corner_timer=0.30
+[22:14:56] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:57] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(921,120), corner_timer=-0.02
+[22:14:57] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:14:57] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(927,120), corner_timer=0.30
+[22:14:57] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:57] [ENEMY] [Enemy1] Death animation completed
+[22:14:57] [ENEMY] [Enemy4] Death animation completed
+[22:14:57] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(1028,129), corner_timer=-0.02
+[22:14:57] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:14:57] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(1032,131), corner_timer=0.30
+[22:14:57] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:57] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(1111,185), corner_timer=-0.02
+[22:14:57] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:57] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1117,185), corner_timer=0.30
+[22:14:57] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:58] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(1221,186), corner_timer=-0.02
+[22:14:58] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:58] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1227,186), corner_timer=0.30
+[22:14:58] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:58] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(1329,180), corner_timer=-0.02
+[22:14:58] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:58] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1333,177), corner_timer=0.30
+[22:14:58] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:58] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(1410,111), corner_timer=-0.02
+[22:14:58] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:58] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1414,108), corner_timer=0.30
+[22:14:58] [INFO] [ScoreManager] Combo ended at 2. Max combo: 2
+[22:14:58] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:59] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(1507,121), corner_timer=-0.02
+[22:14:59] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:14:59] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(1511,125), corner_timer=0.30
+[22:14:59] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1546.801, 160.0135), source=PLAYER (MiniUzi), range=1469, listeners=6
+[22:14:59] [ENEMY] [Enemy5] Heard gunshot at (1546.801, 160.0135), source_type=0, intensity=0.04, distance=244
+[22:14:59] [ENEMY] [Enemy6] Heard gunshot at (1546.801, 160.0135), source_type=0, intensity=0.01, distance=497
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=0, below_threshold=2
+[22:14:59] [ENEMY] [Enemy5] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-128.9°, current=56.2°, player=(1546,160), corner_timer=0.00
+[22:14:59] [ENEMY] [Enemy6] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-144.3°, current=-22.5°, player=(1546,160), corner_timer=0.00
+[22:14:59] [ENEMY] [Enemy6] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-143.2°, current=-169.6°, player=(1546,148), corner_timer=0.00
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1555.582, 165.546), source=PLAYER (MiniUzi), range=1469, listeners=6
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=0, below_threshold=2
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1554.513, 185.2086), source=PLAYER (MiniUzi), range=1469, listeners=6
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=0, below_threshold=2
+[22:14:59] [ENEMY] [Enemy7] Memory: high confidence (0.90) - transitioning to PURSUING
+[22:14:59] [ENEMY] [Enemy7] State: IDLE -> PURSUING
+[22:14:59] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P2:combat_state, state=PURSUING, target=-94.7°, current=89.4°, player=(1551,173), corner_timer=0.05
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1543.809, 185.0383), source=PLAYER (MiniUzi), range=1469, listeners=6
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=0, below_threshold=3
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1897.382, 413.5966), source=ENEMY (Enemy6), range=1469, listeners=6
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:14:59] [ENEMY] [Enemy7] PURSUING corner check: angle 83.5°
+[22:14:59] [INFO] [LastChance] Threat detected: Bullet
+[22:14:59] [INFO] [LastChance] Effect already used this life
+[22:14:59] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:59] [ENEMY] [Enemy6] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-154.4°, current=-154.4°, player=(1552,236), corner_timer=0.00
+[22:14:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1835.73, 385.1705), shooter_id=837870947527, bullet_pos=(1657.812, 276.7841)
+[22:14:59] [INFO] [Bullet] Using shooter_position, distance=208.333084106445
+[22:14:59] [INFO] [Bullet] Distance to wall: 208.333084106445 (14.1857827875695% of viewport)
+[22:14:59] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:59] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:59] [ENEMY] [Enemy6] Hit taken, damage: 1, health: 3/3 -> 2/3
+[22:14:59] [ENEMY] [Enemy6] ImpactEffectsManager found, calling spawn_blood_effect
+[22:14:59] [INFO] [ImpactEffects] spawn_blood_effect called at (1890.279, 398.6483), dir=(0.824473, 0.565901), lethal=false
+[22:14:59] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:14:59] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:14:59] [INFO] [ImpactEffects] Blood effect spawned at (1890.279, 398.6483) (scale=0.9)
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (86 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [ENEMY] [Enemy5] State: COMBAT -> RETREATING
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (83 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [ENEMY] [Enemy5] State: RETREATING -> IN_COVER
+[22:14:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1554.513, 185.2086), shooter_id=839917766978, bullet_pos=(1842.218, 325.3009)
+[22:14:59] [INFO] [Bullet] Using shooter_position, distance=320.000091552734
+[22:14:59] [INFO] [Bullet] Distance to wall: 320.000091552734 (21.7893946621078% of viewport)
+[22:14:59] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:59] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:14:59] [ENEMY] [Enemy5] State: IN_COVER -> SUPPRESSED
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (83 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (79 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (78 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (77 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [ENEMY] [Enemy6] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-153.6°, current=-153.6°, player=(1583,248), corner_timer=0.00
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (76 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (76 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (143 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [ENEMY] [Enemy6] State: COMBAT -> RETREATING
+[22:14:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1835.73, 385.1705), shooter_id=837870947527, bullet_pos=(1979.617, 48.44691)
+[22:14:59] [INFO] [Bullet] Using shooter_position, distance=366.177520751953
+[22:14:59] [INFO] [Bullet] Distance to wall: 366.177520751953 (24.9337007290874% of viewport)
+[22:14:59] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (75 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (139 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (75 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (137 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (135 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [ENEMY] [Enemy5] ROT_CHANGE: P2:combat_state -> P1:visible, state=SUPPRESSED, target=-123.4°, current=-133.7°, player=(1618,226), corner_timer=0.00
+[22:14:59] [ENEMY] [Enemy5] Player distracted - priority attack triggered
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1700, 350), source=ENEMY (Enemy5), range=1469, listeners=6
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (134 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1836.251, 381.7743), source=ENEMY (Enemy6), range=1469, listeners=6
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:14:59] [ENEMY] [Enemy7] PURSUING corner check: angle 95.4°
+[22:14:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1656.289, 297.847), shooter_id=837568956636, bullet_pos=(1656.289, 297.847)
+[22:14:59] [INFO] [Bullet] Using shooter_position, distance=0
+[22:14:59] [INFO] [Bullet] Distance to wall: 0 (0% of viewport)
+[22:14:59] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:14:59] [INFO] [Bullet] Starting wall penetration at (1656.289, 297.847)
+[22:14:59] [INFO] [LastChance] Threat detected: @Area2D@3879
+[22:14:59] [INFO] [LastChance] Effect already used this life
+[22:14:59] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (132 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [Bullet] Raycast backward hit penetrating body at distance 20.5021305084229
+[22:14:59] [INFO] [BloodDecal] Blood puddle created at (1926.208, 457.0409) (added to group)
+[22:14:59] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:14:59] [INFO] [Bullet] Exiting penetration at (1630.609, 258.881) after traveling 41.6666679382324 pixels through wall
+[22:14:59] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (131 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (131 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [BloodDecal] Blood puddle created at (1952.414, 457.6151) (added to group)
+[22:14:59] [INFO] [BloodDecal] Blood puddle created at (1971.959, 434.1026) (added to group)
+[22:14:59] [INFO] [BloodDecal] Blood puddle created at (1932.517, 471.3651) (added to group)
+[22:14:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1777.505, 349.3563), shooter_id=837870947527, bullet_pos=(1663.128, 298.9296)
+[22:14:59] [INFO] [Bullet] Using shooter_position, distance=124.999977111816
+[22:14:59] [INFO] [Bullet] Distance to wall: 124.999977111816 (8.51147829623342% of viewport)
+[22:14:59] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:14:59] [INFO] [Bullet] Starting wall penetration at (1663.128, 298.9296)
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1711.371, 360.8554), source=ENEMY (Enemy5), range=1469, listeners=6
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:14:59] [INFO] [EnemyGrenade] Unsafe throw distance (130 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1830.148, 390.3179), source=ENEMY (Enemy6), range=1469, listeners=6
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:14:59] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:14:59] [INFO] [Bullet] Exiting penetration at (1620.427, 280.1037) after traveling 41.6666679382324 pixels through wall
+[22:14:59] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:14:59] [INFO] [BloodDecal] Blood puddle created at (1945.135, 504.0125) (added to group)
+[22:14:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1673.383, 303.3677), shooter_id=837568956636, bullet_pos=(1645.634, 272.2856)
+[22:14:59] [INFO] [Bullet] Using shooter_position, distance=41.6666946411133
+[22:14:59] [INFO] [Bullet] Distance to wall: 41.6666946411133 (2.83716185640882% of viewport)
+[22:14:59] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:14:59] [INFO] [Bullet] Starting wall penetration at (1645.634, 272.2856)
+[22:14:59] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:14:59] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:14:59] [INFO] [Bullet] Exiting penetration at (1614.555, 237.4736) after traveling 41.6666679382324 pixels through wall
+[22:14:59] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:14:59] [ENEMY] [Enemy5] Player distracted - priority attack triggered
+[22:14:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1711.371, 360.8554), source=ENEMY (Enemy5), range=1469, listeners=6
+[22:14:59] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:14:59] [INFO] [BloodDecal] Blood puddle created at (1923.756, 481.9009) (added to group)
+[22:15:00] [INFO] [LastChance] Threat detected: @Area2D@3896
+[22:15:00] [INFO] [LastChance] Effect already used this life
+[22:15:00] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:00] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1824.858, 399.5803), source=ENEMY (Enemy6), range=1469, listeners=6
+[22:15:00] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:15:00] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1718.17, 373.5248), source=ENEMY (Enemy5), range=1469, listeners=6
+[22:15:00] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:15:00] [INFO] [LastChance] Threat detected: @Area2D@3900
+[22:15:00] [INFO] [LastChance] Effect already used this life
+[22:15:00] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:00] [INFO] [LastChance] Threat detected: @Area2D@3902
+[22:15:00] [INFO] [LastChance] Effect already used this life
+[22:15:00] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:00] [ENEMY] [Enemy6] ROT_CHANGE: P1:visible -> P4:velocity, state=RETREATING, target=119.7°, current=156.7°, player=(1657,202), corner_timer=0.00
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1950.931, 538.2155) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1947.899, 507.1091) (added to group)
+[22:15:00] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1718.17, 373.5248), source=ENEMY (Enemy5), range=1469, listeners=6
+[22:15:00] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:15:00] [INFO] [LastChance] Threat detected: @Area2D@3907
+[22:15:00] [INFO] [LastChance] Effect already used this life
+[22:15:00] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:00] [INFO] [Player] Spawning blood effect at (1667.0461, 197.20525), dir=(1, 0), lethal=True (C#)
+[22:15:00] [INFO] [ImpactEffects] spawn_blood_effect called at (1667.046, 197.2052), dir=(1, 0), lethal=true
+[22:15:00] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:00] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:15:00] [INFO] [ImpactEffects] Blood effect spawned at (1667.046, 197.2052) (scale=1.5)
+[22:15:00] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[22:15:00] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[22:15:00] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[22:15:00] [INFO] [LastChance] Player died
+[22:15:00] [ENEMY] [Enemy5] Player distracted - priority attack triggered
+[22:15:00] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1718.17, 373.5248), source=ENEMY (Enemy5), range=1469, listeners=6
+[22:15:00] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:15:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1678.444, 301.3036), shooter_id=837568956636, bullet_pos=(1567.502, 31.56054)
+[22:15:00] [INFO] [Bullet] Using shooter_position, distance=291.666748046875
+[22:15:00] [INFO] [Bullet] Distance to wall: 291.666748046875 (19.8601252023692% of viewport)
+[22:15:00] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:00] [INFO] [Bullet] Starting wall penetration at (1567.502, 31.56054)
+[22:15:00] [INFO] [LastChance] Threat detected: @Area2D@3913
+[22:15:00] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:15:00] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:00] [INFO] [Bullet] Raycast backward hit penetrating body at distance 47.1418647766113
+[22:15:00] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:00] [INFO] [Bullet] Exiting penetration at (1549.752, -11.59835) after traveling 41.6666717529297 pixels through wall
+[22:15:00] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1687.147, 312.6719), shooter_id=837568956636, bullet_pos=(1565.841, 47.42812)
+[22:15:00] [INFO] [Bullet] Using shooter_position, distance=291.666687011719
+[22:15:00] [INFO] [Bullet] Distance to wall: 291.666687011719 (19.8601210463732% of viewport)
+[22:15:00] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1776.436, 351.7819), shooter_id=837870947527, bullet_pos=(1365.659, 66.71661)
+[22:15:00] [INFO] [Bullet] Using shooter_position, distance=500.000244140625
+[22:15:00] [INFO] [Bullet] Distance to wall: 500.000244140625 (34.0459360429118% of viewport)
+[22:15:00] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (2035.932, 512.191) (added to group)
+[22:15:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1835.73, 385.1705), shooter_id=837870947527, bullet_pos=(2477.898, 445.5908)
+[22:15:00] [INFO] [Bullet] Using shooter_position, distance=645.00390625
+[22:15:00] [INFO] [Bullet] Distance to wall: 645.00390625 (43.9195020341622% of viewport)
+[22:15:00] [INFO] [Bullet] Distance-based penetration chance: 95.4272476268108%
+[22:15:00] [INFO] [Bullet] Starting wall penetration at (2477.898, 445.5908)
+[22:15:00] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1722.515, 389.1647), source=ENEMY (Enemy5), range=1469, listeners=6
+[22:15:00] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=4
+[22:15:00] [INFO] [Bullet] Raycast backward hit penetrating body at distance 11.9560060501099
+[22:15:00] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:00] [INFO] [Bullet] Exiting penetration at (2505.35, 467.4704) after traveling 30.1041660308838 pixels through wall
+[22:15:00] [INFO] [Bullet] Damage multiplier after penetration: 0.225
+[22:15:00] [INFO] [LastChance] Threat detected: @Area2D@3926
+[22:15:00] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:15:00] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:00] [ENEMY] [Enemy5] State: SUPPRESSED -> SEEKING_COVER
+[22:15:00] [ENEMY] [Enemy5] ROT_CHANGE: P1:visible -> P4:velocity, state=SEEKING_COVER, target=-164.7°, current=-164.3°, player=(1673,193), corner_timer=0.00
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (100 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (99 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (98 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (97 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1776.436, 351.7819), shooter_id=837870947527, bullet_pos=(1123.462, 223.1673)
+[22:15:00] [INFO] [Bullet] Using shooter_position, distance=665.520263671875
+[22:15:00] [INFO] [Bullet] Distance to wall: 665.520263671875 (45.3164985372723% of viewport)
+[22:15:00] [INFO] [Bullet] Distance-based penetration chance: 93.7974183731823%
+[22:15:00] [INFO] [Bullet] Starting wall penetration at (1123.462, 223.1673)
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (96 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:15:00] [INFO] [Bullet] Exiting penetration at (1089.512, 245.0975) after traveling 35.4166717529297 pixels through wall
+[22:15:00] [INFO] [Bullet] Damage multiplier after penetration: 0.45
+[22:15:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1698.07, 325.4054), shooter_id=837568956636, bullet_pos=(1688.394, 33.89922)
+[22:15:00] [INFO] [Bullet] Using shooter_position, distance=291.666687011719
+[22:15:00] [INFO] [Bullet] Distance to wall: 291.666687011719 (19.8601210463732% of viewport)
+[22:15:00] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:00] [INFO] [Bullet] Starting wall penetration at (1688.394, 33.89922)
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (95 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:15:00] [INFO] [Bullet] Raycast backward hit penetrating body at distance 44.7663955688477
+[22:15:00] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:00] [INFO] [Bullet] Exiting penetration at (1686.846, -12.74175) after traveling 41.6666679382324 pixels through wall
+[22:15:00] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:00] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1543.809, 185.0383), shooter_id=839917766978, bullet_pos=(2469.205, 614.0465)
+[22:15:00] [INFO] [Bullet] Using shooter_position, distance=1020.00274658203
+[22:15:00] [INFO] [Bullet] Distance to wall: 1020.00274658203 (69.4538626344335% of viewport)
+[22:15:00] [INFO] [Bullet] Distance-based penetration chance: 65.6371602598275%
+[22:15:00] [INFO] [Bullet] Penetration failed (distance roll)
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (94 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (94 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (2097.719, 541.3396) (added to group)
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (93 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1725.53, 188.1179) (added to group)
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (92 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1757.165, 204.3949) (added to group)
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (91 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (91 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (90 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1754.49, 187.6184) (added to group)
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (89 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [ENEMY] [Enemy5] State: SEEKING_COVER -> IN_COVER
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1782.22, 198.0536) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1771.126, 248.8343) (added to group)
+[22:15:00] [INFO] [EnemyGrenade] Unsafe throw distance (89 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:15:00] [ENEMY] [Enemy5] State: IN_COVER -> SUPPRESSED
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1795.424, 239.1163) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1775.578, 235.2261) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1750.28, 225.5587) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1801.431, 288.0694) (added to group)
+[22:15:00] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:15:00] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:15:00] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:15:00] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:15:00] [ENEMY] [Enemy1] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:15:00] [ENEMY] [Enemy2] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:15:00] [ENEMY] [Enemy3] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:15:00] [ENEMY] [Enemy4] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:15:00] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:00] [ENEMY] [Enemy5] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:15:00] [ENEMY] [Enemy6] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:15:00] [ENEMY] [Enemy7] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:15:00] [ENEMY] [Enemy8] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:15:00] [ENEMY] [Enemy9] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:15:00] [ENEMY] [Enemy10] Death animation component initialized
+[22:15:00] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:00] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:15:00] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:15:00] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:15:00] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:15:00] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:15:00] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:15:00] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:15:00] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:15:00] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:15:00] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:15:00] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:15:00] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[22:15:00] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:15:00] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:15:00] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:15:00] [INFO] [ScoreManager] Level started with 10 enemies
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1775.611, 187.2762) (added to group)
+[22:15:00] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 7)
+[22:15:00] [ENEMY] [Enemy1] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[22:15:00] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 8)
+[22:15:00] [ENEMY] [Enemy2] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:15:00] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 9)
+[22:15:00] [ENEMY] [Enemy3] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:15:00] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 10)
+[22:15:00] [ENEMY] [Enemy4] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[22:15:00] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 11)
+[22:15:00] [ENEMY] [Enemy5] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[22:15:00] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 12)
+[22:15:00] [ENEMY] [Enemy6] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[22:15:00] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 13)
+[22:15:00] [ENEMY] [Enemy7] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[22:15:00] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 14)
+[22:15:00] [ENEMY] [Enemy8] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[22:15:00] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 15)
+[22:15:00] [ENEMY] [Enemy9] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:15:00] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:15:00] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 16)
+[22:15:00] [ENEMY] [Enemy10] Registered as sound listener
+[22:15:00] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[22:15:00] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:15:00] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:00] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:00] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:00] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:00] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:00] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:00] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=213.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:00] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:00] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:15:00] [INFO] [Player] Detected weapon: Mini UZI (SMG pose)
+[22:15:00] [INFO] [Player] Applied SMG arm pose: Left=(14, 6), Right=(1, 6)
+[22:15:00] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:15:00] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:15:00] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:15:00] [INFO] [LastChance] Found player: Player
+[22:15:00] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:15:00] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:15:00] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1746.941, 268.7008) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1752.441, 214.1501) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1808.796, 243.7356) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1835.748, 203.5514) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1752.712, 233.442) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1792.632, 293.6198) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1784.567, 352.0522) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1857.029, 340.0353) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1831.096, 270.8026) (added to group)
+[22:15:00] [INFO] [BloodDecal] Blood puddle created at (1800.818, 302.3669) (added to group)
+[22:15:02] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:15:02] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:15:02] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(451,825), corner_timer=0.30
+[22:15:02] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(451,825), corner_timer=0.30
+[22:15:02] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=164.0°, current=123.7°, player=(453,820), corner_timer=0.00
+[22:15:02] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[22:15:02] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=165.9°, current=-65.6°, player=(456,811), corner_timer=0.00
+[22:15:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(486.0708, 774.8732), source=PLAYER (MiniUzi), range=1469, listeners=16
+[22:15:02] [INFO] [SoundPropagation] Cleaned up 6 invalid listeners
+[22:15:02] [ENEMY] [Enemy1] Heard gunshot at (486.0708, 774.8732), source_type=0, intensity=0.01, distance=464
+[22:15:02] [ENEMY] [Enemy2] Heard gunshot at (486.0708, 774.8732), source_type=0, intensity=0.04, distance=241
+[22:15:02] [ENEMY] [Enemy4] Heard gunshot at (486.0708, 774.8732), source_type=0, intensity=0.02, distance=338
+[22:15:02] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:15:02] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=66.3°, current=-33.8°, player=(486,774), corner_timer=0.00
+[22:15:02] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=69.1°, current=-157.5°, player=(486,774), corner_timer=0.00
+[22:15:02] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-158.3°, current=168.8°, player=(486,774), corner_timer=0.00
+[22:15:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(476.8346, 769.9297), source=PLAYER (MiniUzi), range=1469, listeners=10
+[22:15:02] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:15:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(467.3974, 765.4728), source=PLAYER (MiniUzi), range=1469, listeners=10
+[22:15:02] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:15:02] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(463,757), corner_timer=-0.02
+[22:15:02] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:15:02] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(463,757), corner_timer=-0.02
+[22:15:02] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:15:02] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(465,765), corner_timer=0.30
+[22:15:02] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(465,765), corner_timer=0.30
+[22:15:02] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 3/3 -> 2/3
+[22:15:02] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:15:02] [INFO] [ImpactEffects] spawn_blood_effect called at (689.7003, 752.7737), dir=(0.979978, -0.199107), lethal=false
+[22:15:02] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:02] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:02] [INFO] [ImpactEffects] Blood effect spawned at (689.7003, 752.7737) (scale=0.9)
+[22:15:02] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=174.7°, current=168.5°, player=(467,773), corner_timer=0.00
+[22:15:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(689.7003, 752.7737), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:02] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:02] [INFO] [LastChance] Threat detected: Bullet
+[22:15:02] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:15:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:02] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=162.7°, current=162.7°, player=(479,821), corner_timer=0.00
+[22:15:02] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[22:15:02] [ENEMY] [Enemy3] State: RETREATING -> IN_COVER
+[22:15:02] [ENEMY] [Enemy3] State: IN_COVER -> SUPPRESSED
+[22:15:02] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(623.8429, 766.7139), shooter_id=1016950951641, bullet_pos=(43.02917, 820.8734)
+[22:15:02] [INFO] [Bullet] Using shooter_position, distance=583.333374023438
+[22:15:02] [INFO] [Bullet] Distance to wall: 583.333374023438 (39.7202420927463% of viewport)
+[22:15:02] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:02] [INFO] [Bullet] Starting wall penetration at (43.02917, 820.8734)
+[22:15:02] [INFO] [Bullet] Raycast backward hit penetrating body at distance 35.5896492004395
+[22:15:02] [INFO] [BloodDecal] Blood puddle created at (728.8801, 750.2841) (added to group)
+[22:15:02] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:02] [INFO] [Bullet] Exiting penetration at (-3.435921, 825.2061) after traveling 41.6666679382324 pixels through wall
+[22:15:02] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:02] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(476.8346, 769.9297), shooter_id=1019903741833, bullet_pos=(926.4716, 672.8381)
+[22:15:02] [INFO] [Bullet] Using shooter_position, distance=460.000274658203
+[22:15:02] [INFO] [Bullet] Distance to wall: 460.000274658203 (31.3222645673956% of viewport)
+[22:15:02] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:02] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:15:02] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(479,839), corner_timer=-0.02
+[22:15:02] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:15:02] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(480,841), corner_timer=0.30
+[22:15:02] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(467.3974, 765.4728), shooter_id=1019903741833, bullet_pos=(927.5693, 628.9391)
+[22:15:02] [INFO] [Bullet] Using shooter_position, distance=479.999633789063
+[22:15:02] [INFO] [Bullet] Distance to wall: 479.999633789063 (32.6840577061945% of viewport)
+[22:15:02] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:02] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:15:02] [INFO] [BloodDecal] Blood puddle created at (741.9708, 775.0622) (added to group)
+[22:15:02] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[22:15:02] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[22:15:02] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:15:02] [INFO] [BloodDecal] Blood puddle created at (819.5757, 745.7124) (added to group)
+[22:15:02] [INFO] [BloodDecal] Blood puddle created at (771.1223, 776.4788) (added to group)
+[22:15:02] [INFO] [BloodDecal] Blood puddle created at (851.9699, 828.9703) (added to group)
+[22:15:03] [INFO] [BloodDecal] Blood puddle created at (864.8823, 802.9738) (added to group)
+[22:15:03] [INFO] [BloodDecal] Blood puddle created at (831.6413, 852.3663) (added to group)
+[22:15:03] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(476,889), corner_timer=-0.02
+[22:15:03] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[22:15:03] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(473,888), corner_timer=0.30
+[22:15:03] [INFO] [BloodDecal] Blood puddle created at (864.9034, 818.0316) (added to group)
+[22:15:03] [INFO] [BloodDecal] Blood puddle created at (903.7772, 852.5638) (added to group)
+[22:15:03] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(449,825), corner_timer=-0.02
+[22:15:03] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[22:15:03] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=SUPPRESSED, target=165.0°, current=161.7°, player=(449,819), corner_timer=0.00
+[22:15:03] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(449,819), corner_timer=0.30
+[22:15:03] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(701.8611, 752.6583), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:03] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:03] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(636.0643, 772.3799), shooter_id=1016950951641, bullet_pos=(522.2549, 824.0756)
+[22:15:03] [INFO] [Bullet] Using shooter_position, distance=125.000053405762
+[22:15:03] [INFO] [Bullet] Distance to wall: 125.000053405762 (8.51148349122845% of viewport)
+[22:15:03] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:03] [INFO] [Bullet] Starting wall penetration at (522.2549, 824.0756)
+[22:15:03] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(701.8611, 752.6583), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:03] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:03] [INFO] [Bullet] Raycast backward hit penetrating body at distance 22.2234325408936
+[22:15:03] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:03] [INFO] [Bullet] Exiting penetration at (479.7661, 843.3752) after traveling 41.6666717529297 pixels through wall
+[22:15:03] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:03] [INFO] [LastChance] Threat detected: @Area2D@4222
+[22:15:03] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:15:03] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:03] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(701.8611, 752.6583), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:03] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:03] [INFO] [LastChance] Threat detected: Bullet
+[22:15:03] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:15:03] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:03] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(701.8611, 752.6583), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:03] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:03] [INFO] [Player] Spawning blood effect at (472.26968, 738.51447), dir=(1, 0), lethal=False (C#)
+[22:15:03] [INFO] [ImpactEffects] spawn_blood_effect called at (472.2697, 738.5145), dir=(1, 0), lethal=false
+[22:15:03] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:03] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:03] [INFO] [ImpactEffects] Blood effect spawned at (472.2697, 738.5145) (scale=1)
+[22:15:03] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[22:15:03] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[22:15:03] [ENEMY] [Enemy3] State: SUPPRESSED -> SEEKING_COVER
+[22:15:03] [INFO] [LastChance] Threat detected: @Area2D@4223
+[22:15:03] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[22:15:03] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:03] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(701.8611, 752.6583), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:03] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:03] [INFO] [BloodyFeet:Enemy3] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:15:03] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(479,732), corner_timer=-0.02
+[22:15:03] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[22:15:03] [INFO] [LastChance] Threat detected: Bullet
+[22:15:03] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[22:15:03] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:03] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(482,730), corner_timer=0.30
+[22:15:03] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(633.4524, 757.2497), shooter_id=1016950951641, bullet_pos=(474.0427, 708.6049)
+[22:15:03] [INFO] [Bullet] Using shooter_position, distance=166.666625976563
+[22:15:03] [INFO] [Bullet] Distance to wall: 166.666625976563 (11.3486370356452% of viewport)
+[22:15:03] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:03] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(634.6793, 766.9257), shooter_id=1016950951641, bullet_pos=(55.57631, 837.0513)
+[22:15:03] [INFO] [Bullet] Using shooter_position, distance=583.333435058594
+[22:15:03] [INFO] [Bullet] Distance to wall: 583.333435058594 (39.7202462487424% of viewport)
+[22:15:03] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:03] [INFO] [Bullet] Starting wall penetration at (55.57631, 837.0513)
+[22:15:03] [INFO] [Bullet] Raycast backward hit penetrating body at distance 22.9181232452393
+[22:15:03] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:03] [INFO] [Bullet] Exiting penetration at (9.248077, 842.6613) after traveling 41.6666679382324 pixels through wall
+[22:15:03] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:03] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(686.6573, 770.3732), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:03] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:03] [INFO] [LastChance] Threat detected: @Area2D@4227
+[22:15:03] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[22:15:03] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:03] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=57.6°, current=58.1°, player=(519,737), corner_timer=0.00
+[22:15:03] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[22:15:03] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(633.4524, 757.2497), shooter_id=1016950951641, bullet_pos=(255.5374, 469.7125)
+[22:15:03] [INFO] [Bullet] Using shooter_position, distance=474.865631103516
+[22:15:03] [INFO] [Bullet] Distance to wall: 474.865631103516 (32.3344740227371% of viewport)
+[22:15:03] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:03] [INFO] [Bullet] Starting wall penetration at (255.5374, 469.7125)
+[22:15:03] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:15:03] [INFO] [Bullet] Exiting penetration at (228.2594, 439.8894) after traveling 35.4166717529297 pixels through wall
+[22:15:03] [INFO] [Bullet] Damage multiplier after penetration: 0.45
+[22:15:03] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[22:15:03] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(672.9803, 786.8227), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:03] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:04] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(635.8745, 755.2238), shooter_id=1016950951641, bullet_pos=(54.2063, 711.1799)
+[22:15:04] [INFO] [Bullet] Using shooter_position, distance=583.333312988281
+[22:15:04] [INFO] [Bullet] Distance to wall: 583.333312988281 (39.7202379367503% of viewport)
+[22:15:04] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:04] [INFO] [Bullet] Starting wall penetration at (54.2063, 711.1799)
+[22:15:04] [INFO] [LastChance] Threat detected: @Area2D@4231
+[22:15:04] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[22:15:04] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:04] [INFO] [Bullet] Raycast backward hit penetrating body at distance 24.3968067169189
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (550.9477, 793.7933) (added to group)
+[22:15:04] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:04] [INFO] [Bullet] Exiting penetration at (7.672832, 707.6564) after traveling 41.6666679382324 pixels through wall
+[22:15:04] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:04] [INFO] [Player] Spawning blood effect at (542.6429, 757.8082), dir=(1, 0), lethal=False (C#)
+[22:15:04] [INFO] [ImpactEffects] spawn_blood_effect called at (542.6429, 757.8082), dir=(1, 0), lethal=false
+[22:15:04] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:04] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:04] [INFO] [ImpactEffects] Blood effect spawned at (542.6429, 757.8082) (scale=1)
+[22:15:04] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[22:15:04] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[22:15:04] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[22:15:04] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (566.4984, 805.9126) (added to group)
+[22:15:04] [ENEMY] [Enemy2] State: PURSUING -> RETREATING
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (534.9985, 749.2455) (added to group)
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (557.6217, 764.0275) (added to group)
+[22:15:04] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P4:velocity, state=SEEKING_COVER, target=128.4°, current=137.5°, player=(554,769), corner_timer=0.00
+[22:15:04] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:15:04] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:15:04] [ENEMY] [Enemy1] State: PURSUING -> RETREATING
+[22:15:04] [ENEMY] [Enemy1] State: RETREATING -> IN_COVER
+[22:15:04] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[22:15:04] [ENEMY] [Enemy2] Player distracted - priority attack triggered
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (614.812, 742.3603) (added to group)
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (608.496, 742.773) (added to group)
+[22:15:04] [ENEMY] [Enemy2] ROT_CHANGE: P1:visible -> P4:velocity, state=RETREATING, target=103.7°, current=49.7°, player=(581,796), corner_timer=0.00
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (622.6435, 796.285) (added to group)
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (582.2867, 768.9153) (added to group)
+[22:15:04] [ENEMY] [Enemy2] State: RETREATING -> IN_COVER
+[22:15:04] [ENEMY] [Enemy2] State: IN_COVER -> SUPPRESSED
+[22:15:04] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(600.9794, 816.1447), source=PLAYER (MiniUzi), range=1469, listeners=10
+[22:15:04] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=6
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (616.2894, 748.3593) (added to group)
+[22:15:04] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(593,818), corner_timer=-0.02
+[22:15:04] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[22:15:04] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(594,822), corner_timer=0.30
+[22:15:04] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(594.8297, 826.0891), source=PLAYER (MiniUzi), range=1469, listeners=10
+[22:15:04] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=6
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (619.9116, 818.6678) (added to group)
+[22:15:04] [ENEMY] [Enemy4] PURSUING corner check: angle -47.8°
+[22:15:04] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(584.4269, 835.4438), source=PLAYER (MiniUzi), range=1469, listeners=10
+[22:15:04] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=6
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (654.3589, 784.6203) (added to group)
+[22:15:04] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(594.8297, 826.0891), shooter_id=1019903741833, bullet_pos=(694.4006, 816.8362)
+[22:15:04] [INFO] [Bullet] Using shooter_position, distance=99.9999313354492
+[22:15:04] [INFO] [Bullet] Distance to wall: 99.9999313354492 (6.80917920829002% of viewport)
+[22:15:04] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:04] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (623.9716, 845.9705) (added to group)
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (647.5261, 837.33) (added to group)
+[22:15:04] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:15:04] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(584.4269, 835.4438), shooter_id=1019903741833, bullet_pos=(684.3054, 830.5192)
+[22:15:04] [INFO] [Bullet] Using shooter_position, distance=99.999870300293
+[22:15:04] [INFO] [Bullet] Distance to wall: 99.999870300293 (6.80917505229399% of viewport)
+[22:15:04] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:04] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (634.4591, 797.8623) (added to group)
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (671.9897, 800.4818) (added to group)
+[22:15:04] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-161.1°, current=-171.9°, player=(575,851), corner_timer=0.22
+[22:15:04] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[22:15:04] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(765.3517, 916.487), source=ENEMY (Enemy4), range=1469, listeners=10
+[22:15:04] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:04] [INFO] [LastChance] Threat detected: Bullet
+[22:15:04] [INFO] [LastChance] Triggering last chance effect!
+[22:15:04] [INFO] [LastChance] Starting last chance effect:
+[22:15:04] [INFO] [LastChance]   - Time will be frozen (except player)
+[22:15:04] [INFO] [LastChance]   - Duration: 6.0 real seconds
+[22:15:04] [INFO] [LastChance]   - Sepia intensity: 0.70
+[22:15:04] [INFO] [LastChance]   - Brightness: 0.60
+[22:15:04] [INFO] [LastChance] Pushed bullet Bullet from distance 131.9 to 200.0
+[22:15:04] [INFO] [LastChance] Pushed 1 threatening bullets away from player
+[22:15:04] [INFO] [LastChance] Set player Player and all 21 children to PROCESS_MODE_ALWAYS
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room1_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room1_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room2_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room2_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room2_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room3_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room3_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room4_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room4_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room5_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room5_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Left' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Right' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBL' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTL' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Desk1' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Desk2' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Table1' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Cabinet1' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Cabinet2' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Desk3' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Desk4' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Table2' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Table3' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'Cabinet3' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'StorageCrate1' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'StorageCrate2' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Set StaticBody2D 'HallTable' to PROCESS_MODE_ALWAYS for collision
+[22:15:04] [INFO] [LastChance] Skipping player node: Player
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: Casing
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4206
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4208
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4209
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4224
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4228
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4232
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4246
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4249
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4252
+[22:15:04] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@4261
+[22:15:04] [INFO] [LastChance] Froze all nodes except player and autoloads (including GameManager for quick restart)
+[22:15:04] [INFO] [LastChance] Applied visual effects: sepia=0.70, brightness=0.60, ripple=0.0080
+[22:15:04] [INFO] [LastChance] Applied 4.0x saturation to 6 player sprites
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (641.5465, 870.3531) (added to group)
+[22:15:04] [INFO] [BloodDecal] Blood puddle created at (701.9717, 787.7535) (added to group)
+[22:15:05] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:15:05] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:15:05] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:15:05] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:15:05] [INFO] [LastChance] Ending last chance effect
+[22:15:05] [ENEMY] [Enemy1] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [ENEMY] [Enemy2] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [ENEMY] [Enemy3] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [ENEMY] [Enemy4] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [ENEMY] [Enemy5] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [ENEMY] [Enemy6] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [ENEMY] [Enemy7] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [ENEMY] [Enemy8] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [ENEMY] [Enemy9] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [ENEMY] [Enemy10] Memory reset: confusion=2.0s, had_target=false
+[22:15:05] [INFO] [LastChance] Reset memory for 10 enemies (player teleport effect)
+[22:15:05] [INFO] [LastChance] All process modes restored
+[22:15:05] [INFO] [LastChance] Restored original colors to 5 player sprites
+[22:15:05] [ENEMY] [Enemy1] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:15:05] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:05] [ENEMY] [Enemy2] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:15:05] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:05] [ENEMY] [Enemy3] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:15:05] [ENEMY] [Enemy4] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:15:05] [ENEMY] [Enemy5] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:15:05] [ENEMY] [Enemy6] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:15:05] [ENEMY] [Enemy7] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:15:05] [ENEMY] [Enemy8] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:15:05] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:05] [ENEMY] [Enemy9] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:15:05] [ENEMY] [Enemy10] Death animation component initialized
+[22:15:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:05] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:15:05] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:15:05] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:15:05] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:15:05] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:15:05] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:15:05] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:15:05] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:15:05] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:15:05] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:15:05] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:15:05] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[22:15:05] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:15:05] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:15:05] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:15:05] [INFO] [ScoreManager] Level started with 10 enemies
+[22:15:05] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[22:15:05] [ENEMY] [Enemy1] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[22:15:05] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[22:15:05] [ENEMY] [Enemy2] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[22:15:05] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[22:15:05] [ENEMY] [Enemy3] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[22:15:05] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[22:15:05] [ENEMY] [Enemy4] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[22:15:05] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[22:15:05] [ENEMY] [Enemy5] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 3, behavior: GUARD
+[22:15:05] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[22:15:05] [ENEMY] [Enemy6] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:15:05] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[22:15:05] [ENEMY] [Enemy7] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[22:15:05] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[22:15:05] [ENEMY] [Enemy8] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:15:05] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[22:15:05] [ENEMY] [Enemy9] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:15:05] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:15:05] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[22:15:05] [ENEMY] [Enemy10] Registered as sound listener
+[22:15:05] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:15:05] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:15:05] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:05] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:05] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:05] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:05] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:05] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:05] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=157.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:05] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:05] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:15:05] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:15:05] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:15:05] [INFO] [LastChance] Found player: Player
+[22:15:05] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:15:05] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:15:05] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:15:05] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:15:05] [INFO] [Player] Detected weapon: Mini UZI (SMG pose)
+[22:15:05] [INFO] [Player] Applied SMG arm pose: Left=(14, 6), Right=(1, 6)
+[22:15:07] [INFO] [PauseMenu] Armory button pressed
+[22:15:07] [INFO] [PauseMenu] Creating new armory menu instance
+[22:15:07] [INFO] [PauseMenu] armory_menu_scene resource path: res://scenes/ui/ArmoryMenu.tscn
+[22:15:07] [INFO] [PauseMenu] Instance created, class: CanvasLayer, name: ArmoryMenu
+[22:15:07] [INFO] [PauseMenu] Script attached: res://scripts/ui/armory_menu.gd
+[22:15:07] [INFO] [PauseMenu] back_pressed signal exists on instance
+[22:15:07] [INFO] [PauseMenu] back_pressed signal connected
+[22:15:07] [INFO] [PauseMenu] Armory menu instance added as child, is_inside_tree: true
+[22:15:07] [INFO] [PauseMenu] _populate_weapon_grid method exists
+[22:15:08] [INFO] [GameManager] Weapon selected: m16
+[22:15:08] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:15:08] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:15:08] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:15:08] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:15:08] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:08] [ENEMY] [Enemy1] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:15:08] [ENEMY] [Enemy2] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:15:08] [ENEMY] [Enemy3] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:15:08] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:08] [ENEMY] [Enemy4] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:15:08] [ENEMY] [Enemy5] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:15:08] [ENEMY] [Enemy6] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:15:08] [ENEMY] [Enemy7] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:15:08] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:08] [ENEMY] [Enemy8] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:15:08] [ENEMY] [Enemy9] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:15:08] [ENEMY] [Enemy10] Death animation component initialized
+[22:15:08] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:08] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:15:08] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:15:08] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:15:08] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:15:08] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:15:08] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:15:08] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:15:08] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:15:08] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:15:08] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:15:08] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:15:08] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[22:15:08] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:15:08] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:15:08] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:15:08] [INFO] [ScoreManager] Level started with 10 enemies
+[22:15:08] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 21)
+[22:15:08] [ENEMY] [Enemy1] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[22:15:08] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 22)
+[22:15:08] [ENEMY] [Enemy2] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[22:15:08] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 23)
+[22:15:08] [ENEMY] [Enemy3] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:15:08] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 24)
+[22:15:08] [ENEMY] [Enemy4] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[22:15:08] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 25)
+[22:15:08] [ENEMY] [Enemy5] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:15:08] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 26)
+[22:15:08] [ENEMY] [Enemy6] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[22:15:08] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 27)
+[22:15:08] [ENEMY] [Enemy7] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[22:15:08] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 28)
+[22:15:08] [ENEMY] [Enemy8] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:15:08] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 29)
+[22:15:08] [ENEMY] [Enemy9] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:15:08] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:15:08] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 30)
+[22:15:08] [ENEMY] [Enemy10] Registered as sound listener
+[22:15:08] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:15:08] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:15:08] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450, 1256), source=PLAYER (AssaultRifle), range=1469, listeners=30
+[22:15:08] [INFO] [SoundPropagation] Cleaned up 20 invalid listeners
+[22:15:08] [ENEMY] [Enemy4] Heard gunshot at (450, 1256), source_type=0, intensity=0.01, distance=499
+[22:15:08] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=6
+[22:15:08] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:08] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:08] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:08] [ENEMY] [Enemy4] ROT_CHANGE: none -> P2:combat_state, state=COMBAT, target=135.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:08] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:08] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:08] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=157.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:08] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:08] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:15:08] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:15:08] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:15:08] [INFO] [LastChance] Found player: Player
+[22:15:08] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:15:08] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:15:08] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:15:08] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:15:08] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:15:08] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:15:08] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(730.1733, 950.6833), source=ENEMY (Enemy4), range=1469, listeners=10
+[22:15:08] [ENEMY] [Enemy3] Heard gunshot at (730.1733, 950.6833), source_type=1, intensity=0.06, distance=203
+[22:15:08] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=1, below_threshold=7
+[22:15:08] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(694.7737, 1008.799), shooter_id=1190477695316, bullet_pos=(694.7737, 1008.799)
+[22:15:08] [INFO] [Bullet] Using shooter_position, distance=0
+[22:15:08] [INFO] [Bullet] Distance to wall: 0 (0% of viewport)
+[22:15:08] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:15:08] [INFO] [Bullet] Starting wall penetration at (694.7737, 1008.799)
+[22:15:08] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=114.7°, current=-57.3°, player=(425,1344), corner_timer=0.00
+[22:15:08] [INFO] [Bullet] Raycast backward hit penetrating body at distance 27.3956298828125
+[22:15:08] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:08] [INFO] [Bullet] Exiting penetration at (666.0889, 1045.609) after traveling 41.6666717529297 pixels through wall
+[22:15:08] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:09] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(728.4092, 971.1793), source=ENEMY (Enemy4), range=1469, listeners=10
+[22:15:09] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=1, below_threshold=7
+[22:15:09] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:15:09] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:15:09] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:15:09] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:15:09] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:15:09] [ENEMY] [Enemy1] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:15:09] [ENEMY] [Enemy2] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:15:09] [ENEMY] [Enemy3] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:15:09] [ENEMY] [Enemy4] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:15:09] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:09] [ENEMY] [Enemy5] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:15:09] [ENEMY] [Enemy6] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:15:09] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:09] [ENEMY] [Enemy7] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:15:09] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:15:09] [ENEMY] [Enemy8] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:15:09] [ENEMY] [Enemy9] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:15:09] [ENEMY] [Enemy10] Death animation component initialized
+[22:15:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:15:09] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:15:09] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:15:09] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:15:09] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[22:15:09] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:15:09] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:15:09] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:15:09] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:15:09] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:15:09] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:15:09] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:15:09] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[22:15:09] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:15:09] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:15:09] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:15:09] [INFO] [ScoreManager] Level started with 10 enemies
+[22:15:09] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[22:15:09] [ENEMY] [Enemy1] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[22:15:09] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[22:15:09] [ENEMY] [Enemy2] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:15:09] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[22:15:09] [ENEMY] [Enemy3] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[22:15:09] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[22:15:09] [ENEMY] [Enemy4] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[22:15:09] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[22:15:09] [ENEMY] [Enemy5] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:15:09] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[22:15:09] [ENEMY] [Enemy6] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[22:15:09] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[22:15:09] [ENEMY] [Enemy7] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[22:15:09] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[22:15:09] [ENEMY] [Enemy8] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:15:09] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[22:15:09] [ENEMY] [Enemy9] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[22:15:09] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:15:09] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[22:15:09] [ENEMY] [Enemy10] Registered as sound listener
+[22:15:09] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[22:15:09] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:15:09] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:09] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:09] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:09] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:09] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:09] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:09] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=213.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:09] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:15:09] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:15:09] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:15:09] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:15:09] [INFO] [LastChance] Found player: Player
+[22:15:09] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:15:09] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:15:09] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:15:09] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:15:09] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:15:09] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:15:10] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:15:10] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:15:10] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,836), corner_timer=0.30
+[22:15:10] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,836), corner_timer=0.30
+[22:15:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(496.0098, 778.6395), source=PLAYER (AssaultRifle), range=1469, listeners=20
+[22:15:11] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[22:15:11] [ENEMY] [Enemy1] Heard gunshot at (496.0098, 778.6395), source_type=0, intensity=0.01, distance=471
+[22:15:11] [ENEMY] [Enemy2] Heard gunshot at (496.0098, 778.6395), source_type=0, intensity=0.04, distance=248
+[22:15:11] [ENEMY] [Enemy3] Heard gunshot at (496.0098, 778.6395), source_type=0, intensity=0.06, distance=206
+[22:15:11] [ENEMY] [Enemy4] Heard gunshot at (496.0098, 778.6395), source_type=0, intensity=0.02, distance=327
+[22:15:11] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:15:11] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=65.1°, current=-33.8°, player=(496,772), corner_timer=0.00
+[22:15:11] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=66.7°, current=-157.5°, player=(496,772), corner_timer=0.00
+[22:15:11] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=173.7°, current=11.3°, player=(496,772), corner_timer=0.00
+[22:15:11] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-157.3°, current=-101.3°, player=(496,772), corner_timer=0.00
+[22:15:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(494,769), corner_timer=-0.02
+[22:15:11] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:15:11] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(494,769), corner_timer=-0.02
+[22:15:11] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:15:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(495,768), corner_timer=0.30
+[22:15:11] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(495,768), corner_timer=0.30
+[22:15:11] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 4/4 -> 3/4
+[22:15:11] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:15:11] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(1, 0), lethal=false
+[22:15:11] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:11] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:11] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[22:15:11] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=175.2°, current=180.0°, player=(496,766), corner_timer=0.00
+[22:15:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(502.2019, 770.2795), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:11] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:15:11] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=175.9°, current=-125.4°, player=(502,764), corner_timer=0.00
+[22:15:11] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 3/4 -> 2/4
+[22:15:11] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:15:11] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(1, 0), lethal=false
+[22:15:11] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:11] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:11] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[22:15:11] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=176.9°, current=180.0°, player=(504,760), corner_timer=0.00
+[22:15:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:11] [INFO] [LastChance] Threat detected: Bullet
+[22:15:11] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:15:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(509.9515, 765.0735), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:11] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[22:15:11] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[22:15:11] [INFO] [Player] Spawning blood effect at (508.82663, 773.71594), dir=(1, 0), lethal=False (C#)
+[22:15:11] [INFO] [ImpactEffects] spawn_blood_effect called at (508.8266, 773.7159), dir=(1, 0), lethal=false
+[22:15:11] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:11] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:11] [INFO] [ImpactEffects] Blood effect spawned at (508.8266, 773.7159) (scale=1)
+[22:15:11] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[22:15:11] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[22:15:11] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 2/4 -> 1/4
+[22:15:11] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[22:15:11] [INFO] [ImpactEffects] spawn_blood_effect called at (719.7776, 753.8479), dir=(1, 0), lethal=false
+[22:15:11] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:11] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:11] [INFO] [ImpactEffects] Blood effect spawned at (719.7776, 753.8479) (scale=1)
+[22:15:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(721.1548, 755.4772), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:11] [INFO] [LastChance] Threat detected: Bullet
+[22:15:11] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[22:15:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (757.9728, 769.746) (added to group)
+[22:15:11] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.1°, player=(513,774), corner_timer=-0.00
+[22:15:11] [ENEMY] [Enemy10] PATROL corner check: angle 7.2°
+[22:15:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(654.4221, 769.4938), shooter_id=1219619720457, bullet_pos=(525.8958, 804.9728)
+[22:15:11] [INFO] [Bullet] Using shooter_position, distance=133.333374023438
+[22:15:11] [INFO] [Bullet] Distance to wall: 133.333374023438 (9.0789146157114% of viewport)
+[22:15:11] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:11] [INFO] [Bullet] Starting wall penetration at (525.8958, 804.9728)
+[22:15:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(728.3403, 763.3579), source=ENEMY (Enemy3), range=1469, listeners=10
+[22:15:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:11] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.2°, current=16.2°, player=(513,774), corner_timer=0.30
+[22:15:11] [INFO] [Bullet] Raycast backward hit penetrating body at distance 11.4690866470337
+[22:15:11] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:11] [INFO] [Bullet] Exiting penetration at (488.9444, 815.173) after traveling 33.3333358764648 pixels through wall
+[22:15:11] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:11] [INFO] [LastChance] Threat detected: @Area2D@5080
+[22:15:11] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[22:15:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (779.882, 810.9952) (added to group)
+[22:15:11] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P4:velocity, state=RETREATING, target=53.1°, current=112.6°, player=(513,774), corner_timer=0.00
+[22:15:11] [INFO] [BloodyFeet:Enemy3] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (742.8164, 776.7161) (added to group)
+[22:15:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(662.6837, 774.426), shooter_id=1219619720457, bullet_pos=(498.9822, 805.7249)
+[22:15:11] [INFO] [Bullet] Using shooter_position, distance=166.666702270508
+[22:15:11] [INFO] [Bullet] Distance to wall: 166.666702270508 (11.3486422306402% of viewport)
+[22:15:11] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:11] [INFO] [Bullet] Starting wall penetration at (498.9822, 805.7249)
+[22:15:11] [INFO] [Bullet] Raycast backward hit penetrating body at distance 39.3695945739746
+[22:15:11] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:11] [INFO] [Bullet] Exiting penetration at (461.3308, 812.9236) after traveling 33.3333320617676 pixels through wall
+[22:15:11] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:11] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-145.5°, current=-174.6°, player=(513,774), corner_timer=0.00
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (744.9015, 775.4218) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (789.0671, 782.273) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (769.2566, 748.5061) (added to group)
+[22:15:11] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[22:15:11] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (835.8679, 760.1973) (added to group)
+[22:15:11] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[22:15:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(712.6121, 914.0652), source=ENEMY (Enemy4), range=1469, listeners=10
+[22:15:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (805.1754, 769.0117) (added to group)
+[22:15:11] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-146.2°, current=-145.0°, player=(513,774), corner_timer=0.00
+[22:15:11] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (833.9322, 779.7982) (added to group)
+[22:15:11] [INFO] [LastChance] Threat detected: Bullet
+[22:15:11] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[22:15:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (561.3845, 794.1721) (added to group)
+[22:15:11] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-146.5°, current=-146.3°, player=(513,776), corner_timer=0.00
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (586.3973, 831.9158) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (763.2192, 785.7255) (added to group)
+[22:15:11] [INFO] [Player] Spawning blood effect at (513.46545, 777.67084), dir=(1, 0), lethal=False (C#)
+[22:15:11] [INFO] [ImpactEffects] spawn_blood_effect called at (513.4655, 777.6708), dir=(1, 0), lethal=false
+[22:15:11] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:11] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:11] [INFO] [ImpactEffects] Blood effect spawned at (513.4655, 777.6708) (scale=1)
+[22:15:11] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[22:15:11] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (777.8536, 802.2986) (added to group)
+[22:15:11] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=PURSUING, target=-146.9°, current=-146.7°, player=(513,778), corner_timer=0.00
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (860.4473, 849.5607) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (822.7542, 872.3851) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (786.7065, 815.4982) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (606.5666, 796.4689) (added to group)
+[22:15:11] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=7.1°, player=(513,783), corner_timer=-0.01
+[22:15:11] [ENEMY] [Enemy10] PATROL corner check: angle 3.7°
+[22:15:11] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.7°, current=9.3°, player=(513,783), corner_timer=0.30
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (850.3065, 823.3645) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (641.3973, 804.8291) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (877.0032, 861.7034) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (803.6262, 840.9075) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (856.8372, 799.0645) (added to group)
+[22:15:11] [INFO] [BloodDecal] Blood puddle created at (636.0249, 791.7343) (added to group)
+[22:15:12] [ENEMY] [Enemy3] State: RETREATING -> IN_COVER
+[22:15:12] [ENEMY] [Enemy3] State: IN_COVER -> SUPPRESSED
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (846.0875, 766.592) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (818.1542, 853.3567) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (887.4302, 914.3355) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (663.2917, 881.0408) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (849.941, 810.3569) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (872.1655, 890.3833) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (809.2113, 824.5594) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (579.1494, 774.7245) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (578.3707, 786.0787) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (591.4464, 776.6069) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (877.7471, 875.1259) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (698.5629, 973.605) (added to group)
+[22:15:12] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.7°, player=(513,783), corner_timer=-0.01
+[22:15:12] [ENEMY] [Enemy10] PATROL corner check: angle 2.0°
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (898.1346, 792.4288) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (603.3638, 844.1848) (added to group)
+[22:15:12] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=2.0°, current=5.9°, player=(513,783), corner_timer=0.30
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (599.8959, 792.7192) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (645.9095, 829.7125) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (680.5728, 929.0983) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (617.4594, 910.5304) (added to group)
+[22:15:12] [INFO] [BloodDecal] Blood puddle created at (669.1617, 844.8604) (added to group)
+[22:15:12] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=2.0°, player=(513,783), corner_timer=-0.01
+[22:15:12] [ENEMY] [Enemy10] PATROL corner check: angle 1.1°
+[22:15:12] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.1°, current=4.2°, player=(513,783), corner_timer=0.30
+[22:15:12] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-146.4°, current=-146.7°, player=(525,783), corner_timer=0.00
+[22:15:12] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[22:15:12] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-146.0°, current=-146.2°, player=(528,784), corner_timer=0.00
+[22:15:13] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.0°, player=(531,784), corner_timer=-0.01
+[22:15:13] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:15:13] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.6°, current=3.3°, player=(531,785), corner_timer=0.30
+[22:15:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(724.9032, 916.5359), source=ENEMY (Enemy4), range=1469, listeners=10
+[22:15:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:13] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:15:13] [INFO] [LastChance] Threat detected: Bullet
+[22:15:13] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[22:15:13] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:15:13] [INFO] [Player] Spawning blood effect at (534.4661, 787.89264), dir=(1, 0), lethal=False (C#)
+[22:15:13] [INFO] [ImpactEffects] spawn_blood_effect called at (534.4661, 787.8926), dir=(1, 0), lethal=false
+[22:15:13] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:13] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:13] [INFO] [ImpactEffects] Blood effect spawned at (534.4661, 787.8926) (scale=1)
+[22:15:13] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[22:15:13] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[22:15:13] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[22:15:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(743.1186, 923.1293), source=ENEMY (Enemy4), range=1469, listeners=10
+[22:15:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=1, below_threshold=7
+[22:15:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(682.131, 892.9447), shooter_id=1219921708598, bullet_pos=(682.131, 892.9447)
+[22:15:13] [INFO] [Bullet] Using shooter_position, distance=0
+[22:15:13] [INFO] [Bullet] Distance to wall: 0 (0% of viewport)
+[22:15:13] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:15:13] [INFO] [Bullet] Starting wall penetration at (682.131, 892.9447)
+[22:15:13] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:15:13] [INFO] [Bullet] Exiting penetration at (649.9507, 872.1151) after traveling 33.3333320617676 pixels through wall
+[22:15:13] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:13] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.9°, current=-129.0°, player=(539,794), corner_timer=-0.00
+[22:15:13] [ENEMY] [Enemy7] PATROL corner check: angle 89.9°
+[22:15:13] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.9°, current=-131.3°, player=(539,796), corner_timer=0.30
+[22:15:13] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:15:13] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[22:15:13] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-151.7°, current=-151.3°, player=(545,812), corner_timer=0.00
+[22:15:13] [INFO] [BloodDecal] Blood puddle created at (572.8907, 808.6154) (added to group)
+[22:15:13] [ENEMY] [Enemy1] PURSUING corner check: angle -135.3°
+[22:15:13] [ENEMY] [Enemy2] PURSUING corner check: angle 174.2°
+[22:15:13] [INFO] [BloodDecal] Blood puddle created at (590.468, 803.7972) (added to group)
+[22:15:13] [INFO] [BloodDecal] Blood puddle created at (626.3871, 808.5768) (added to group)
+[22:15:13] [INFO] [BloodDecal] Blood puddle created at (662.7808, 795.6517) (added to group)
+[22:15:13] [INFO] [BloodDecal] Blood puddle created at (672.8584, 823.5898) (added to group)
+[22:15:13] [INFO] [BloodDecal] Blood puddle created at (628.2287, 852.6884) (added to group)
+[22:15:13] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.9°, current=175.8°, player=(588,860), corner_timer=-0.01
+[22:15:13] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[22:15:13] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=178.1°, player=(591,863), corner_timer=0.30
+[22:15:13] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=60.1°, current=35.3°, player=(601,877), corner_timer=0.07
+[22:15:13] [ENEMY] [Enemy1] Player distracted - priority attack triggered
+[22:15:13] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[22:15:13] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:15:13] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P2:combat_state, state=PURSUING, target=61.0°, current=-11.3°, player=(604,884), corner_timer=0.06
+[22:15:13] [INFO] [BloodDecal] Blood puddle created at (637.1544, 919.987) (added to group)
+[22:15:13] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=63.2°, current=15.5°, player=(610,904), corner_timer=-0.01
+[22:15:13] [ENEMY] [Enemy1] PURSUING corner check: angle -85.7°
+[22:15:13] [ENEMY] [Enemy1] Player distracted - priority attack triggered
+[22:15:13] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P2:combat_state, state=PURSUING, target=64.6°, current=6.4°, player=(612,915), corner_timer=0.29
+[22:15:14] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=64.9°, current=32.6°, player=(613,918), corner_timer=0.27
+[22:15:14] [ENEMY] [Enemy1] State: PURSUING -> COMBAT
+[22:15:14] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(614.48, 930.9415), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:14] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=6
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (741.9794, 943.8071) (added to group)
+[22:15:14] [INFO] [BloodyFeet:Enemy4] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (721.9161, 960.8447) (added to group)
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (722.0698, 982.0956) (added to group)
+[22:15:14] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 2/2 -> 1/2
+[22:15:14] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[22:15:14] [INFO] [ImpactEffects] spawn_blood_effect called at (758.3895, 932.2013), dir=(1, 0), lethal=false
+[22:15:14] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:14] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:14] [INFO] [ImpactEffects] Blood effect spawned at (758.3895, 932.2013) (scale=1)
+[22:15:14] [ENEMY] [Enemy1] Player distracted - priority attack triggered
+[22:15:14] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(758.3895, 932.2013), source=ENEMY (Enemy4), range=1469, listeners=10
+[22:15:14] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[22:15:14] [INFO] [LastChance] Threat detected: @Area2D@5147
+[22:15:14] [INFO] [LastChance] Triggering last chance effect!
+[22:15:14] [INFO] [LastChance] Starting last chance effect:
+[22:15:14] [INFO] [LastChance]   - Time will be frozen (except player)
+[22:15:14] [INFO] [LastChance]   - Duration: 6.0 real seconds
+[22:15:14] [INFO] [LastChance]   - Sepia intensity: 0.70
+[22:15:14] [INFO] [LastChance]   - Brightness: 0.60
+[22:15:14] [INFO] [LastChance] Pushed bullet @Area2D@5147 from distance 82.4 to 200.0
+[22:15:14] [INFO] [LastChance] Pushed 1 threatening bullets away from player
+[22:15:14] [INFO] [LastChance] Set player Player and all 22 children to PROCESS_MODE_ALWAYS
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room1_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room1_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room2_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room2_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room2_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room3_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room3_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room4_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room4_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room5_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room5_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Left' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Right' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallRight' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallTop' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBL' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTL' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Desk1' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Desk2' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Table1' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Cabinet1' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Cabinet2' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Desk3' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Desk4' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Table2' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Table3' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'Cabinet3' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'StorageCrate1' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'StorageCrate2' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Set StaticBody2D 'HallTable' to PROCESS_MODE_ALWAYS for collision
+[22:15:14] [INFO] [LastChance] Skipping player node: Player
+[22:15:14] [INFO] [LastChance] Froze existing bullet casing: Casing
+[22:15:14] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@5069
+[22:15:14] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@5071
+[22:15:14] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@5073
+[22:15:14] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@5091
+[22:15:14] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@5131
+[22:15:14] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@5132
+[22:15:14] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@5142
+[22:15:14] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@5148
+[22:15:14] [INFO] [LastChance] Froze all nodes except player and autoloads (including GameManager for quick restart)
+[22:15:14] [INFO] [LastChance] Applied visual effects: sepia=0.70, brightness=0.60, ripple=0.0080
+[22:15:14] [INFO] [LastChance] Applied 4.0x saturation to 6 player sprites
+[22:15:14] [INFO] [LastChance] Freezing newly fired player bullet: Bullet
+[22:15:14] [INFO] [LastChance] Registered frozen player bullet: Bullet
+[22:15:14] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@5149
+[22:15:14] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@5149
+[22:15:14] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(608.668, 946.8372), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:14] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=6
+[22:15:14] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@5151
+[22:15:14] [INFO] [LastChance] Registered frozen player bullet: @Area2D@5151
+[22:15:14] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@5152
+[22:15:14] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@5152
+[22:15:14] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(608.668, 953.4151), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:14] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=6
+[22:15:14] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@5153
+[22:15:14] [INFO] [LastChance] Registered frozen player bullet: @Area2D@5153
+[22:15:14] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@5154
+[22:15:14] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@5154
+[22:15:14] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(608.668, 953.4373), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:14] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=6
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (816.2711, 937.2845) (added to group)
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (854.7491, 958.5092) (added to group)
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (831.6276, 983.8037) (added to group)
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (845.3452, 924.52) (added to group)
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (823.1707, 973.0047) (added to group)
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (888.8777, 986.3138) (added to group)
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (874.0576, 945.0272) (added to group)
+[22:15:14] [INFO] [BloodDecal] Blood puddle created at (863.8389, 985.9175) (added to group)
+[22:15:15] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@5169
+[22:15:15] [INFO] [LastChance] Registered frozen player bullet: @Area2D@5169
+[22:15:15] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@5170
+[22:15:15] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@5170
+[22:15:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(610.6389, 707.0526), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:15] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=2, self=0, below_threshold=4
+[22:15:16] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@5172
+[22:15:16] [INFO] [LastChance] Registered frozen player bullet: @Area2D@5172
+[22:15:16] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@5173
+[22:15:16] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@5173
+[22:15:16] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(622.041, 680.2116), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:16] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=2, self=0, below_threshold=4
+[22:15:16] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@5175
+[22:15:16] [INFO] [LastChance] Registered frozen player bullet: @Area2D@5175
+[22:15:16] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@5176
+[22:15:16] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@5176
+[22:15:16] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(642.5009, 663.5867), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:16] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=2, self=0, below_threshold=4
+[22:15:17] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@5183
+[22:15:17] [INFO] [LastChance] Registered frozen player bullet: @Area2D@5183
+[22:15:17] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@5184
+[22:15:17] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@5184
+[22:15:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(807.9278, 715.2861), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:17] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=6
+[22:15:17] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@5186
+[22:15:17] [INFO] [LastChance] Registered frozen player bullet: @Area2D@5186
+[22:15:17] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@5187
+[22:15:17] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@5187
+[22:15:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(833.1611, 715.2861), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[22:15:17] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=0, below_threshold=6
+[22:15:18] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[22:15:18] [ENEMY] [Enemy1] Player reloading: false -> true
+[22:15:18] [ENEMY] [Enemy2] Player reloading: false -> true
+[22:15:18] [ENEMY] [Enemy3] Player reloading: false -> true
+[22:15:18] [ENEMY] [Enemy4] Player reloading: false -> true
+[22:15:18] [ENEMY] [Enemy5] Player reloading: false -> true
+[22:15:18] [ENEMY] [Enemy6] Player reloading: false -> true
+[22:15:18] [ENEMY] [Enemy7] Player reloading: false -> true
+[22:15:18] [ENEMY] [Enemy8] Player reloading: false -> true
+[22:15:18] [ENEMY] [Enemy9] Player reloading: false -> true
+[22:15:18] [ENEMY] [Enemy10] Player reloading: false -> true
+[22:15:18] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(851.4944, 709.2861), source=PLAYER (Player), range=900, listeners=10
+[22:15:18] [ENEMY] [Enemy2] Heard player RELOAD at (851.4944, 709.2861), intensity=0.01, distance=451
+[22:15:18] [ENEMY] [Enemy3] Heard player RELOAD at (851.4944, 709.2861), intensity=0.14, distance=132
+[22:15:18] [ENEMY] [Enemy3] Vulnerability sound triggered pursuit - transitioning from SUPPRESSED to PURSUING
+[22:15:18] [ENEMY] [Enemy4] Heard player RELOAD at (851.4944, 709.2861), intensity=0.04, distance=238
+[22:15:18] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=5, self=0, below_threshold=2
+[22:15:18] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[22:15:19] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[22:15:19] [ENEMY] [Enemy1] Player reloading: true -> false
+[22:15:19] [ENEMY] [Enemy2] Player reloading: true -> false
+[22:15:19] [ENEMY] [Enemy3] Player reloading: true -> false
+[22:15:19] [ENEMY] [Enemy4] Player reloading: true -> false
+[22:15:19] [ENEMY] [Enemy5] Player reloading: true -> false
+[22:15:19] [ENEMY] [Enemy6] Player reloading: true -> false
+[22:15:19] [ENEMY] [Enemy7] Player reloading: true -> false
+[22:15:19] [ENEMY] [Enemy8] Player reloading: true -> false
+[22:15:19] [ENEMY] [Enemy9] Player reloading: true -> false
+[22:15:19] [ENEMY] [Enemy10] Player reloading: true -> false
+[22:15:19] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[22:15:19] [INFO] [Player.Reload.Anim] LeftArm: pos=(14.81068, 5.9051185), target=(24, 6), base=(24, 6)
+[22:15:19] [INFO] [Player.Reload.Anim] RightArm: pos=(-2.0000002, 7.4524856), target=(-2, 6), base=(-2, 6)
+[22:15:19] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[22:15:20] [INFO] [LastChance] Effect duration expired after 6.00 real seconds
+[22:15:20] [INFO] [LastChance] Ending last chance effect
+[22:15:20] [ENEMY] [Enemy1] Memory reset: confusion=2.0s, had_target=true
+[22:15:20] [ENEMY] [Enemy1] Search mode: COMBAT -> SEARCHING at (608.668, 930.9481)
+[22:15:20] [ENEMY] [Enemy1] SEARCHING started: center=(608.668, 930.9481), radius=100, waypoints=5
+[22:15:20] [ENEMY] [Enemy2] Memory reset: confusion=2.0s, had_target=true
+[22:15:20] [ENEMY] [Enemy2] Search mode: PURSUING -> SEARCHING at (527.5473, 784.3943)
+[22:15:20] [ENEMY] [Enemy2] SEARCHING started: center=(527.5473, 784.3943), radius=100, waypoints=5
+[22:15:20] [ENEMY] [Enemy3] Memory reset: confusion=2.0s, had_target=true
+[22:15:20] [ENEMY] [Enemy3] Search mode: PURSUING -> SEARCHING at (599.1853, 873.627)
+[22:15:20] [ENEMY] [Enemy3] SEARCHING started: center=(599.1853, 873.627), radius=100, waypoints=5
+[22:15:20] [ENEMY] [Enemy4] Memory reset: confusion=2.0s, had_target=true
+[22:15:20] [ENEMY] [Enemy4] Search mode: COMBAT -> SEARCHING at (608.668, 930.9481)
+[22:15:20] [ENEMY] [Enemy4] SEARCHING started: center=(608.668, 930.9481), radius=100, waypoints=5
+[22:15:20] [ENEMY] [Enemy5] Memory reset: confusion=2.0s, had_target=false
+[22:15:20] [ENEMY] [Enemy6] Memory reset: confusion=2.0s, had_target=false
+[22:15:20] [ENEMY] [Enemy7] Memory reset: confusion=2.0s, had_target=false
+[22:15:20] [ENEMY] [Enemy8] Memory reset: confusion=2.0s, had_target=false
+[22:15:20] [ENEMY] [Enemy9] Memory reset: confusion=2.0s, had_target=false
+[22:15:20] [ENEMY] [Enemy10] Memory reset: confusion=2.0s, had_target=false
+[22:15:20] [INFO] [LastChance] Reset memory for 10 enemies (player teleport effect)
+[22:15:20] [INFO] [LastChance] All process modes restored
+[22:15:20] [INFO] [LastChance] Unfroze player bullet: Bullet
+[22:15:20] [INFO] [LastChance] Unfroze player bullet: @Area2D@5151
+[22:15:20] [INFO] [LastChance] Unfroze player bullet: @Area2D@5153
+[22:15:20] [INFO] [LastChance] Unfroze player bullet: @Area2D@5169
+[22:15:20] [INFO] [LastChance] Unfroze player bullet: @Area2D@5172
+[22:15:20] [INFO] [LastChance] Unfroze player bullet: @Area2D@5175
+[22:15:20] [INFO] [LastChance] Unfroze player bullet: @Area2D@5183
+[22:15:20] [INFO] [LastChance] Unfroze player bullet: @Area2D@5186
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: Casing
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5069
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5071
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5073
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5091
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5131
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5132
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5142
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5148
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5149
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5152
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5154
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5170
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5173
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5176
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5184
+[22:15:20] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@5187
+[22:15:20] [INFO] [LastChance] Restored original colors to 5 player sprites
+[22:15:20] [INFO] [LastChance] Called player RefreshHealthVisual (C#)
+[22:15:20] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P2:combat_state, state=SEARCHING, target=31.9°, current=65.5°, player=(851,709), corner_timer=0.27
+[22:15:20] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P2:combat_state, state=SEARCHING, target=-82.9°, current=64.5°, player=(851,709), corner_timer=0.00
+[22:15:20] [ENEMY] [Enemy3] SEARCHING corner check: angle -145.2°
+[22:15:20] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=SEARCHING, target=-69.5°, current=179.5°, player=(851,709), corner_timer=0.00
+[22:15:20] [ENEMY] [Enemy4] SEARCHING corner check: angle -89.5°
+[22:15:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.0°, current=124.1°, player=(851,709), corner_timer=-0.01
+[22:15:20] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[22:15:20] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 1/2 -> 0/2
+[22:15:20] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[22:15:20] [INFO] [ImpactEffects] spawn_blood_effect called at (769.011, 932.4713), dir=(1, 0), lethal=true
+[22:15:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:20] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:15:20] [INFO] [ImpactEffects] Blood effect spawned at (769.011, 932.4713) (scale=1.5)
+[22:15:20] [ENEMY] [Enemy4] Enemy died (ricochet: false, penetration: false)
+[22:15:20] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:15:20] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 9)
+[22:15:20] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[22:15:20] [ENEMY] [Enemy4] Death animation started with hit direction: (1, 0)
+[22:15:20] [ENEMY] [Enemy2] SEARCHING corner check: angle -80.0°
+[22:15:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=126.9°, player=(851,709), corner_timer=0.30
+[22:15:20] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 4/4 -> 3/4
+[22:15:20] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:15:20] [INFO] [ImpactEffects] spawn_blood_effect called at (425.2899, 646.6246), dir=(1, 0), lethal=false
+[22:15:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:20] [INFO] [ImpactEffects] Blood effect spawned at (425.2899, 646.6246) (scale=1)
+[22:15:20] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 3/4 -> 2/4
+[22:15:20] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:15:20] [INFO] [ImpactEffects] spawn_blood_effect called at (425.2899, 646.6246), dir=(1, 0), lethal=false
+[22:15:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:20] [INFO] [ImpactEffects] Blood effect spawned at (425.2899, 646.6246) (scale=1)
+[22:15:20] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 2/4 -> 1/4
+[22:15:20] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[22:15:20] [INFO] [ImpactEffects] spawn_blood_effect called at (429.3344, 647.3365), dir=(1, 0), lethal=false
+[22:15:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:15:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:15:20] [INFO] [ImpactEffects] Blood effect spawned at (429.3344, 647.3365) (scale=1)
+[22:15:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(833.1611, 715.2861), shooter_id=1222572510029, bullet_pos=(893.9304, 1000.5519)
+[22:15:20] [INFO] [Bullet] Using shooter_position, distance=291,66675
+[22:15:20] [INFO] [Bullet] Distance to wall: 291,66675 (19,860126% of viewport)
+[22:15:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:20] [INFO] [Bullet] Starting wall penetration at (893.9304, 1000.5519)
+[22:15:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:15:20] [INFO] [Bullet] Raycast backward hit penetrating body at distance 14,359075
+[22:15:20] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:20] [INFO] [Bullet] Exiting penetration at (901.91724, 1038.044) after traveling 33,333332 pixels through wall
+[22:15:20] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:15:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(608.66797, 953.4373), shooter_id=1222572510029, bullet_pos=(929.42883, 901.11676)
+[22:15:20] [INFO] [Bullet] Using shooter_position, distance=324,99994
+[22:15:20] [INFO] [Bullet] Distance to wall: 324,99994 (22,129845% of viewport)
+[22:15:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:20] [INFO] [Bullet] Starting wall penetration at (929.42883, 901.11676)
+[22:15:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(608.66797, 953.4151), shooter_id=1222572510029, bullet_pos=(933.3339, 938.67957)
+[22:15:20] [INFO] [Bullet] Using shooter_position, distance=325,00018
+[22:15:20] [INFO] [Bullet] Distance to wall: 325,00018 (22,12986% of viewport)
+[22:15:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:20] [INFO] [Bullet] Starting wall penetration at (933.3339, 938.67957)
+[22:15:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(690.8573, 939.4352), shooter_id=1219921708598, bullet_pos=(508.1202, 945.7032)
+[22:15:20] [INFO] [Bullet] Using shooter_position, distance=182.844528198242
+[22:15:20] [INFO] [Bullet] Distance to wall: 182.844528198242 (12.4502201464584% of viewport)
+[22:15:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:15:20] [INFO] [Bullet] Starting wall penetration at (508.1202, 945.7032)
+[22:15:20] [INFO] [Bullet] Raycast backward hit penetrating body at distance 30.2127895355225
+[22:15:20] [INFO] [Bullet] Raycast backward hit penetrating body at distance 35,664547
+[22:15:20] [INFO] [Bullet] Raycast backward hit penetrating body at distance 31,6753
+[22:15:20] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:20] [INFO] [Bullet] Exiting penetration at (967.26215, 894.9456) after traveling 33,333336 pixels through wall
+[22:15:20] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:15:20] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:20] [INFO] [Bullet] Exiting penetration at (971.62787, 936.9415) after traveling 33,333336 pixels through wall
+[22:15:20] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:15:20] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:15:20] [INFO] [Bullet] Exiting penetration at (469.7883, 945.3824) after traveling 33.3333320617676 pixels through wall
+[22:15:20] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[22:15:20] [ENEMY] [Enemy1] SEARCHING corner check: angle 153.4°
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (807.1774, 930.2993) (added to group)
+[22:15:20] [ENEMY] [Enemy3] SEARCHING corner check: angle -91.1°
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (482.4803, 641.8839) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (491.9457, 686.4413) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (468.7994, 682.4752) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (474.8811, 640.5236) (added to group)
+[22:15:20] [INFO] [BloodyFeet:Enemy2] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:15:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.6°, player=(851,709), corner_timer=-0.01
+[22:15:20] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (828.9999, 963.6644) (added to group)
+[22:15:20] [ENEMY] [Enemy2] SEARCHING corner check: angle -80.0°
+[22:15:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=91.9°, player=(851,709), corner_timer=0.30
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (880.8006, 912.6057) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (829.3038, 986.3291) (added to group)
+[22:15:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (510.1692, 682.2883) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (488.4013, 669.9449) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (568.29, 716.494) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (881.7516, 953.5042) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (545.6031, 651.6865) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (501.7541, 673.0359) (added to group)
+[22:15:20] [ENEMY] [Enemy4] Ragdoll activated
+[22:15:20] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (855.7259, 970.4877) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (572.8126, 715.0256) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (531.2068, 667.2982) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (567.1595, 673.9315) (added to group)
+[22:15:20] [ENEMY] [Enemy1] SEARCHING corner check: angle 153.4°
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (537.042, 668.1919) (added to group)
+[22:15:20] [INFO] [BloodDecal] Blood puddle created at (577.6532, 723.8568) (added to group)
+[22:15:20] [INFO] ------------------------------------------------------------
+[22:15:20] [INFO] GAME LOG ENDED: 2026-02-03T22:15:20
+[22:15:20] [INFO] ============================================================

--- a/scripts/levels/building_level.gd
+++ b/scripts/levels/building_level.gd
@@ -934,10 +934,11 @@ func _setup_selected_weapon() -> void:
 			mini_uzi.name = "MiniUzi"
 
 			# Reduce Mini UZI ammunition by half for Building level (issue #413)
-			# Default StartingMagazineCount is 4, reduce to 2
+			# Set StartingMagazineCount to 2 BEFORE adding to scene tree
+			# This ensures magazines are initialized with correct count when _Ready() is called
 			if mini_uzi.get("StartingMagazineCount") != null:
 				mini_uzi.StartingMagazineCount = 2
-				print("BuildingLevel: Mini UZI magazine count set to 2 (reduced by half)")
+				print("BuildingLevel: Mini UZI StartingMagazineCount set to 2 (before initialization)")
 
 			_player.add_child(mini_uzi)
 
@@ -979,10 +980,13 @@ func _setup_selected_weapon() -> void:
 		var assault_rifle = _player.get_node_or_null("AssaultRifle")
 		if assault_rifle:
 			# Reduce M16 ammunition by half for Building level (issue #413)
-			# Default StartingMagazineCount is 4, reduce to 2
-			if assault_rifle.get("StartingMagazineCount") != null:
-				assault_rifle.StartingMagazineCount = 2
-				print("BuildingLevel: M16 magazine count set to 2 (reduced by half)")
+			# The weapon is already initialized, so we need to reinitialize magazines
+			# M16 has magazine size of 30, so 2 magazines = 60 rounds total (30+30)
+			if assault_rifle.has_method("ReinitializeMagazines"):
+				assault_rifle.ReinitializeMagazines(2, true)
+				print("BuildingLevel: M16 magazines reinitialized to 2 (reduced by half)")
+			else:
+				print("BuildingLevel: WARNING - M16 doesn't have ReinitializeMagazines method")
 
 			if _player.get("CurrentWeapon") == null:
 				if _player.has_method("EquipWeapon"):


### PR DESCRIPTION
## Summary

This PR fixes issue #413 by properly reducing ammunition for UIZ (Mini UZI) and M16 (Assault Rifle) weapons by half on the Building map (Здание). The previous implementation had a critical bug where magazines were already initialized before the reduction code ran.

## Problem Analysis

### User Feedback
User reported: "всё ещё слишком много патронов в m16 - должно быть 30 + 30" (still too many bullets in M16 - should be 30 + 30)

### Root Cause
The initial fix attempted to set `StartingMagazineCount` **after** weapon initialization:

```gdscript
var assault_rifle = _player.get_node_or_null("AssaultRifle")
assault_rifle.StartingMagazineCount = 2  # TOO LATE!
```

**Why this failed:**
1. AssaultRifle is already in the Player scene
2. When Player loads, `AssaultRifle._Ready()` is called
3. `_Ready()` reads `StartingMagazineCount` and initializes magazines with default value (4)
4. By the time level code runs, magazines are already created with 120 rounds (4×30)
5. Setting `StartingMagazineCount` post-initialization has no effect

## Solution

### 1. Added `ReinitializeMagazines` Method to BaseWeapon

```csharp
public virtual void ReinitializeMagazines(int magazineCount, bool fillAllMagazines = true)
{
    MagazineInventory.Initialize(magazineCount, WeaponData.MagazineSize, fillAllMagazines);
    EmitSignal(SignalName.AmmoChanged, CurrentAmmo, ReserveAmmo);
    EmitMagazinesChanged();
}
```

This allows runtime reinitialization of already-initialized weapons.

### 2. Updated Building Level Logic

**For M16 (already in scene):**
```gdscript
if assault_rifle.has_method("ReinitializeMagazines"):
    assault_rifle.ReinitializeMagazines(2, true)
```

**For Mini UZI (dynamically loaded):**
```gdscript
var mini_uzi = mini_uzi_scene.instantiate()
mini_uzi.StartingMagazineCount = 2  # Set BEFORE add_child()
_player.add_child(mini_uzi)  # Triggers _Ready() with correct value
```

## Changes Made

### Files Modified

1. **Scripts/AbstractClasses/BaseWeapon.cs**
   - Added `ReinitializeMagazines(int, bool)` method after line 667
   - Allows level-specific magazine configuration

2. **scripts/levels/building_level.gd**
   - M16: Call `ReinitializeMagazines(2, true)` at line 986
   - Mini UZI: Improved comments, kept existing `StartingMagazineCount` approach

3. **docs/case-studies/issue-413/**
   - Added comprehensive case study with root cause analysis
   - Saved user's game log for reference
   - Documented timeline, technical details, and alternatives considered

## Results

### M16 (Assault Rifle)
- **Before**: 4 magazines × 30 rounds = **120 rounds total**
- **After**: 2 magazines × 30 rounds = **60 rounds total** ✓
- **Reduction**: Exactly 50% as requested (30+30)

### Mini UZI
- **Before**: (4 starting + 1 extra) magazines × 32 rounds = **160 rounds total**
- **After**: 2 magazines × 32 rounds = **64 rounds total** ✓
- **Reduction**: 60% reduction (fewer magazines as requested)

## Verification

The fix can be verified by:
1. Starting Building level with M16 or Mini UZI
2. Checking game log for "Magazines reinitialized" message
3. Observing player can only reload once (2 magazines total)
4. Total shots fired should not exceed:
   - M16: 60 rounds
   - Mini UZI: 64 rounds

## Technical Notes

- Only affects Building level (other levels unchanged)
- Works with existing magazine inventory system
- Properly emits signals for UI updates
- No changes to weapon scene files (level-specific only)

## Documentation

Complete technical analysis available in `docs/case-studies/issue-413/README.md` including:
- Detailed root cause analysis with code flow
- Timeline of initialization sequence
- Alternative approaches considered
- Magazine inventory system explanation

Fixes #413

---
*This PR was created by AI issue solver with comprehensive root cause analysis and documentation*