### PR TITLE
fix: cinema film effects v5.2 - visible specks, expanding spots, right corner (Issue #431)

### DIFF
--- a/docs/case-studies/issue-431/README.md
+++ b/docs/case-studies/issue-431/README.md
@@ -7,7 +7,16 @@ Issue #431 reported that effects from [PR #419 comment](https://github.com/Jhon-
 1. **More grain/noise** (добавь немного больше зернистости)
 2. **Small scratches effect** - tiny scratches max 2px long, like small dots on old film
 3. **Cigarette burn effect** - appears when player dies
-4. **End of reel effect** - countdown marker in the **left** corner when player dies
+4. **End of reel effect** - countdown marker in the corner when player dies
+
+### Feedback Round 2 (v5.2)
+
+After v5.1 implementation, additional feedback was received:
+
+1. **White circle (end of reel) should be in RIGHT corner** - not left
+2. **Death spots should gradually expand and multiply** - currently static
+3. **White "motes" (small specks) are not visible** - need to be more prominent
+4. **More grain/noise needed** - still not enough
 
 The user specifically noted that scratches should be "realistic" - very small dots like on old film that appear rarely.
 
@@ -46,22 +55,75 @@ The original implementation created short line segments (micro scratches), but t
 
 The user requested more visible grain/noise effect.
 
-**Fix**: Increased default grain intensity from 0.07 to 0.10.
+**Fix v5.1**: Increased default grain intensity from 0.07 to 0.10.
+**Fix v5.2**: Increased further from 0.10 to 0.15.
+
+### Issue 5: End of Reel Position Wrong (v5.2)
+
+After v5.1, user clarified that the end of reel marker (white circle) should be in the **TOP-RIGHT** corner, not top-left.
+
+**Fix**: Changed position from `vec2(0.15, 0.15)` to `vec2(0.85, 0.15)` and changed color to white/light.
+
+### Issue 6: Death Spots Not Expanding (v5.2)
+
+User requested that the spots appearing on death should gradually expand and multiply over time, not stay static.
+
+**Fix**: Added new `death_spots` effect that:
+- Starts with 2 spots, grows to 8 spots over time
+- Each spot starts small and expands gradually
+- Spots have staggered appearance (new ones spawn over time)
+- Irregular edges for organic look
+- Pulsing/flickering animation
+
+### Issue 7: White Specks Not Visible (v5.2)
+
+The white "motes" (micro specks) were too subtle and not visible during gameplay.
+
+**Fix**:
+- Increased speck size from 1-2px to 3-6px
+- Increased intensity from 0.35 to 0.7
+- Increased probability from 1.5% to 4%
+- Made 70% of specks white (dust motes in projector light)
+- Increased number of specks generated (from 6 to 10)
 
 ## Implementation Details
 
 ### Files Modified
 
-1. **scripts/shaders/cinema_film.gdshader** (v5.0 -> v5.1)
-   - End of reel position: `vec2(0.85, 0.15)` -> `vec2(0.15, 0.15)`
+1. **scripts/shaders/cinema_film.gdshader** (v5.0 -> v5.1 -> v5.2)
+
+   **v5.1 Changes**:
+   - End of reel position: `vec2(0.85, 0.15)` -> `vec2(0.15, 0.15)` (top-left)
    - Grain intensity default: `0.07` -> `0.10`
    - Micro scratch probability: `0.03` -> `0.015`
    - Micro scratches function: Line-based -> Dot/speck-based
 
-2. **scripts/autoload/cinema_effects_manager.gd** (v5.0 -> v5.1)
+   **v5.2 Changes**:
+   - End of reel position: `vec2(0.15, 0.15)` -> `vec2(0.85, 0.15)` (top-RIGHT)
+   - End of reel color: dark -> white/light (`vec3(0.95, 0.92, 0.88)`)
+   - Grain intensity: `0.10` -> `0.15`
+   - Micro scratch intensity: `0.35` -> `0.7`
+   - Micro scratch probability: `0.015` -> `0.04`
+   - Speck size: 1-2px -> 3-6px
+   - Added new `death_spots` effect with expanding/multiplying spots
+   - Added `death_spots_enabled`, `death_spots_intensity`, `death_spots_time` uniforms
+
+2. **scripts/autoload/cinema_effects_manager.gd** (v5.0 -> v5.1 -> v5.2)
+
+   **v5.1 Changes**:
    - Death signal connection: Now checks for both "Died" and "died"
    - Updated default constants to match shader changes
    - Added documentation about v5.1 fixes
+
+   **v5.2 Changes**:
+   - Updated DEFAULT_GRAIN_INTENSITY: 0.10 -> 0.15
+   - Updated DEFAULT_MICRO_SCRATCH_INTENSITY: 0.35 -> 0.7
+   - Updated DEFAULT_MICRO_SCRATCH_PROBABILITY: 0.015 -> 0.04
+   - Added `_death_spots_timer` variable
+   - Added death_spots shader parameter initialization
+   - Updated `trigger_death_effects()` to enable death_spots
+   - Updated `reset_death_effects()` to reset death_spots
+   - Updated `_process()` to animate death_spots_time and death_spots_intensity
 
 ### Micro Scratches Implementation Change
 
@@ -122,15 +184,25 @@ This project uses the **overlay-based approach** for post-processing effects (im
 
 1. **Death Effects Test**: Kill the player and verify:
    - Cigarette burn appears (random position in center-ish area)
-   - End of reel countdown appears in **top-left** corner
+   - End of reel countdown (white circle) appears in **top-RIGHT** corner
+   - Dark spots appear and gradually expand over time
+   - More spots appear as time passes (starts with 2, grows to 8)
    - Effects fade in smoothly
 
-2. **Micro Specks Test**: Observe gameplay and verify:
-   - Small dots/specks appear occasionally (not frequently)
-   - Dots are tiny (1-2 pixels)
-   - Mix of light and dark specks
+2. **White Specks Test**: Observe gameplay and verify:
+   - White specks/motes are **visible** (should be noticeable)
+   - Specks appear more frequently than before
+   - Most specks are white (like dust in projector light)
+   - Some darker specks for variety
 
-3. **Grain Test**: Verify increased grain visibility compared to v5.0
+3. **Grain Test**: Verify noticeably increased grain visibility (0.15 intensity)
+
+4. **Overall Film Look**: The combination should create an authentic vintage film appearance:
+   - Visible grain noise
+   - Occasional white dust motes
+   - Warm color tint
+   - Vignette at edges
+   - Dramatic death effects with expanding damage
 
 ## Version History
 
@@ -138,3 +210,16 @@ This project uses the **overlay-based approach** for post-processing effects (im
 |---------|---------|
 | v5.0 | Added micro scratches, cigarette burn, end of reel death effects |
 | v5.1 | Fixed death signal, moved end of reel to left corner, converted scratches to dots, increased grain |
+| v5.2 | Moved end of reel to RIGHT corner (white circle), added expanding death spots, made white specks more visible, increased grain to 0.15 |
+
+## Log Files
+
+The following game logs were provided for analysis:
+- `game_log_20260203_175703.txt` - Initial test session
+- `game_log_20260203_180051.txt` - Follow-up test session
+
+Key observations from logs:
+- CinemaEffects manager initializes correctly
+- Player 'Died' signal connected successfully (C# naming)
+- Cinema shader warmup completes in ~142-145ms
+- Effect becomes visible after 1 frame delay

--- a/docs/case-studies/issue-431/game_log_20260203_175703.txt
+++ b/docs/case-studies/issue-431/game_log_20260203_175703.txt
@@ -1,0 +1,6221 @@
+[17:57:03] [INFO] ============================================================
+[17:57:03] [INFO] GAME LOG STARTED
+[17:57:03] [INFO] ============================================================
+[17:57:03] [INFO] Timestamp: 2026-02-03T17:57:03
+[17:57:03] [INFO] Log file: I:/Загрузки/godot exe/game_log_20260203_175703.txt
+[17:57:03] [INFO] Executable: I:/Загрузки/godot exe/Godot-Top-Down-Template.exe
+[17:57:03] [INFO] OS: Windows
+[17:57:03] [INFO] Debug build: false
+[17:57:03] [INFO] Engine version: 4.3-stable (official)
+[17:57:03] [INFO] Project: Godot Top-Down Template
+[17:57:03] [INFO] ------------------------------------------------------------
+[17:57:03] [INFO] [GameManager] GameManager ready
+[17:57:03] [INFO] [ScoreManager] ScoreManager ready
+[17:57:03] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[17:57:03] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[17:57:03] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[17:57:03] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[17:57:03] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:57:03] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[17:57:03] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[17:57:03] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[17:57:03] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[17:57:03] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[17:57:03] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[17:57:03] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[17:57:03] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:57:03] [INFO] [LastChance] Last chance shader loaded successfully
+[17:57:03] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[17:57:03] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[17:57:03] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[17:57:03] [INFO] [LastChance]   Sepia intensity: 0.70
+[17:57:03] [INFO] [LastChance]   Brightness: 0.60
+[17:57:03] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[17:57:03] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[17:57:03] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV enabled: true, Complex grenade throwing: false
+[17:57:03] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.0 - overlay approach with death effects)...
+[17:57:03] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:57:03] [INFO] [CinemaEffects] Created effects layer at layer 99
+[17:57:03] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[17:57:03] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[17:57:03] [INFO] [CinemaEffects] Cinema film effect initialized (v5.0) - Configuration:
+[17:57:03] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[17:57:03] [INFO] [CinemaEffects]   Grain intensity: 0.10
+[17:57:03] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[17:57:03] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[17:57:03] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[17:57:03] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[17:57:03] [INFO] [CinemaEffects]   Micro scratches: 0.35 intensity, 1.5% probability
+[17:57:03] [INFO] [CinemaEffects]   Death effects: cigarette burn + end of reel (activated on player death)
+[17:57:03] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:57:03] [ENEMY] [Enemy1] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:57:03] [ENEMY] [Enemy2] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:57:03] [ENEMY] [Enemy3] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:57:03] [ENEMY] [Enemy4] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:57:03] [ENEMY] [Enemy5] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:57:03] [ENEMY] [Enemy6] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:57:03] [ENEMY] [Enemy7] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:57:03] [ENEMY] [Enemy8] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:57:03] [ENEMY] [Enemy9] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:57:03] [ENEMY] [Enemy10] Death animation component initialized
+[17:57:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:03] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:57:03] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:57:03] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:57:03] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:57:03] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:57:03] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:57:03] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:57:03] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:57:03] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:57:03] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:57:03] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:57:03] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[17:57:03] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:57:03] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[17:57:03] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:57:03] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:57:03] [INFO] [ScoreManager] Level started with 10 enemies
+[17:57:03] [INFO] [CinemaEffects] Found player node: Player
+[17:57:03] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:57:03] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[17:57:03] [ENEMY] [Enemy1] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[17:57:03] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[17:57:03] [ENEMY] [Enemy2] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[17:57:03] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[17:57:03] [ENEMY] [Enemy3] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[17:57:03] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[17:57:03] [ENEMY] [Enemy4] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[17:57:03] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[17:57:03] [ENEMY] [Enemy5] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[17:57:03] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[17:57:03] [ENEMY] [Enemy6] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[17:57:03] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[17:57:03] [ENEMY] [Enemy7] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy7] Spawned at (1606.114, 893.8859), hp: 2, behavior: PATROL
+[17:57:03] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[17:57:03] [ENEMY] [Enemy8] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[17:57:03] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[17:57:03] [ENEMY] [Enemy9] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:57:03] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:57:03] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[17:57:03] [ENEMY] [Enemy10] Registered as sound listener
+[17:57:03] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[17:57:03] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:57:03] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:03] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=45.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:03] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:03] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:03] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:03] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:03] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:03] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:03] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:57:03] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:57:03] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:57:03] [INFO] [PenultimateHit] Shader warmup complete in 170 ms
+[17:57:03] [INFO] [LastChance] Shader warmup complete in 169 ms
+[17:57:03] [INFO] [CinemaEffects] Cinema shader warmup complete in 145 ms
+[17:57:03] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:57:03] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:57:03] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:57:03] [INFO] [LastChance] Found player: Player
+[17:57:03] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:57:03] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:57:03] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:57:03] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:57:04] [INFO] [ImpactEffects] Particle shader warmup complete: 5 effects warmed up in 1022 ms
+[17:57:05] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:05] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:57:05] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1250), corner_timer=0.30
+[17:57:05] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1250), corner_timer=0.30
+[17:57:05] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1250), corner_timer=-0.02
+[17:57:05] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:05] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1250), corner_timer=-0.02
+[17:57:05] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:57:05] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1250), corner_timer=0.30
+[17:57:05] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1250), corner_timer=0.30
+[17:57:06] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,1250), corner_timer=-0.02
+[17:57:06] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:57:06] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,1250), corner_timer=0.30
+[17:57:06] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(450,1250), corner_timer=-0.02
+[17:57:06] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:57:06] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(450,1250), corner_timer=0.30
+[17:57:06] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(450,1250), corner_timer=-0.02
+[17:57:06] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:57:06] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(450,1250), corner_timer=0.30
+[17:57:07] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(450,1250), corner_timer=-0.02
+[17:57:07] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:57:07] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(450,1250), corner_timer=0.30
+[17:57:07] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:07] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(450,1193), corner_timer=-0.02
+[17:57:07] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:57:07] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(450,1188), corner_timer=0.30
+[17:57:07] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:08] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(450,1083), corner_timer=-0.02
+[17:57:08] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[17:57:08] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(450,1078), corner_timer=0.30
+[17:57:08] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:08] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(450,983), corner_timer=-0.02
+[17:57:08] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[17:57:08] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(450,980), corner_timer=0.30
+[17:57:08] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:08] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(450,965), corner_timer=-0.02
+[17:57:08] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[17:57:08] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(450,965), corner_timer=0.30
+[17:57:08] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:09] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(450,965), corner_timer=-0.02
+[17:57:09] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[17:57:09] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(450,965), corner_timer=0.30
+[17:57:09] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:09] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(450,965), corner_timer=-0.02
+[17:57:09] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[17:57:09] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(450,965), corner_timer=0.30
+[17:57:09] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:09] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(450,962), corner_timer=-0.02
+[17:57:09] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[17:57:09] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(450,960), corner_timer=0.30
+[17:57:09] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:10] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(450,876), corner_timer=-0.02
+[17:57:10] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:57:10] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,871), corner_timer=0.30
+[17:57:10] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:10] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=164.0°, current=123.7°, player=(450,821), corner_timer=0.00
+[17:57:10] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:57:10] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=166.4°, current=-65.3°, player=(450,810), corner_timer=0.00
+[17:57:10] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(441,770), corner_timer=-0.02
+[17:57:10] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:57:10] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(439,766), corner_timer=0.30
+[17:57:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(434.524, 765.0903), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[17:57:10] [ENEMY] [Enemy1] Heard gunshot at (434.524, 765.0903), source_type=0, intensity=0.01, distance=436
+[17:57:10] [ENEMY] [Enemy2] Heard gunshot at (434.524, 765.0903), source_type=0, intensity=0.05, distance=218
+[17:57:10] [ENEMY] [Enemy4] Heard gunshot at (434.524, 765.0903), source_type=0, intensity=0.02, distance=390
+[17:57:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[17:57:10] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=71.8°, current=168.8°, player=(434,759), corner_timer=0.00
+[17:57:10] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=80.6°, current=45.0°, player=(434,759), corner_timer=0.00
+[17:57:10] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-158.9°, current=168.8°, player=(434,759), corner_timer=0.00
+[17:57:10] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 3/3 -> 2/3
+[17:57:10] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:10] [INFO] [ImpactEffects] spawn_blood_effect called at (684.4765, 753.8722), dir=(1, 0), lethal=false
+[17:57:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:10] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:10] [INFO] [ImpactEffects] Blood effect spawned at (684.4765, 753.8722) (scale=1)
+[17:57:10] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-178.2°, current=180.0°, player=(418,745), corner_timer=0.00
+[17:57:10] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(415.6143, 749.5377), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[17:57:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[17:57:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(684.4765, 753.8722), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:10] [INFO] [LastChance] Threat detected: Bullet
+[17:57:10] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[17:57:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:10] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 2/3 -> 1/3
+[17:57:10] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:10] [INFO] [ImpactEffects] spawn_blood_effect called at (684.4765, 753.8722), dir=(1, 0), lethal=false
+[17:57:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:10] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:10] [INFO] [ImpactEffects] Blood effect spawned at (684.4765, 753.8722) (scale=1)
+[17:57:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(395.6669, 745.3187), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[17:57:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[17:57:10] [INFO] [Player] Spawning blood effect at (395.66687, 739.3187), dir=(1, 0), lethal=False (C#)
+[17:57:10] [INFO] [ImpactEffects] spawn_blood_effect called at (395.6669, 739.3187), dir=(1, 0), lethal=false
+[17:57:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:10] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:10] [INFO] [ImpactEffects] Blood effect spawned at (395.6669, 739.3187) (scale=1)
+[17:57:10] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[17:57:10] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[17:57:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(684.4765, 753.8722), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:10] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[17:57:10] [INFO] [LastChance] Threat detected: @Area2D@293
+[17:57:10] [INFO] [LastChance] Player health is 3.0 - effect requires exactly 1 HP or less but alive
+[17:57:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:10] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.1°, current=89.4°, player=(389,742), corner_timer=-0.01
+[17:57:10] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:57:10] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=91.7°, player=(387,743), corner_timer=0.30
+[17:57:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(684.6585, 764.8599), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(383.9461, 754.7715), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[17:57:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[17:57:10] [INFO] [Player] Spawning blood effect at (383.94614, 748.7715), dir=(1, 0), lethal=False (C#)
+[17:57:10] [INFO] [ImpactEffects] spawn_blood_effect called at (383.9461, 748.7715), dir=(1, 0), lethal=false
+[17:57:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:10] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:10] [INFO] [ImpactEffects] Blood effect spawned at (383.9461, 748.7715) (scale=1)
+[17:57:10] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[17:57:10] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[17:57:10] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 1/3 -> 0/3
+[17:57:10] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:10] [INFO] [ImpactEffects] spawn_blood_effect called at (683.2574, 766.4686), dir=(1, 0), lethal=true
+[17:57:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:10] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:10] [INFO] [ImpactEffects] Blood effect spawned at (683.2574, 766.4686) (scale=1.5)
+[17:57:10] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[17:57:10] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[17:57:10] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 9)
+[17:57:10] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[17:57:10] [ENEMY] [Enemy3] Death animation started with hit direction: (1, 0)
+[17:57:10] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:10] [INFO] [BloodDecal] Blood puddle created at (756.346, 797.7384) (added to group)
+[17:57:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(377.8822, 776.6506), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[17:57:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[17:57:10] [INFO] [BloodDecal] Blood puddle created at (793.8822, 761.5388) (added to group)
+[17:57:10] [INFO] [BloodDecal] Blood puddle created at (463.2404, 781.139) (added to group)
+[17:57:11] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[17:57:11] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:57:11] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (465.5497, 743.6811) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (447.6178, 784.2071) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (777.6882, 765.6292) (added to group)
+[17:57:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(383.94614, 754.7715), shooter_id=50365204183, bullet_pos=(908.34406, 729.63727)
+[17:57:11] [INFO] [Bullet] Using shooter_position, distance=524,99994
+[17:57:11] [INFO] [Bullet] Distance to wall: 524,99994 (35,748215% of viewport)
+[17:57:11] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:11] [INFO] [Bullet] Starting wall penetration at (908.34406, 729.63727)
+[17:57:11] [INFO] [Bullet] Raycast backward hit penetrating body at distance 10,645629
+[17:57:11] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:11] [INFO] [Bullet] Exiting penetration at (946.6334, 727.80206) after traveling 33,33334 pixels through wall
+[17:57:11] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (806.8528, 752.6058) (added to group)
+[17:57:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(616.713, 768.6025), shooter_id=47412413991, bullet_pos=(54.8736, 842.411)
+[17:57:11] [INFO] [Bullet] Using shooter_position, distance=566.666748046875
+[17:57:11] [INFO] [Bullet] Distance to wall: 566.666748046875 (38.5853808827794% of viewport)
+[17:57:11] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (475.1887, 781.7389) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (465.4512, 783.7595) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (755.8802, 760.7994) (added to group)
+[17:57:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.9°, current=89.4°, player=(376,821), corner_timer=-0.01
+[17:57:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (808.9303, 759.4753) (added to group)
+[17:57:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.7°, player=(376,825), corner_timer=0.30
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (474.7972, 815.3141) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (783.6304, 773.7028) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (781.0021, 803.6572) (added to group)
+[17:57:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(377.88217, 776.6506), shooter_id=50365204183, bullet_pos=(932.6534, 713.6837)
+[17:57:11] [INFO] [Bullet] Using shooter_position, distance=558,3332
+[17:57:11] [INFO] [Bullet] Distance to wall: 558,3332 (38,017933% of viewport)
+[17:57:11] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (826.5681, 787.4547) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (762.9322, 795.9306) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (444.5987, 785.8854) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (785.5029, 749.3328) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (857.8649, 824.2874) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (758.4366, 784.0266) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (762.2355, 791.4182) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (764.3545, 754.8734) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (460.2676, 814.7396) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (478.0574, 777.7239) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (804.2273, 808.8055) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (461.033, 794.97) (added to group)
+[17:57:11] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (825.1241, 852.9153) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (815.8375, 745.9127) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (825.8441, 829.3331) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (774.0615, 769.2897) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (473.6028, 820.3284) (added to group)
+[17:57:11] [ENEMY] [Enemy3] Ragdoll activated
+[17:57:11] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (820.3952, 851.9119) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (771.0928, 803.2682) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (489.3112, 854.7901) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (466.3048, 840.166) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (546.0145, 808.9839) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (495.0126, 807.5802) (added to group)
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (841.9889, 830.2548) (added to group)
+[17:57:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.8°, current=89.3°, player=(376,873), corner_timer=-0.01
+[17:57:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[17:57:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(376,873), corner_timer=0.30
+[17:57:11] [INFO] [BloodDecal] Blood puddle created at (786.9454, 802.4239) (added to group)
+[17:57:11] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.7°, current=89.3°, player=(376,857), corner_timer=-0.01
+[17:57:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[17:57:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(376,854), corner_timer=0.30
+[17:57:12] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:12] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.3°, player=(425,793), corner_timer=-0.01
+[17:57:12] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[17:57:12] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[17:57:12] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(428,792), corner_timer=0.30
+[17:57:12] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:12] [ENEMY] [Enemy3] Death animation completed
+[17:57:12] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.3°, player=(487,789), corner_timer=-0.01
+[17:57:12] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:12] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(488,789), corner_timer=0.30
+[17:57:12] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:12] [ENEMY] [Enemy1] PURSUING corner check: angle -36.5°
+[17:57:12] [ENEMY] [Enemy2] PURSUING corner check: angle 157.8°
+[17:57:12] [ENEMY] [Enemy4] PURSUING corner check: angle -97.9°
+[17:57:13] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=51.8°, current=53.4°, player=(534,742), corner_timer=0.15
+[17:57:13] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(537,739), corner_timer=-0.01
+[17:57:13] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:13] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(540,736), corner_timer=0.30
+[17:57:13] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=55.8°, current=7.8°, player=(546,731), corner_timer=0.10
+[17:57:13] [ENEMY] [Enemy1] State: PURSUING -> COMBAT
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.396, 735.4111), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[17:57:13] [ENEMY] [Enemy2] State: PURSUING -> COMBAT
+[17:57:13] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 3/3 -> 2/3
+[17:57:13] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:13] [INFO] [ImpactEffects] spawn_blood_effect called at (433.8405, 632.9631), dir=(1, 0), lethal=false
+[17:57:13] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:13] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:13] [INFO] [ImpactEffects] Blood effect spawned at (433.8405, 632.9631) (scale=1)
+[17:57:13] [ENEMY] [Enemy2] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=33.8°, current=180.0°, player=(564,720), corner_timer=0.06
+[17:57:13] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=51.4°, current=66.8°, player=(567,717), corner_timer=0.10
+[17:57:13] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:13] [ENEMY] [Enemy4] PURSUING corner check: angle -95.6°
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(577.3121, 718.168), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(596.5681, 706.9995), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[17:57:13] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(279.0485, 401.9333), source=ENEMY (Enemy1), range=1469, listeners=9
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=1, below_threshold=3
+[17:57:13] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P3:corner, state=RETREATING, target=157.8°, current=105.6°, player=(598,700), corner_timer=0.06
+[17:57:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(323.5547, 453.4095), shooter_id=46808434179, bullet_pos=(323.5547, 453.4095)
+[17:57:13] [INFO] [Bullet] Using shooter_position, distance=0
+[17:57:13] [INFO] [Bullet] Distance to wall: 0 (0% of viewport)
+[17:57:13] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[17:57:13] [INFO] [Bullet] Starting wall penetration at (323.5547, 453.4095)
+[17:57:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(577.31213, 718.16797), shooter_id=50365204183, bullet_pos=(330.49097, 458.39456)
+[17:57:13] [INFO] [Bullet] Using shooter_position, distance=358,33353
+[17:57:13] [INFO] [Bullet] Distance to wall: 358,33353 (24,39959% of viewport)
+[17:57:13] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:13] [INFO] [Bullet] Raycast backward hit penetrating body at distance 16.0023708343506
+[17:57:13] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:13] [INFO] [Bullet] Exiting penetration at (351.7847, 479.3423) after traveling 33.3333320617676 pixels through wall
+[17:57:13] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:57:13] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(603,699), corner_timer=-0.01
+[17:57:13] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:13] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(605,699), corner_timer=0.30
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(608.8305, 706.1791), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[17:57:13] [INFO] [BloodDecal] Blood puddle created at (492.5336, 643.8795) (added to group)
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(277.9192, 401.9337), source=ENEMY (Enemy1), range=1469, listeners=9
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=1, below_threshold=3
+[17:57:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(322.9608, 452.9421), shooter_id=46808434179, bullet_pos=(322.9608, 452.9421)
+[17:57:13] [INFO] [Bullet] Using shooter_position, distance=0
+[17:57:13] [INFO] [Bullet] Distance to wall: 0 (0% of viewport)
+[17:57:13] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[17:57:13] [INFO] [Bullet] Starting wall penetration at (322.9608, 452.9421)
+[17:57:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(596.56805, 706.9995), shooter_id=50365204183, bullet_pos=(321.5103, 477.3344)
+[17:57:13] [INFO] [Bullet] Using shooter_position, distance=358,33337
+[17:57:13] [INFO] [Bullet] Distance to wall: 358,33337 (24,399578% of viewport)
+[17:57:13] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:13] [INFO] [Bullet] Starting wall penetration at (321.5103, 477.3344)
+[17:57:13] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[17:57:13] [INFO] [Bullet] Exiting penetration at (292.08554, 452.7656) after traveling 33,333332 pixels through wall
+[17:57:13] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[17:57:13] [INFO] [Bullet] Raycast backward hit penetrating body at distance 15.4145908355713
+[17:57:13] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:13] [INFO] [Bullet] Exiting penetration at (351.4602, 478.5786) after traveling 33.3333358764648 pixels through wall
+[17:57:13] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:57:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(577.31213, 718.16797), shooter_id=50365204183, bullet_pos=(506.98135, 230.38733)
+[17:57:13] [INFO] [Bullet] Using shooter_position, distance=492,8249
+[17:57:13] [INFO] [Bullet] Distance to wall: 492,8249 (33,557354% of viewport)
+[17:57:13] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:13] [INFO] [BloodDecal] Blood puddle created at (486.4271, 661.1522) (added to group)
+[17:57:13] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 2/3 -> 1/3
+[17:57:13] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:13] [INFO] [ImpactEffects] spawn_blood_effect called at (438.9092, 607.8696), dir=(1, 0), lethal=false
+[17:57:13] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:13] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:13] [INFO] [ImpactEffects] Blood effect spawned at (438.9092, 607.8696) (scale=1)
+[17:57:13] [INFO] [BloodDecal] Blood puddle created at (529.1542, 614.5573) (added to group)
+[17:57:13] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(610.3519, 713.4286), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[17:57:13] [INFO] [BloodDecal] Blood puddle created at (486.845, 643.3793) (added to group)
+[17:57:13] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[17:57:13] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-111.2°, current=-112.1°, player=(610,707), corner_timer=-0.01
+[17:57:13] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[17:57:13] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P3:corner, state=RETREATING, target=-36.5°, current=43.5°, player=(609,708), corner_timer=0.10
+[17:57:13] [ENEMY] [Enemy1] State: RETREATING -> IN_COVER
+[17:57:13] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(686.3935, 914.0652), source=ENEMY (Enemy4), range=1469, listeners=9
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=1, below_threshold=6
+[17:57:13] [INFO] [LastChance] Threat detected: @Area2D@409
+[17:57:13] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[17:57:13] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:13] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[17:57:13] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 1/3 -> 0/3
+[17:57:13] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:13] [INFO] [ImpactEffects] spawn_blood_effect called at (442.2884, 591.1406), dir=(1, 0), lethal=true
+[17:57:13] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:13] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:13] [INFO] [ImpactEffects] Wall found for blood splatter at (500, 591.1406) (dist=57 px)
+[17:57:13] [INFO] [BloodDecal] Blood puddle created at (499, 591.1406) (added to group)
+[17:57:13] [INFO] [ImpactEffects] Blood effect spawned at (442.2884, 591.1406) (scale=1.5)
+[17:57:13] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[17:57:13] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[17:57:13] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 8)
+[17:57:13] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[17:57:13] [ENEMY] [Enemy2] Death animation started with hit direction: (1, 0)
+[17:57:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(577.31213, 718.16797), shooter_id=50365204183, bullet_pos=(333.69867, 56.010963)
+[17:57:13] [INFO] [Bullet] Using shooter_position, distance=705,549
+[17:57:13] [INFO] [Bullet] Distance to wall: 705,549 (48,04213% of viewport)
+[17:57:13] [INFO] [Bullet] Distance-based penetration chance: 90,617516%
+[17:57:13] [INFO] [Bullet] Starting wall penetration at (333.69867, 56.010963)
+[17:57:13] [INFO] [Player] Spawning blood effect at (604.31934, 717.9123), dir=(1, 0), lethal=False (C#)
+[17:57:13] [INFO] [ImpactEffects] spawn_blood_effect called at (604.3193, 717.9123), dir=(1, 0), lethal=false
+[17:57:13] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:13] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:13] [INFO] [ImpactEffects] Blood effect spawned at (604.3193, 717.9123) (scale=1)
+[17:57:13] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:57:13] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[17:57:13] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:57:13] [ENEMY] [Enemy1] State: SUPPRESSED -> SEEKING_COVER
+[17:57:13] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[17:57:13] [INFO] [Bullet] Exiting penetration at (313.19846, 35.381355) after traveling 24,083334 pixels through wall
+[17:57:13] [INFO] [Bullet] Damage multiplier after penetration: 0,225
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(602.1833, 728.6815), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=0, below_threshold=4
+[17:57:13] [ENEMY] [Enemy1] State: SEEKING_COVER -> IN_COVER
+[17:57:13] [INFO] [BloodDecal] Blood puddle created at (524.0566, 661.0466) (added to group)
+[17:57:13] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[17:57:13] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[17:57:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(678.2569, 914.0652), source=ENEMY (Enemy4), range=1469, listeners=8
+[17:57:13] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=6
+[17:57:13] [INFO] [LastChance] Threat detected: @Area2D@427
+[17:57:13] [INFO] [LastChance] Triggering last chance effect!
+[17:57:13] [INFO] [LastChance] Starting last chance effect:
+[17:57:13] [INFO] [LastChance]   - Time will be frozen (except player)
+[17:57:13] [INFO] [LastChance]   - Duration: 6.0 real seconds
+[17:57:13] [INFO] [LastChance]   - Sepia intensity: 0.70
+[17:57:13] [INFO] [LastChance]   - Brightness: 0.60
+[17:57:13] [INFO] [LastChance] Pushed bullet Bullet from distance 90.0 to 200.0
+[17:57:13] [INFO] [LastChance] Pushed bullet @Area2D@427 from distance 134.0 to 200.0
+[17:57:13] [INFO] [LastChance] Pushed 2 threatening bullets away from player
+[17:57:13] [INFO] [LastChance] Set player Player and all 24 children to PROCESS_MODE_ALWAYS
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'WallTop' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'WallBottom' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'WallLeft' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'WallRight' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room1_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room1_WallRight' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room2_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room2_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room2_WallRight' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallTop' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room3_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room3_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room4_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room4_WallTop' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room5_WallTop' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room5_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Left' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Right' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallTop' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallRight' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallRight' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallTop' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBL' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTL' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Desk1' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Desk2' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Table1' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Cabinet1' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Cabinet2' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Desk3' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Desk4' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Table2' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Table3' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'Cabinet3' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'StorageCrate1' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'StorageCrate2' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Set StaticBody2D 'HallTable' to PROCESS_MODE_ALWAYS for collision
+[17:57:13] [INFO] [LastChance] Skipping player node: Player
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: Casing
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@287
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@288
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@291
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@294
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@296
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@309
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@385
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@387
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@390
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@392
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@396
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@399
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@407
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@410
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@424
+[17:57:13] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@428
+[17:57:13] [INFO] [LastChance] Froze all nodes except player and autoloads (including GameManager for quick restart)
+[17:57:13] [INFO] [LastChance] Applied visual effects: sepia=0.70, brightness=0.60, ripple=0.0080
+[17:57:13] [INFO] [LastChance] Applied 4.0x saturation to 6 player sprites
+[17:57:13] [INFO] [BloodDecal] Blood puddle created at (527.0363, 703.2434) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (484.8324, 643.8918) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (486.4859, 636.5488) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (631.665, 694.637) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (522.5571, 667.1598) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (516.317, 606.3018) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (492.3253, 649.511) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (671.4485, 711.4525) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (675.2643, 751.5035) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (494.3129, 617.4345) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (657.1145, 733.8635) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (522.8588, 669.9753) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (559.3569, 616.1491) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (728.0895, 761.4332) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (702.4552, 764.8807) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (530.2255, 648.6086) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (623.3586, 623.616) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (695.2068, 745.789) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (545.2169, 740.6104) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (615.7848, 788.3101) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (548.1664, 654.3032) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (590.776, 728.5258) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (597.0507, 647.9392) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (563.2912, 616.3701) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (579.3987, 660.1978) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (556.7569, 722.913) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (545.6032, 624.1971) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (597.9831, 697.2694) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (617.6423, 636.0082) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (611.1401, 617.4399) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (626.33, 712.9798) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (606.6011, 768.7614) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (754.4632, 752.1567) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (593.5424, 710.29) (added to group)
+[17:57:14] [INFO] [BloodDecal] Blood puddle created at (666.9819, 812.3358) (added to group)
+[17:57:15] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@468
+[17:57:15] [INFO] [LastChance] Registered frozen player bullet: @Area2D@468
+[17:57:15] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@469
+[17:57:15] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@469
+[17:57:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(594.5934, 790.1543), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[17:57:15] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@470
+[17:57:15] [INFO] [LastChance] Registered frozen player bullet: @Area2D@470
+[17:57:15] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@471
+[17:57:15] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@471
+[17:57:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(594.5934, 790.1543), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[17:57:15] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@472
+[17:57:15] [INFO] [LastChance] Registered frozen player bullet: @Area2D@472
+[17:57:15] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@473
+[17:57:15] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@473
+[17:57:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(594.5934, 790.1543), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[17:57:15] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@474
+[17:57:15] [INFO] [LastChance] Registered frozen player bullet: @Area2D@474
+[17:57:15] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@475
+[17:57:15] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@475
+[17:57:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(594.5934, 790.1543), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[17:57:15] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@476
+[17:57:15] [INFO] [LastChance] Registered frozen player bullet: @Area2D@476
+[17:57:15] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@477
+[17:57:15] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@477
+[17:57:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(594.5934, 788.0209), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=6
+[17:57:17] [INFO] [ScoreManager] Combo ended at 2. Max combo: 2
+[17:57:17] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@484
+[17:57:17] [INFO] [LastChance] Registered frozen player bullet: @Area2D@484
+[17:57:17] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@485
+[17:57:17] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@485
+[17:57:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(460.4604, 412.8022), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[17:57:17] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@487
+[17:57:17] [INFO] [LastChance] Registered frozen player bullet: @Area2D@487
+[17:57:17] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@488
+[17:57:17] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@488
+[17:57:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(460.4604, 387.9133), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[17:57:17] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@489
+[17:57:17] [INFO] [LastChance] Registered frozen player bullet: @Area2D@489
+[17:57:17] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@490
+[17:57:17] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@490
+[17:57:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(460.4604, 376.6355), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[17:57:17] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@491
+[17:57:17] [INFO] [LastChance] Registered frozen player bullet: @Area2D@491
+[17:57:17] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@492
+[17:57:17] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@492
+[17:57:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(460.4604, 375.5799), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[17:57:17] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@494
+[17:57:17] [INFO] [LastChance] Registered frozen player bullet: @Area2D@494
+[17:57:17] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@495
+[17:57:17] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@495
+[17:57:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(460.4604, 363.9133), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[17:57:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=4
+[17:57:18] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[17:57:18] [ENEMY] [Enemy1] Player reloading: false -> true
+[17:57:18] [ENEMY] [Enemy4] Player reloading: false -> true
+[17:57:18] [ENEMY] [Enemy5] Player reloading: false -> true
+[17:57:18] [ENEMY] [Enemy6] Player reloading: false -> true
+[17:57:18] [ENEMY] [Enemy7] Player reloading: false -> true
+[17:57:18] [ENEMY] [Enemy8] Player reloading: false -> true
+[17:57:18] [ENEMY] [Enemy9] Player reloading: false -> true
+[17:57:18] [ENEMY] [Enemy10] Player reloading: false -> true
+[17:57:18] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(460.4604, 275.0799), source=PLAYER (Player), range=900, listeners=8
+[17:57:18] [ENEMY] [Enemy1] Heard player RELOAD at (460.4604, 275.0799), intensity=0.05, distance=223
+[17:57:18] [ENEMY] [Enemy1] Vulnerability sound triggered pursuit - transitioning from SUPPRESSED to PURSUING
+[17:57:18] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=1
+[17:57:18] [INFO] [BloodyFeet:Player] Blood ran out - no more footprints
+[17:57:18] [INFO] [Player.Reload.Anim] LeftArm: pos=(4.149328, 2.0312831), target=(4, 2), base=(24, 6)
+[17:57:18] [INFO] [Player.Reload.Anim] RightArm: pos=(-1.992912, 6), target=(-2, 6), base=(-2, 6)
+[17:57:18] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[17:57:18] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[17:57:18] [ENEMY] [Enemy1] Player reloading: true -> false
+[17:57:18] [ENEMY] [Enemy4] Player reloading: true -> false
+[17:57:18] [ENEMY] [Enemy5] Player reloading: true -> false
+[17:57:18] [ENEMY] [Enemy6] Player reloading: true -> false
+[17:57:18] [ENEMY] [Enemy7] Player reloading: true -> false
+[17:57:18] [ENEMY] [Enemy8] Player reloading: true -> false
+[17:57:18] [ENEMY] [Enemy9] Player reloading: true -> false
+[17:57:18] [ENEMY] [Enemy10] Player reloading: true -> false
+[17:57:18] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[17:57:18] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[17:57:19] [INFO] [LastChance] Effect duration expired after 6.00 real seconds
+[17:57:19] [INFO] [LastChance] Ending last chance effect
+[17:57:19] [ENEMY] [Enemy1] Memory reset: confusion=2.0s, had_target=true
+[17:57:19] [ENEMY] [Enemy1] Search mode: PURSUING -> SEARCHING at (564.1473, 720.1196)
+[17:57:19] [ENEMY] [Enemy1] SEARCHING started: center=(564.1473, 720.1196), radius=100, waypoints=5
+[17:57:19] [ENEMY] [Enemy4] Memory reset: confusion=2.0s, had_target=true
+[17:57:19] [ENEMY] [Enemy4] Search mode: COMBAT -> SEARCHING at (601.2651, 725.3489)
+[17:57:19] [ENEMY] [Enemy4] SEARCHING started: center=(601.2651, 725.3489), radius=100, waypoints=5
+[17:57:19] [ENEMY] [Enemy5] Memory reset: confusion=2.0s, had_target=false
+[17:57:19] [ENEMY] [Enemy6] Memory reset: confusion=2.0s, had_target=false
+[17:57:19] [ENEMY] [Enemy7] Memory reset: confusion=2.0s, had_target=false
+[17:57:19] [ENEMY] [Enemy8] Memory reset: confusion=2.0s, had_target=false
+[17:57:19] [ENEMY] [Enemy9] Memory reset: confusion=2.0s, had_target=false
+[17:57:19] [ENEMY] [Enemy10] Memory reset: confusion=2.0s, had_target=false
+[17:57:19] [INFO] [LastChance] Reset memory for 8 enemies (player teleport effect)
+[17:57:19] [INFO] [LastChance] All process modes restored
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@468
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@470
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@472
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@474
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@476
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@484
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@487
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@489
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@491
+[17:57:19] [INFO] [LastChance] Unfroze player bullet: @Area2D@494
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: Casing
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@287
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@288
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@291
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@294
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@296
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@309
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@385
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@387
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@390
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@392
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@396
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@399
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@407
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@410
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@424
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@428
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@469
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@471
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@473
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@475
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@477
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@485
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@488
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@490
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@492
+[17:57:19] [INFO] [LastChance] Unfroze bullet casing: @RigidBody2D@495
+[17:57:19] [INFO] [LastChance] Restored original colors to 5 player sprites
+[17:57:19] [INFO] [LastChance] Called player RefreshHealthVisual (C#)
+[17:57:19] [ENEMY] [Enemy1] ROT_CHANGE: P3:corner -> P2:combat_state, state=SEARCHING, target=-32.8°, current=22.9°, player=(748,80), corner_timer=0.10
+[17:57:19] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=SEARCHING, target=-85.2°, current=-112.2°, player=(748,80), corner_timer=-0.01
+[17:57:19] [ENEMY] [Enemy4] SEARCHING corner check: angle 157.8°
+[17:57:19] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(759,80), corner_timer=-0.01
+[17:57:19] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:19] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 3/3 -> 2/3
+[17:57:19] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:19] [INFO] [ImpactEffects] spawn_blood_effect called at (664.7125, 908.9415), dir=(1, 0), lethal=false
+[17:57:19] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:19] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:19] [INFO] [ImpactEffects] Blood effect spawned at (664.7125, 908.9415) (scale=1)
+[17:57:19] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 2/3 -> 1/3
+[17:57:19] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:19] [INFO] [ImpactEffects] spawn_blood_effect called at (664.7125, 908.9415), dir=(1, 0), lethal=false
+[17:57:19] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:19] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:19] [INFO] [ImpactEffects] Blood effect spawned at (664.7125, 908.9415) (scale=1)
+[17:57:19] [ENEMY] [Enemy4] Hit taken, damage: 1, health: 1/3 -> 0/3
+[17:57:19] [ENEMY] [Enemy4] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:19] [INFO] [ImpactEffects] spawn_blood_effect called at (664.7125, 908.9415), dir=(1, 0), lethal=true
+[17:57:19] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:19] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:19] [INFO] [ImpactEffects] Blood effect spawned at (664.7125, 908.9415) (scale=1.5)
+[17:57:19] [ENEMY] [Enemy4] Enemy died (ricochet: false, penetration: false)
+[17:57:19] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[17:57:19] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 7)
+[17:57:19] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[17:57:19] [ENEMY] [Enemy4] Death animation started with hit direction: (1, 0)
+[17:57:19] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=92.1°, player=(765,80), corner_timer=0.30
+[17:57:20] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 4/4 -> 3/4
+[17:57:20] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:20] [INFO] [ImpactEffects] spawn_blood_effect called at (285.3605, 388.0934), dir=(1, 0), lethal=false
+[17:57:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:20] [INFO] [ImpactEffects] Blood effect spawned at (285.3605, 388.0934) (scale=1)
+[17:57:20] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 3/4 -> 2/4
+[17:57:20] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:20] [INFO] [ImpactEffects] spawn_blood_effect called at (285.3605, 388.0934), dir=(1, 0), lethal=false
+[17:57:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:20] [INFO] [ImpactEffects] Blood effect spawned at (285.3605, 388.0934) (scale=1)
+[17:57:20] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 2/4 -> 1/4
+[17:57:20] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:20] [INFO] [ImpactEffects] spawn_blood_effect called at (285.3605, 388.0934), dir=(1, 0), lethal=false
+[17:57:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:20] [INFO] [ImpactEffects] Blood effect spawned at (285.3605, 388.0934) (scale=1)
+[17:57:20] [ENEMY] [Enemy1] Hit taken, damage: 1, health: 1/4 -> 0/4
+[17:57:20] [ENEMY] [Enemy1] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:20] [INFO] [ImpactEffects] spawn_blood_effect called at (285.3605, 388.0934), dir=(1, 0), lethal=true
+[17:57:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:20] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:20] [INFO] [ImpactEffects] Blood effect spawned at (285.3605, 388.0934) (scale=1.5)
+[17:57:20] [ENEMY] [Enemy1] Enemy died (ricochet: false, penetration: false)
+[17:57:20] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[17:57:20] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 6)
+[17:57:20] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[17:57:20] [ENEMY] [Enemy1] Death animation started with hit direction: (1, 0)
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(602.1833, 728.6815), shooter_id=50365204183, bullet_pos=(297.3081, 467.23712)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=401,62427
+[17:57:20] [INFO] [Bullet] Distance to wall: 401,62427 (27,347336% of viewport)
+[17:57:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(594.59344, 788.02094), shooter_id=50365204183, bullet_pos=(746.6826, 996.8391)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=258,3334
+[17:57:20] [INFO] [Bullet] Distance to wall: 258,3334 (17,590397% of viewport)
+[17:57:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:20] [INFO] [Bullet] Starting wall penetration at (746.6826, 996.8391)
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(594.59344, 790.1543), shooter_id=50365204183, bullet_pos=(718.76984, 1016.6854)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=258,33337
+[17:57:20] [INFO] [Bullet] Distance to wall: 258,33337 (17,590395% of viewport)
+[17:57:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:20] [INFO] [Bullet] Raycast backward hit penetrating body at distance 4,731922
+[17:57:20] [INFO] [Bullet] Max penetration distance exceeded: 66,66667 >= 48
+[17:57:20] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:20] [INFO] [Bullet] Exiting penetration at (788.8751, 1054.7692) after traveling 66,66667 pixels through wall
+[17:57:20] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(460.46045, 363.91327), shooter_id=50365204183, bullet_pos=(36.95288, 399.4998)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=425,00006
+[17:57:20] [INFO] [Bullet] Distance to wall: 425,00006 (28,939035% of viewport)
+[17:57:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:20] [INFO] [Bullet] Starting wall penetration at (36.95288, 399.4998)
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(645.499, 854.4202), shooter_id=47714403897, bullet_pos=(516.582, 546.2016)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=334.09326171875
+[17:57:20] [INFO] [Bullet] Distance to wall: 334.09326171875 (22.7490245337666% of viewport)
+[17:57:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:20] [INFO] [Bullet] Raycast backward hit penetrating body at distance 33,363
+[17:57:20] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:20] [INFO] [Bullet] Exiting penetration at (-1.2458382, 402.70956) after traveling 33,333336 pixels through wall
+[17:57:20] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(602.1833, 728.6815), shooter_id=50365204183, bullet_pos=(64.43536, 681.82544)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=539,78546
+[17:57:20] [INFO] [Bullet] Distance to wall: 539,78546 (36,754986% of viewport)
+[17:57:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(602.1833, 728.6815), shooter_id=50365204183, bullet_pos=(108.269135, 711.9136)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=494,1987
+[17:57:20] [INFO] [Bullet] Distance to wall: 494,1987 (33,650898% of viewport)
+[17:57:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(602.1833, 728.6815), shooter_id=50365204183, bullet_pos=(52.206223, 747.51654)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=550,29944
+[17:57:20] [INFO] [Bullet] Distance to wall: 550,29944 (37,4709% of viewport)
+[17:57:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (744.407, 919.4789) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (343.776, 382.424) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (333.6214, 404.3695) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (340.4193, 374.5157) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (332.5541, 380.2281) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (715.3646, 937.1055) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (368.925, 408.6831) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (324.3581, 390.8488) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (342.6084, 381.8) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (721.066, 930.6249) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (746.6586, 894.0657) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (334.069, 381.2522) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (349.2198, 390.1714) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (764.7061, 931.77) (added to group)
+[17:57:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(867,80), corner_timer=-0.01
+[17:57:20] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (363.005, 391.6439) (added to group)
+[17:57:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(871,80), corner_timer=0.30
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (721.7477, 955.6747) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (718.7908, 961.1544) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (756.0607, 899.2333) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (352.0174, 392.1221) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (355.8506, 429.817) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (363.0872, 373.5024) (added to group)
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(645.499, 854.4202), shooter_id=47714403897, bullet_pos=(632.8176, 44.49033)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=810.029174804688
+[17:57:20] [INFO] [Bullet] Distance to wall: 810.029174804688 (55.1563760247618% of viewport)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (727.9359, 945.9231) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (763.6249, 899.8735) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (367.9301, 429.423) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (395.0843, 372.8351) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (393.9548, 404.7595) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (400.1488, 445.9818) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (767.5141, 916.5025) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (350.0991, 419.3413) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (374.9147, 421.0809) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (789.2399, 972.4672) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (805.9725, 967.7001) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (351.6654, 422.5112) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (385.1288, 404.7046) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (759.7931, 911.5605) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (743.0338, 979.9429) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (413.1649, 431.2662) (added to group)
+[17:57:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (799.9297, 948.4518) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (813.3307, 937.2865) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (768.5919, 956.9202) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (787.482, 997.4454) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (791.0822, 937.4575) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (395.138, 448.4338) (added to group)
+[17:57:20] [ENEMY] [Enemy4] Ragdoll activated
+[17:57:20] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (435.2786, 468.9328) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (360.014, 422.8102) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (380.9036, 422.9226) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (421.8324, 456.2262) (added to group)
+[17:57:20] [ENEMY] [Enemy1] Ragdoll activated
+[17:57:20] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (741.0452, 994.1527) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (792.5124, 936.7446) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (765.7728, 939.1468) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (375.0482, 437.208) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (814.0842, 909.6727) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (435.1801, 456.1823) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (361.2766, 421.5227) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (397.1658, 436.2993) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (835.1456, 937.0248) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (863.7556, 976.598) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (435.5381, 467.1621) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (467.4877, 436.7404) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (772.7506, 997.8868) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (844.406, 926.7782) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (772.2946, 971.1138) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (796.7098, 964.4901) (added to group)
+[17:57:20] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(602.1833, 728.6815), shooter_id=50365204183, bullet_pos=(504.2509, 982.7914)
+[17:57:20] [INFO] [Bullet] Using shooter_position, distance=272,32806
+[17:57:20] [INFO] [Bullet] Distance to wall: 272,32806 (18,54332% of viewport)
+[17:57:20] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(968,90), corner_timer=-0.01
+[17:57:20] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (440.871, 486.7967) (added to group)
+[17:57:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(972,93), corner_timer=0.30
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (830.7898, 953.4681) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (409.2247, 444.7075) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (439.5916, 471.1192) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (498.0699, 531.9003) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (396.219, 442.7535) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (444.3817, 470.4465) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (482.4833, 406.3957) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (825.1689, 982.7236) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (462.6344, 423.5114) (added to group)
+[17:57:20] [INFO] [BloodDecal] Blood puddle created at (401.1914, 450.0829) (added to group)
+[17:57:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:21] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(1046,157), corner_timer=-0.01
+[17:57:21] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:21] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1050,158), corner_timer=0.30
+[17:57:21] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:21] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(1148,167), corner_timer=-0.01
+[17:57:21] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:21] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1152,168), corner_timer=0.30
+[17:57:21] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:21] [ENEMY] [Enemy4] Death animation completed
+[17:57:21] [ENEMY] [Enemy1] Death animation completed
+[17:57:21] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1246,183), corner_timer=-0.01
+[17:57:21] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:21] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1251,183), corner_timer=0.30
+[17:57:22] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:22] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1336,144), corner_timer=-0.01
+[17:57:22] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:22] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1339,141), corner_timer=0.30
+[17:57:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1355.007, 132.1102), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[17:57:22] [ENEMY] [Enemy5] Heard gunshot at (1355.007, 132.1102), source_type=0, intensity=0.02, distance=408
+[17:57:22] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=3
+[17:57:22] [ENEMY] [Enemy5] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-147.0°, current=101.3°, player=(1355,126), corner_timer=0.00
+[17:57:22] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1383.378, 115.9063), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[17:57:22] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=3
+[17:57:22] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1355.0066, 132.11017), shooter_id=50365204183, bullet_pos=(1844.935, 320.7782)
+[17:57:22] [INFO] [Bullet] Using shooter_position, distance=525,0005
+[17:57:22] [INFO] [Bullet] Distance to wall: 525,0005 (35,74825% of viewport)
+[17:57:22] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1408.35, 110.5663), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[17:57:22] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=3
+[17:57:22] [ENEMY] [Enemy5] Hit taken, damage: 1, health: 4/4 -> 3/4
+[17:57:22] [ENEMY] [Enemy5] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:22] [INFO] [ImpactEffects] spawn_blood_effect called at (1684.076, 292.8244), dir=(1, 0), lethal=false
+[17:57:22] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:22] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:22] [INFO] [ImpactEffects] Blood effect spawned at (1684.076, 292.8244) (scale=1)
+[17:57:22] [ENEMY] [Enemy5] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-145.4°, current=180.0°, player=(1410,104), corner_timer=0.00
+[17:57:22] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1412,104), corner_timer=-0.01
+[17:57:22] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:22] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1414,104), corner_timer=0.30
+[17:57:22] [ENEMY] [Enemy5] State: COMBAT -> RETREATING
+[17:57:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1421.7, 112.3534), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[17:57:22] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=3
+[17:57:22] [ENEMY] [Enemy5] Hit taken, damage: 1, health: 3/4 -> 2/4
+[17:57:22] [ENEMY] [Enemy5] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:22] [INFO] [ImpactEffects] spawn_blood_effect called at (1687.906, 286.9151), dir=(1, 0), lethal=false
+[17:57:22] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:22] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:22] [INFO] [ImpactEffects] Blood effect spawned at (1687.906, 286.9151) (scale=1)
+[17:57:22] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1423.219, 120.2202), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[17:57:22] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=3
+[17:57:23] [ENEMY] [Enemy5] Hit taken, damage: 1, health: 2/4 -> 1/4
+[17:57:23] [ENEMY] [Enemy5] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:23] [INFO] [ImpactEffects] spawn_blood_effect called at (1703.236, 294.4156), dir=(1, 0), lethal=false
+[17:57:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:23] [INFO] [ImpactEffects] Blood effect spawned at (1703.236, 294.4156) (scale=1)
+[17:57:23] [ENEMY] [Enemy5] ROT_CHANGE: P1:visible -> P4:velocity, state=RETREATING, target=-157.4°, current=119.1°, player=(1420,116), corner_timer=0.00
+[17:57:23] [ENEMY] [Enemy6] Memory: high confidence (0.90) - transitioning to PURSUING
+[17:57:23] [ENEMY] [Enemy6] State: IDLE -> PURSUING
+[17:57:23] [ENEMY] [Enemy6] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-148.1°, current=146.3°, player=(1417,118), corner_timer=0.00
+[17:57:23] [ENEMY] [Enemy6] PURSUING corner check: angle 150.2°
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1732.352, 328.8873) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1738.416, 331.4822) (added to group)
+[17:57:23] [ENEMY] [Enemy5] Hit taken, damage: 1, health: 1/4 -> 0/4
+[17:57:23] [ENEMY] [Enemy5] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:23] [INFO] [ImpactEffects] spawn_blood_effect called at (1691.368, 289.6082), dir=(1, 0), lethal=true
+[17:57:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:23] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:23] [INFO] [ImpactEffects] Blood effect spawned at (1691.368, 289.6082) (scale=1.5)
+[17:57:23] [ENEMY] [Enemy5] Enemy died (ricochet: false, penetration: false)
+[17:57:23] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[17:57:23] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 5)
+[17:57:23] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[17:57:23] [ENEMY] [Enemy5] Death animation started with hit direction: (1, 0)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1766.264, 293.611) (added to group)
+[17:57:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1406,121), corner_timer=-0.01
+[17:57:23] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1404,121), corner_timer=0.30
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1759.117, 309.0629) (added to group)
+[17:57:23] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1777.115, 295.7942) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1748.791, 330.6812) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1766.102, 328.9492) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1756.244, 329.1302) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1865.859, 380.3603) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1818.717, 266.8132) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1821.033, 355.4987) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1727.907, 316.3645) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1812.122, 305.8492) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1772.977, 282.5652) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1777.89, 405.4942) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1775.205, 382.397) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1766.681, 339.3113) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1733.194, 304.3376) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1753.291, 308.2418) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1801.835, 437.1892) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1739.946, 322.4411) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1787.346, 398.6468) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1792.275, 315.5143) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1745.612, 328.5764) (added to group)
+[17:57:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1320,123), corner_timer=-0.01
+[17:57:23] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1847.802, 368.5052) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1854.387, 403.407) (added to group)
+[17:57:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1317,123), corner_timer=0.30
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1867.536, 445.9962) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1773.228, 292.4332) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1777.774, 377.9436) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1816.507, 402.8264) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1816.876, 364.3916) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1805.8, 360.802) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1790.234, 282.2885) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1786.288, 306.9111) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1885.911, 391.1969) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1803.54, 292.0677) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1771.131, 357.2791) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1787.895, 316.9122) (added to group)
+[17:57:23] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1796.429, 376.1915) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1855.336, 327.8807) (added to group)
+[17:57:23] [ENEMY] [Enemy5] Ragdoll activated
+[17:57:23] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1816.207, 318.5332) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1772.496, 342.4275) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1815.15, 311.2546) (added to group)
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1818.446, 404.4401) (added to group)
+[17:57:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1321,123), corner_timer=-0.01
+[17:57:23] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:23] [INFO] [BloodDecal] Blood puddle created at (1834.121, 402.4362) (added to group)
+[17:57:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1324,122), corner_timer=0.30
+[17:57:24] [INFO] [BloodDecal] Blood puddle created at (1905.33, 495.9277) (added to group)
+[17:57:24] [INFO] [BloodDecal] Blood puddle created at (1879.161, 419.1159) (added to group)
+[17:57:24] [ENEMY] [Enemy6] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-155.7°, current=-106.5°, player=(1345,113), corner_timer=0.02
+[17:57:24] [ENEMY] [Enemy6] State: PURSUING -> COMBAT
+[17:57:24] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1364.383, 106.4251), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:24] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[17:57:24] [INFO] [BloodyFeet:Enemy6] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[17:57:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1386.184, 93.82407), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:24] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[17:57:24] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1387,86), corner_timer=-0.01
+[17:57:24] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:24] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1389,85), corner_timer=0.30
+[17:57:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1394.693, 86.06806), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:24] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=2
+[17:57:24] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:24] [ENEMY] [Enemy6] Hit taken, damage: 1, health: 4/4 -> 3/4
+[17:57:24] [ENEMY] [Enemy6] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:24] [INFO] [ImpactEffects] spawn_blood_effect called at (1803.21, 327.9319), dir=(1, 0), lethal=false
+[17:57:24] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:24] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:24] [INFO] [ImpactEffects] Blood effect spawned at (1803.21, 327.9319) (scale=1)
+[17:57:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1389.259, 91.50776), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:24] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=2
+[17:57:24] [ENEMY] [Enemy6] Hit taken, damage: 1, health: 3/4 -> 2/4
+[17:57:24] [ENEMY] [Enemy6] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:24] [INFO] [ImpactEffects] spawn_blood_effect called at (1785.186, 304.1209), dir=(1, 0), lethal=false
+[17:57:24] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:24] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:24] [INFO] [ImpactEffects] Wall found for blood splatter at (1840, 304.1209) (dist=54 px)
+[17:57:24] [INFO] [BloodDecal] Blood puddle created at (1839, 304.1209) (added to group)
+[17:57:24] [INFO] [ImpactEffects] Blood effect spawned at (1785.186, 304.1209) (scale=1)
+[17:57:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1374.172, 106.5971), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:24] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=2
+[17:57:24] [ENEMY] [Enemy6] State: COMBAT -> RETREATING
+[17:57:24] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1371,103), corner_timer=-0.01
+[17:57:24] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:24] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1368,105), corner_timer=0.30
+[17:57:24] [ENEMY] [Enemy6] Hit taken, damage: 1, health: 2/4 -> 1/4
+[17:57:24] [ENEMY] [Enemy6] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:24] [INFO] [ImpactEffects] spawn_blood_effect called at (1768.692, 290.6161), dir=(1, 0), lethal=false
+[17:57:24] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:24] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:24] [INFO] [ImpactEffects] Wall found for blood splatter at (1840, 290.6161) (dist=71 px)
+[17:57:24] [INFO] [BloodDecal] Blood puddle created at (1839, 290.6161) (added to group)
+[17:57:24] [INFO] [ImpactEffects] Blood effect spawned at (1768.692, 290.6161) (scale=1)
+[17:57:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1772.911, 291.2513), source=ENEMY (Enemy6), range=1469, listeners=5
+[17:57:24] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=4
+[17:57:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1350.562, 130.2068), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:24] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=2
+[17:57:24] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1783.413, 291.9825), source=ENEMY (Enemy6), range=1469, listeners=5
+[17:57:24] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=4
+[17:57:24] [ENEMY] [Enemy6] ROT_CHANGE: P1:visible -> P3:corner, state=RETREATING, target=150.2°, current=-98.8°, player=(1335,139), corner_timer=0.02
+[17:57:24] [ENEMY] [Enemy5] Death animation completed
+[17:57:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1325.672, 155.0969), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:25] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=3
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1859.654, 356.2945) (added to group)
+[17:57:25] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1709.675, 273.0222), shooter_id=48318383709, bullet_pos=(1381.475, 214.7544)
+[17:57:25] [INFO] [Bullet] Using shooter_position, distance=333.332916259766
+[17:57:25] [INFO] [Bullet] Distance to wall: 333.332916259766 (22.6972512133123% of viewport)
+[17:57:25] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:25] [INFO] [Bullet] Starting wall penetration at (1381.475, 214.7544)
+[17:57:25] [INFO] [Bullet] Raycast backward hit penetrating body at distance 20.585376739502
+[17:57:25] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:25] [INFO] [Bullet] Exiting penetration at (1343.732, 208.0536) after traveling 33.3333358764648 pixels through wall
+[17:57:25] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1856.655, 336.156) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1838.069, 314.4712) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1882.26, 342.6433) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1927.638, 365.5069) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1879.05, 370.356) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1847.691, 339.8374) (added to group)
+[17:57:25] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1325.6715, 155.09692), shooter_id=50365204183, bullet_pos=(1625.5756, 280.32797)
+[17:57:25] [INFO] [Bullet] Using shooter_position, distance=325,0004
+[17:57:25] [INFO] [Bullet] Distance to wall: 325,0004 (22,129875% of viewport)
+[17:57:25] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:25] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1300,174), corner_timer=-0.01
+[17:57:25] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:25] [ENEMY] [Enemy6] State: RETREATING -> IN_COVER
+[17:57:25] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1298,176), corner_timer=0.30
+[17:57:25] [ENEMY] [Enemy6] State: IN_COVER -> SUPPRESSED
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1906.807, 397.9612) (added to group)
+[17:57:25] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1716.824, 276.4001), shooter_id=48318383709, bullet_pos=(1121.105, 61.38838)
+[17:57:25] [INFO] [Bullet] Using shooter_position, distance=633.33349609375
+[17:57:25] [INFO] [Bullet] Distance to wall: 633.33349609375 (43.1248423466312% of viewport)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1895.997, 391.6237) (added to group)
+[17:57:25] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1913.161, 406.9918) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1981.329, 348.0314) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1875.983, 388.0748) (added to group)
+[17:57:25] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1374.1716, 106.597115), shooter_id=50365204183, bullet_pos=(2486.9856, 694.00476)
+[17:57:25] [INFO] [Bullet] Using shooter_position, distance=1258,3333
+[17:57:25] [INFO] [Bullet] Distance to wall: 1258,3333 (85,68223% of viewport)
+[17:57:25] [INFO] [Bullet] Distance-based penetration chance: 46,70408%
+[17:57:25] [INFO] [Bullet] Penetration failed (distance roll)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1983.874, 412.5533) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1923.637, 413.6611) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1908.026, 472.9709) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1955.252, 379.3505) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (2016.194, 365.598) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1961.266, 406.2498) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1970.324, 428.7159) (added to group)
+[17:57:25] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1350.5621, 130.20679), shooter_id=50365204183, bullet_pos=(2488.4443, 667.4484)
+[17:57:25] [INFO] [Bullet] Using shooter_position, distance=1258,334
+[17:57:25] [INFO] [Bullet] Distance to wall: 1258,334 (85,68228% of viewport)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1878.79, 396.9438) (added to group)
+[17:57:25] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1279,195), corner_timer=-0.01
+[17:57:25] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:25] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1279,195), corner_timer=0.30
+[17:57:25] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1325.6715, 155.09692), shooter_id=50365204183, bullet_pos=(2335.7253, 66.41983)
+[17:57:25] [INFO] [Bullet] Using shooter_position, distance=1013,939
+[17:57:25] [INFO] [Bullet] Distance to wall: 1013,939 (69,04097% of viewport)
+[17:57:25] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1716.824, 276.4001), shooter_id=48318383709, bullet_pos=(518.5573, 239.5446)
+[17:57:25] [INFO] [Bullet] Using shooter_position, distance=1198.83349609375
+[17:57:25] [INFO] [Bullet] Distance to wall: 1198.83349609375 (81.6307772094384% of viewport)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1874.951, 391.3256) (added to group)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1938.446, 409.3098) (added to group)
+[17:57:25] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1325.6715, 155.09692), shooter_id=50365204183, bullet_pos=(2475.78, 118.71766)
+[17:57:25] [INFO] [Bullet] Using shooter_position, distance=1150,6837
+[17:57:25] [INFO] [Bullet] Distance to wall: 1150,6837 (78,35217% of viewport)
+[17:57:25] [INFO] [BloodDecal] Blood puddle created at (1910.502, 431.2545) (added to group)
+[17:57:25] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:25] [ENEMY] [Enemy6] State: SUPPRESSED -> SEEKING_COVER
+[17:57:25] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1312,160), corner_timer=-0.01
+[17:57:25] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:25] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1315,157), corner_timer=0.30
+[17:57:26] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1365.288, 114.0842), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:26] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[17:57:26] [ENEMY] [Enemy6] ROT_CHANGE: P3:corner -> P1:visible, state=SEEKING_COVER, target=-151.8°, current=178.8°, player=(1374,100), corner_timer=0.02
+[17:57:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1871.403, 367.0558), source=ENEMY (Enemy6), range=1469, listeners=5
+[17:57:26] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=4
+[17:57:26] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1384,92), corner_timer=-0.01
+[17:57:26] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1386.356, 96.27598), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:26] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[17:57:26] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1386,90), corner_timer=0.30
+[17:57:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1860.27, 398.341), source=ENEMY (Enemy6), range=1469, listeners=5
+[17:57:26] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=1, below_threshold=4
+[17:57:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1396.859, 86.06647), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:26] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[17:57:26] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:26] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1799.005, 366.735), shooter_id=48318383709, bullet_pos=(1660.413, 274.1603)
+[17:57:26] [INFO] [Bullet] Using shooter_position, distance=166.666763305664
+[17:57:26] [INFO] [Bullet] Distance to wall: 166.666763305664 (11.3486463866363% of viewport)
+[17:57:26] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:26] [INFO] [Bullet] Starting wall penetration at (1660.413, 274.1603)
+[17:57:26] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[17:57:26] [INFO] [Bullet] Exiting penetration at (1628.537, 252.8681) after traveling 33.3333358764648 pixels through wall
+[17:57:26] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:57:26] [ENEMY] [Enemy6] ROT_CHANGE: P1:visible -> P3:corner, state=SEEKING_COVER, target=150.2°, current=-147.3°, player=(1398,80), corner_timer=0.02
+[17:57:26] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1813.266, 342.7865), shooter_id=48318383709, bullet_pos=(1284.437, 59.34492)
+[17:57:26] [INFO] [Bullet] Using shooter_position, distance=599.999450683594
+[17:57:26] [INFO] [Bullet] Distance to wall: 599.999450683594 (40.855065898749% of viewport)
+[17:57:26] [ENEMY] [Enemy6] State: SEEKING_COVER -> IN_COVER
+[17:57:26] [ENEMY] [Enemy6] State: IN_COVER -> SUPPRESSED
+[17:57:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1397.145, 90.8586), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:26] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[17:57:26] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1388,96), corner_timer=-0.01
+[17:57:26] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1386.758, 104.1691), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:26] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[17:57:26] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1386,98), corner_timer=0.30
+[17:57:26] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1365.2882, 114.08417), shooter_id=50365204183, bullet_pos=(2485.5554, 687.1519)
+[17:57:26] [INFO] [Bullet] Using shooter_position, distance=1258,3344
+[17:57:26] [INFO] [Bullet] Distance to wall: 1258,3344 (85,682304% of viewport)
+[17:57:26] [INFO] [ScoreManager] Combo ended at 3. Max combo: 3
+[17:57:26] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:27] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1386.3562, 96.27598), shooter_id=50365204183, bullet_pos=(2480.885, 717.0888)
+[17:57:27] [INFO] [Bullet] Using shooter_position, distance=1258,333
+[17:57:27] [INFO] [Bullet] Distance to wall: 1258,333 (85,68221% of viewport)
+[17:57:27] [INFO] [Bullet] Distance-based penetration chance: 46,70409%
+[17:57:27] [INFO] [Bullet] Penetration failed (distance roll)
+[17:57:27] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1813.266, 342.7865), shooter_id=48318383709, bullet_pos=(515.97, 364.0358)
+[17:57:27] [INFO] [Bullet] Using shooter_position, distance=1297.46984863281
+[17:57:27] [INFO] [Bullet] Distance to wall: 1297.46984863281 (88.3471078300821% of viewport)
+[17:57:27] [INFO] [Bullet] Distance-based penetration chance: 43.5950408649042%
+[17:57:27] [INFO] [Bullet] Penetration failed (distance roll)
+[17:57:27] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1396.8595, 86.066475), shooter_id=50365204183, bullet_pos=(2483.865, 719.96204)
+[17:57:27] [INFO] [Bullet] Using shooter_position, distance=1258,3341
+[17:57:27] [INFO] [Bullet] Distance to wall: 1258,3341 (85,68228% of viewport)
+[17:57:27] [INFO] [Bullet] Distance-based penetration chance: 46,704006%
+[17:57:27] [INFO] [Bullet] Starting wall penetration at (2483.865, 719.96204)
+[17:57:27] [INFO] [Bullet] Raycast backward hit penetrating body at distance 24,285917
+[17:57:27] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:27] [INFO] [Bullet] Exiting penetration at (2516.9792, 739.27277) after traveling 33,333336 pixels through wall
+[17:57:27] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[17:57:27] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1335,157), corner_timer=-0.01
+[17:57:27] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:27] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1334,159), corner_timer=0.30
+[17:57:27] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1397.1447, 90.858604), shooter_id=50365204183, bullet_pos=(2487.173, 719.54144)
+[17:57:27] [INFO] [Bullet] Using shooter_position, distance=1258,3339
+[17:57:27] [INFO] [Bullet] Distance to wall: 1258,3339 (85,68227% of viewport)
+[17:57:27] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:27] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1386.7584, 104.16905), shooter_id=50365204183, bullet_pos=(2460.9539, 693.00507)
+[17:57:27] [INFO] [Bullet] Using shooter_position, distance=1224,9995
+[17:57:27] [INFO] [Bullet] Distance to wall: 1224,9995 (83,412476% of viewport)
+[17:57:27] [INFO] [Bullet] Distance-based penetration chance: 49,352116%
+[17:57:27] [INFO] [Bullet] Starting wall penetration at (2460.9539, 693.00507)
+[17:57:27] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[17:57:27] [INFO] [Bullet] Exiting penetration at (2494.568, 711.4312) after traveling 33,333332 pixels through wall
+[17:57:27] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[17:57:27] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(1358,158), corner_timer=-0.01
+[17:57:27] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:57:27] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(1361,156), corner_timer=0.30
+[17:57:27] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:27] [ENEMY] [Enemy6] State: SUPPRESSED -> SEEKING_COVER
+[17:57:27] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(1433,84), corner_timer=-0.02
+[17:57:27] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[17:57:27] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=92.1°, player=(1437,81), corner_timer=0.30
+[17:57:28] [ENEMY] [Enemy6] State: SEEKING_COVER -> IN_COVER
+[17:57:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1455.094, 86.06781), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[17:57:28] [ENEMY] [Enemy6] State: IN_COVER -> SUPPRESSED
+[17:57:28] [ENEMY] [Enemy6] State: SUPPRESSED -> SEEKING_COVER
+[17:57:28] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1493.316, 86.06781), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:28] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[17:57:28] [ENEMY] [Enemy6] State: SEEKING_COVER -> IN_COVER
+[17:57:28] [ENEMY] [Enemy6] State: IN_COVER -> SUPPRESSED
+[17:57:28] [ENEMY] [Enemy6] State: SUPPRESSED -> SEEKING_COVER
+[17:57:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1525.217, 92.6675), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:28] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=2
+[17:57:28] [ENEMY] [Enemy6] State: SEEKING_COVER -> IN_COVER
+[17:57:28] [ENEMY] [Enemy6] State: IN_COVER -> SUPPRESSED
+[17:57:28] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.8°, current=89.3°, player=(1528,88), corner_timer=-0.02
+[17:57:28] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[17:57:28] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=92.1°, player=(1532,90), corner_timer=0.30
+[17:57:28] [ENEMY] [Enemy6] State: SUPPRESSED -> SEEKING_COVER
+[17:57:28] [ENEMY] [Enemy6] State: SEEKING_COVER -> IN_COVER
+[17:57:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1545.568, 110.8166), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:28] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=2
+[17:57:28] [ENEMY] [Enemy6] State: IN_COVER -> SUPPRESSED
+[17:57:28] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1554.083, 139.6888), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:28] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=0, below_threshold=2
+[17:57:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1455.0936, 86.06781), shooter_id=50365204183, bullet_pos=(2485.6604, 970.9436)
+[17:57:28] [INFO] [Bullet] Using shooter_position, distance=1358,3346
+[17:57:28] [INFO] [Bullet] Distance to wall: 1358,3346 (92,4915% of viewport)
+[17:57:28] [ENEMY] [Enemy7] Memory: medium confidence (0.74) - transitioning to PURSUING
+[17:57:28] [ENEMY] [Enemy7] State: IDLE -> PURSUING
+[17:57:28] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P2:combat_state, state=PURSUING, target=-94.8°, current=89.3°, player=(1549,159), corner_timer=0.02
+[17:57:28] [ENEMY] [Enemy7] PURSUING corner check: angle 91.6°
+[17:57:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1493.316, 86.06781), shooter_id=50365204183, bullet_pos=(2465.8665, 1034.3367)
+[17:57:28] [INFO] [Bullet] Using shooter_position, distance=1358,3329
+[17:57:28] [INFO] [Bullet] Distance to wall: 1358,3329 (92,49139% of viewport)
+[17:57:28] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1525.2167, 92.667496), shooter_id=50365204183, bullet_pos=(2484.564, 1112.2996)
+[17:57:28] [INFO] [Bullet] Using shooter_position, distance=1399,9988
+[17:57:28] [INFO] [Bullet] Distance to wall: 1399,9988 (95,32849% of viewport)
+[17:57:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1545.5676, 110.81659), shooter_id=50365204183, bullet_pos=(2477.7769, 1155.3204)
+[17:57:28] [INFO] [Bullet] Using shooter_position, distance=1400,0009
+[17:57:28] [INFO] [Bullet] Distance to wall: 1400,0009 (95,328636% of viewport)
+[17:57:28] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1493.316, 86.06781), shooter_id=50365204183, bullet_pos=(2022.0452, 1498.9098)
+[17:57:28] [INFO] [Bullet] Using shooter_position, distance=1508,5347
+[17:57:28] [INFO] [Bullet] Distance to wall: 1508,5347 (102,7189% of viewport)
+[17:57:29] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1554.0833, 139.68883), shooter_id=50365204183, bullet_pos=(2469.1948, 1086.3579)
+[17:57:29] [INFO] [Bullet] Using shooter_position, distance=1316,6669
+[17:57:29] [INFO] [Bullet] Distance to wall: 1316,6669 (89,654274% of viewport)
+[17:57:29] [INFO] [Bullet] Distance-based penetration chance: 42,07002%
+[17:57:29] [INFO] [Bullet] Starting wall penetration at (2469.1948, 1086.3579)
+[17:57:29] [INFO] [Bullet] Raycast backward hit penetrating body at distance 8,099227
+[17:57:29] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:29] [INFO] [Bullet] Exiting penetration at (2501.6292, 1119.9108) after traveling 41,666668 pixels through wall
+[17:57:29] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[17:57:29] [ENEMY] [Enemy9] Hit taken, damage: 1, health: 3/3 -> 2/3
+[17:57:29] [ENEMY] [Enemy9] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:29] [INFO] [ImpactEffects] spawn_blood_effect called at (2100, 1550), dir=(1, 0), lethal=false
+[17:57:29] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:29] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:29] [INFO] [ImpactEffects] Blood effect spawned at (2100, 1550) (scale=1)
+[17:57:29] [ENEMY] [Enemy7] PURSUING corner check: angle 93.2°
+[17:57:29] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:29] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1545.5676, 110.81659), shooter_id=50365204183, bullet_pos=(2041.7816, 1514.0164)
+[17:57:29] [INFO] [Bullet] Using shooter_position, distance=1488,354
+[17:57:29] [INFO] [Bullet] Distance to wall: 1488,354 (101,344765% of viewport)
+[17:57:29] [INFO] [Bullet] Distance-based penetration chance: 29,731047%
+[17:57:29] [INFO] [Bullet] Starting wall penetration at (2041.7816, 1514.0164)
+[17:57:29] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[17:57:29] [INFO] [Bullet] Exiting penetration at (2016.0402, 1535.194) after traveling 28,333332 pixels through wall
+[17:57:29] [INFO] [Bullet] Damage multiplier after penetration: 0,45
+[17:57:29] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:29] [ENEMY] [Enemy6] State: SUPPRESSED -> SEEKING_COVER
+[17:57:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1675.67, 264.965), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:29] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=4
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2197.339, 1576.21) (added to group)
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2207.904, 1553.323) (added to group)
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2189.102, 1587.929) (added to group)
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2192.938, 1636.247) (added to group)
+[17:57:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1708.584, 259.4464), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:29] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=4
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2212.694, 1672.597) (added to group)
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2205.322, 1589.083) (added to group)
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2237.178, 1567.955) (added to group)
+[17:57:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1736.273, 241.3137), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:29] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=3
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2304.598, 1600.384) (added to group)
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2299.678, 1735.803) (added to group)
+[17:57:29] [INFO] [BloodDecal] Blood puddle created at (2231.413, 1621.923) (added to group)
+[17:57:29] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:29] [ENEMY] [Enemy6] ROT_CHANGE: P3:corner -> P1:visible, state=SEEKING_COVER, target=-82.9°, current=-88.7°, player=(1745,225), corner_timer=0.02
+[17:57:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1704.32, 555.3114), source=ENEMY (Enemy6), range=1469, listeners=5
+[17:57:29] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=3
+[17:57:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1761.164, 216.4235), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[17:57:29] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=3
+[17:57:29] [INFO] [LastChance] Threat detected: @Area2D@861
+[17:57:29] [INFO] [LastChance] Effect already used this life
+[17:57:29] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1691.05, 524.6931), source=ENEMY (Enemy6), range=1469, listeners=5
+[17:57:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=3
+[17:57:30] [INFO] [Player] Spawning blood effect at (1776.7202, 194.8672), dir=(1, 0), lethal=True (C#)
+[17:57:30] [INFO] [ImpactEffects] spawn_blood_effect called at (1776.72, 194.8672), dir=(1, 0), lethal=true
+[17:57:30] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:30] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:30] [INFO] [ImpactEffects] Blood effect spawned at (1776.72, 194.8672) (scale=1.5)
+[17:57:30] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:57:30] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:57:30] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:57:30] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:57:30] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:57:30] [INFO] [LastChance] Player died
+[17:57:30] [ENEMY] [Enemy6] Hit taken, damage: 1, health: 1/4 -> 0/4
+[17:57:30] [ENEMY] [Enemy6] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:30] [INFO] [ImpactEffects] spawn_blood_effect called at (1678.642, 507.3395), dir=(1, 0), lethal=true
+[17:57:30] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:30] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:30] [INFO] [ImpactEffects] Blood effect spawned at (1678.642, 507.3395) (scale=1.5)
+[17:57:30] [ENEMY] [Enemy6] Enemy died (ricochet: false, penetration: false)
+[17:57:30] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[17:57:30] [INFO] [SoundPropagation] Unregistered listener: Enemy6 (remaining: 4)
+[17:57:30] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[17:57:30] [ENEMY] [Enemy6] Death animation started with hit direction: (1, 0)
+[17:57:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1789.166, 188.4221), source=PLAYER (AssaultRifle), range=1469, listeners=4
+[17:57:30] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0, below_threshold=3
+[17:57:30] [INFO] [LastChance] Threat detected: @Area2D@866
+[17:57:30] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[17:57:30] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:30] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1708.5837, 259.44635), shooter_id=50365204183, bullet_pos=(2029.4929, 1197.7538)
+[17:57:30] [INFO] [Bullet] Using shooter_position, distance=991,66705
+[17:57:30] [INFO] [Bullet] Distance to wall: 991,66705 (67,52443% of viewport)
+[17:57:30] [INFO] [Bullet] Distance-based penetration chance: 67,88817%
+[17:57:30] [INFO] [Bullet] Penetration failed (distance roll)
+[17:57:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1815.28, 166.4884), source=PLAYER (AssaultRifle), range=1469, listeners=4
+[17:57:30] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0, below_threshold=3
+[17:57:30] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1699.368, 459.0061), shooter_id=48318383709, bullet_pos=(1802.687, 38.16998)
+[17:57:30] [INFO] [Bullet] Using shooter_position, distance=433.33349609375
+[17:57:30] [INFO] [Bullet] Distance to wall: 433.33349609375 (29.5064745790601% of viewport)
+[17:57:30] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:30] [INFO] [Bullet] Starting wall penetration at (1802.687, 38.16998)
+[17:57:30] [INFO] [Bullet] Raycast backward hit penetrating body at distance 31.9801387786865
+[17:57:30] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:30] [INFO] [Bullet] Exiting penetration at (1811.827, 0.942173) after traveling 33.3333320617676 pixels through wall
+[17:57:30] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:57:30] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:30] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1789.1655, 188.42213), shooter_id=50365204183, bullet_pos=(1608.3241, 609.5701)
+[17:57:30] [INFO] [Bullet] Using shooter_position, distance=458,33313
+[17:57:30] [INFO] [Bullet] Distance to wall: 458,33313 (31,208748% of viewport)
+[17:57:30] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:30] [INFO] [Bullet] Starting wall penetration at (1608.3241, 609.5701)
+[17:57:30] [INFO] [Bullet] Raycast backward hit penetrating body at distance 22,629448
+[17:57:30] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:30] [INFO] [Bullet] Exiting penetration at (1593.1992, 644.79346) after traveling 33,333336 pixels through wall
+[17:57:30] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[17:57:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1846.375, 156.5774), source=PLAYER (AssaultRifle), range=1469, listeners=4
+[17:57:30] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0, below_threshold=3
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1752.201, 557.1001) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1748.715, 559.8113) (added to group)
+[17:57:30] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1736.273, 241.31367), shooter_id=50365204183, bullet_pos=(1965.9342, 1478.511)
+[17:57:30] [INFO] [Bullet] Using shooter_position, distance=1258,3328
+[17:57:30] [INFO] [Bullet] Distance to wall: 1258,3328 (85,6822% of viewport)
+[17:57:30] [INFO] [Bullet] Distance-based penetration chance: 46,70411%
+[17:57:30] [INFO] [Bullet] Penetration failed (distance roll)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1862.574, 204.7889) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1879.295, 221.8812) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1880.885, 183.18) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1765.86, 547.0844) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1756.557, 560.9032) (added to group)
+[17:57:30] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1815.2804, 166.4884), shooter_id=50365204183, bullet_pos=(1621.8486, 618.5061)
+[17:57:30] [INFO] [Bullet] Using shooter_position, distance=491,66638
+[17:57:30] [INFO] [Bullet] Distance to wall: 491,66638 (33,47847% of viewport)
+[17:57:30] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:30] [INFO] [Bullet] Starting wall penetration at (1621.8486, 618.5061)
+[17:57:30] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1675.6697, 264.965), shooter_id=50365204183, bullet_pos=(2464.6084, 1947.5166)
+[17:57:30] [INFO] [Bullet] Using shooter_position, distance=1858,3337
+[17:57:30] [INFO] [Bullet] Distance to wall: 1858,3337 (126,53737% of viewport)
+[17:57:30] [INFO] [Bullet] Distance-based penetration chance: 24,692526%
+[17:57:30] [INFO] [Bullet] Penetration failed (distance roll)
+[17:57:30] [INFO] [Bullet] Raycast backward hit penetrating body at distance 32,357517
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1776.742, 516.4733) (added to group)
+[17:57:30] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:57:30] [INFO] [Bullet] Exiting penetration at (1606.7675, 653.74817) after traveling 33,333336 pixels through wall
+[17:57:30] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1784.813, 525.4939) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1898.33, 207.1833) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1860.789, 195.8772) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1799.541, 578.8558) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1895.807, 237.1001) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1846.187, 253.3779) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1808.74, 575.8613) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1914.323, 254.0601) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1883.894, 265.3338) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1807.135, 570.157) (added to group)
+[17:57:30] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1846.3751, 156.57741), shooter_id=50365204183, bullet_pos=(1600.9908, 620.70215)
+[17:57:30] [INFO] [Bullet] Using shooter_position, distance=525,0002
+[17:57:30] [INFO] [Bullet] Distance to wall: 525,0002 (35,74823% of viewport)
+[17:57:30] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1771.168, 562.2344) (added to group)
+[17:57:30] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1867.461, 218.1992) (added to group)
+[17:57:30] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:57:30] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:30] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:57:30] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:57:30] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:57:30] [INFO] [CinemaEffects] Death effects reset
+[17:57:30] [ENEMY] [Enemy1] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:57:30] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:30] [ENEMY] [Enemy2] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:57:30] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:30] [ENEMY] [Enemy3] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:57:30] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:30] [ENEMY] [Enemy4] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:57:30] [ENEMY] [Enemy5] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:57:30] [ENEMY] [Enemy6] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:57:30] [ENEMY] [Enemy7] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:57:30] [ENEMY] [Enemy8] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:57:30] [ENEMY] [Enemy9] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:57:30] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:30] [ENEMY] [Enemy10] Death animation component initialized
+[17:57:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:30] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:57:30] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:57:30] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:57:30] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:57:30] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:57:30] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:57:30] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:57:30] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:57:30] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:57:30] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:57:30] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:57:30] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[17:57:30] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:57:30] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:57:30] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:57:30] [INFO] [ScoreManager] Level started with 10 enemies
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1820.971, 504.7069) (added to group)
+[17:57:30] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:57:30] [INFO] [CinemaEffects] Found player node: Player
+[17:57:30] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 5)
+[17:57:30] [ENEMY] [Enemy1] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[17:57:30] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 6)
+[17:57:30] [ENEMY] [Enemy2] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[17:57:30] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 7)
+[17:57:30] [ENEMY] [Enemy3] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[17:57:30] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 8)
+[17:57:30] [ENEMY] [Enemy4] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[17:57:30] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 9)
+[17:57:30] [ENEMY] [Enemy5] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[17:57:30] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 10)
+[17:57:30] [ENEMY] [Enemy6] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[17:57:30] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 11)
+[17:57:30] [ENEMY] [Enemy7] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[17:57:30] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 12)
+[17:57:30] [ENEMY] [Enemy8] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[17:57:30] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 13)
+[17:57:30] [ENEMY] [Enemy9] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:57:30] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:57:30] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 14)
+[17:57:30] [ENEMY] [Enemy10] Registered as sound listener
+[17:57:30] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[17:57:30] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:57:30] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:30] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:30] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:30] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:30] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:30] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:30] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:30] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:30] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:57:30] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:57:30] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:57:30] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:57:30] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:57:30] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:57:30] [INFO] [LastChance] Found player: Player
+[17:57:30] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:57:30] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:57:30] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:57:30] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1877.88, 243.9566) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1766.442, 575.1666) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1802.394, 537.342) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1876.782, 234.9137) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1769.315, 590.6259) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1795.918, 563.7111) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1777.645, 566.7239) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1777.538, 572.2887) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1910.085, 547.9816) (added to group)
+[17:57:30] [INFO] [BloodDecal] Blood puddle created at (1806.737, 601.1964) (added to group)
+[17:57:32] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:32] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:57:32] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(472,1250), corner_timer=0.30
+[17:57:32] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(472,1250), corner_timer=0.30
+[17:57:32] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(548,1204), corner_timer=-0.02
+[17:57:32] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:32] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(548,1204), corner_timer=-0.02
+[17:57:32] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:57:32] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(552,1200), corner_timer=0.30
+[17:57:32] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(552,1200), corner_timer=0.30
+[17:57:32] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(624,1131), corner_timer=-0.02
+[17:57:32] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:57:32] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(627,1129), corner_timer=0.30
+[17:57:36] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(644,1113), corner_timer=-0.02
+[17:57:36] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:57:36] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(644,1113), corner_timer=0.30
+[17:57:37] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(644,1083), corner_timer=-0.02
+[17:57:37] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:57:37] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(643,1079), corner_timer=0.30
+[17:57:37] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(582,1040), corner_timer=-0.02
+[17:57:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:57:37] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(576,1040), corner_timer=0.30
+[17:57:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:38] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:57:38] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:38] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:57:38] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:57:38] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:57:38] [ENEMY] [Enemy1] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:57:38] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:38] [ENEMY] [Enemy2] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:57:38] [ENEMY] [Enemy3] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:57:38] [ENEMY] [Enemy4] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:57:38] [ENEMY] [Enemy5] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:57:38] [ENEMY] [Enemy6] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:57:38] [ENEMY] [Enemy7] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:57:38] [ENEMY] [Enemy8] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:57:38] [ENEMY] [Enemy9] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:57:38] [ENEMY] [Enemy10] Death animation component initialized
+[17:57:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:38] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:57:38] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:57:38] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:57:38] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:57:38] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:57:38] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:57:38] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:57:38] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:57:38] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:57:38] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:57:38] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:57:38] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[17:57:38] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:57:38] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:57:38] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:57:38] [INFO] [ScoreManager] Level started with 10 enemies
+[17:57:38] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:57:38] [INFO] [CinemaEffects] Found player node: Player
+[17:57:38] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 15)
+[17:57:38] [ENEMY] [Enemy1] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[17:57:38] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 16)
+[17:57:38] [ENEMY] [Enemy2] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[17:57:38] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 17)
+[17:57:38] [ENEMY] [Enemy3] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[17:57:38] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 18)
+[17:57:38] [ENEMY] [Enemy4] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[17:57:38] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 19)
+[17:57:38] [ENEMY] [Enemy5] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[17:57:38] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 20)
+[17:57:38] [ENEMY] [Enemy6] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[17:57:38] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 21)
+[17:57:38] [ENEMY] [Enemy7] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[17:57:38] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 22)
+[17:57:38] [ENEMY] [Enemy8] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[17:57:38] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 23)
+[17:57:38] [ENEMY] [Enemy9] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[17:57:38] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:57:38] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 24)
+[17:57:38] [ENEMY] [Enemy10] Registered as sound listener
+[17:57:38] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[17:57:38] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:57:38] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[17:57:38] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[17:57:38] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[17:57:38] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[17:57:38] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[17:57:38] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[17:57:38] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=213.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[17:57:38] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[17:57:38] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:57:38] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:57:38] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:57:38] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:57:38] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:57:38] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:57:38] [INFO] [LastChance] Found player: Player
+[17:57:38] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:57:38] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:57:38] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:57:38] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:57:39] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:39] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:57:39] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(483,797), corner_timer=0.30
+[17:57:39] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(483,797), corner_timer=0.30
+[17:57:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(537,723), corner_timer=-0.02
+[17:57:39] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:39] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(537,723), corner_timer=-0.02
+[17:57:39] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:57:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(540,719), corner_timer=0.30
+[17:57:39] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(540,719), corner_timer=0.30
+[17:57:40] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(614,645), corner_timer=-0.02
+[17:57:40] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:57:40] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=-127.0°, current=-78.7°, player=(618,641), corner_timer=0.00
+[17:57:40] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:57:40] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(618,641), corner_timer=0.30
+[17:57:40] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-114.1°, current=-180.0°, player=(641,620), corner_timer=0.00
+[17:57:40] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=-116.0°, current=-101.3°, player=(656,606), corner_timer=0.00
+[17:57:40] [ENEMY] [Enemy4] State: IDLE -> COMBAT
+[17:57:40] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-115.4°, current=137.5°, player=(661,602), corner_timer=0.00
+[17:57:40] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-101.1°, current=-148.7°, player=(669,595), corner_timer=0.00
+[17:57:40] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(669,595), corner_timer=-0.02
+[17:57:40] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:57:40] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(670,594), corner_timer=0.30
+[17:57:40] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-114.8°, current=-164.3°, player=(671,593), corner_timer=0.00
+[17:57:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=24
+[17:57:40] [INFO] [SoundPropagation] Cleaned up 14 invalid listeners
+[17:57:40] [ENEMY] [Enemy2] Heard gunshot at (700, 750), source_type=1, intensity=0.02, distance=361
+[17:57:40] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:40] [INFO] [LastChance] Threat detected: Bullet
+[17:57:40] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:40] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:40] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=9.2°, current=-101.3°, player=(671,593), corner_timer=0.00
+[17:57:40] [INFO] [Player] Spawning blood effect at (671.32495, 593.82904), dir=(1, 0), lethal=False (C#)
+[17:57:40] [INFO] [ImpactEffects] spawn_blood_effect called at (671.325, 593.829), dir=(1, 0), lethal=false
+[17:57:40] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:40] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:40] [INFO] [ImpactEffects] Blood effect spawned at (671.325, 593.829) (scale=1)
+[17:57:40] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:57:40] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:57:40] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:57:40] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:57:40] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:57:40] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:57:40] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:57:40] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:57:40] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:57:40] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:57:40] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:57:40] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(671,593), corner_timer=-0.02
+[17:57:40] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:57:40] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(671,593), corner_timer=0.30
+[17:57:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:41] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:41] [INFO] [LastChance] Threat detected: Bullet
+[17:57:41] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:41] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:41] [INFO] [Player] Spawning blood effect at (671.32495, 593.82904), dir=(1, 0), lethal=True (C#)
+[17:57:41] [INFO] [ImpactEffects] spawn_blood_effect called at (671.325, 593.829), dir=(1, 0), lethal=true
+[17:57:41] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:41] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:41] [INFO] [ImpactEffects] Blood effect spawned at (671.325, 593.829) (scale=1.5)
+[17:57:41] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:57:41] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:57:41] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:57:41] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:57:41] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:57:41] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:57:41] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:57:41] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:57:41] [INFO] [LastChance] Player died
+[17:57:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0663, 816.703), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:41] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:41] [INFO] [LastChance] Threat detected: Bullet
+[17:57:41] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:41] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(690.5792, 759.3641), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:41] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:41] [INFO] [LastChance] Threat detected: @Area2D@1421
+[17:57:41] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:41] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:41] [ENEMY] [Enemy1] Memory: medium confidence (0.60) - transitioning to PURSUING
+[17:57:41] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:57:41] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=33.3°, current=168.8°, player=(671,593), corner_timer=0.00
+[17:57:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0663, 816.703), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:41] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:41] [INFO] [BloodDecal] Blood puddle created at (749.238, 580.9643) (added to group)
+[17:57:41] [ENEMY] [Enemy1] PURSUING corner check: angle -50.9°
+[17:57:41] [INFO] [LastChance] Threat detected: Bullet
+[17:57:41] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:41] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(690.5792, 759.3641), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:41] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:41] [INFO] [LastChance] Threat detected: @Area2D@1424
+[17:57:41] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:41] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:41] [INFO] [BloodDecal] Blood puddle created at (775.2805, 619.2816) (added to group)
+[17:57:41] [INFO] [BloodDecal] Blood puddle created at (760.2915, 609.19) (added to group)
+[17:57:42] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(671,593), corner_timer=-0.02
+[17:57:42] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (764.7823, 661.2134) (added to group)
+[17:57:42] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[17:57:42] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(671,593), corner_timer=0.30
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (729.1083, 582.1241) (added to group)
+[17:57:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0436, 829.5192), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:42] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:42] [INFO] [LastChance] Threat detected: Bullet
+[17:57:42] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:42] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (763.4417, 570.8523) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (747.9515, 611.3087) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (746.7748, 608.2031) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (764.6418, 640.6928) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (771.4072, 576.2811) (added to group)
+[17:57:42] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:57:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(693.5766, 785.9338), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:42] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (790.6672, 637.583) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (725.5033, 597.178) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (722.0599, 601.6381) (added to group)
+[17:57:42] [INFO] [LastChance] Threat detected: @Area2D@1439
+[17:57:42] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:42] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0436, 829.5192), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:42] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:42] [INFO] [LastChance] Threat detected: Bullet
+[17:57:42] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:42] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (808.6876, 721.7683) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (777.7795, 610.6041) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (747.1026, 661.3572) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (872.9732, 699.9943) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (803.8876, 609.7754) (added to group)
+[17:57:42] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:57:42] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:42] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:57:42] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:57:42] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:57:42] [INFO] [CinemaEffects] Death effects reset
+[17:57:42] [ENEMY] [Enemy1] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:57:42] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:42] [ENEMY] [Enemy2] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:57:42] [ENEMY] [Enemy3] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:57:42] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:42] [ENEMY] [Enemy4] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:57:42] [ENEMY] [Enemy5] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:57:42] [ENEMY] [Enemy6] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:57:42] [ENEMY] [Enemy7] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:57:42] [ENEMY] [Enemy8] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:57:42] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:42] [ENEMY] [Enemy9] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:57:42] [ENEMY] [Enemy10] Death animation component initialized
+[17:57:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:42] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:57:42] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:57:42] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:57:42] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:57:42] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:57:42] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:57:42] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:57:42] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:57:42] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:57:42] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:57:42] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:57:42] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[17:57:42] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:57:42] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:57:42] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:57:42] [INFO] [ScoreManager] Level started with 10 enemies
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (779.172, 687.1107) (added to group)
+[17:57:42] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:57:42] [INFO] [CinemaEffects] Found player node: Player
+[17:57:42] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:57:42] [ENEMY] [Enemy1] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[17:57:42] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:57:42] [ENEMY] [Enemy2] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[17:57:42] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:57:42] [ENEMY] [Enemy3] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[17:57:42] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:57:42] [ENEMY] [Enemy4] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[17:57:42] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:57:42] [ENEMY] [Enemy5] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[17:57:42] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:57:42] [ENEMY] [Enemy6] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[17:57:42] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:57:42] [ENEMY] [Enemy7] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[17:57:42] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:57:42] [ENEMY] [Enemy8] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[17:57:42] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:57:42] [ENEMY] [Enemy9] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:57:42] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:57:42] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:57:42] [ENEMY] [Enemy10] Registered as sound listener
+[17:57:42] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[17:57:42] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:57:42] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:42] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:42] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:42] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:42] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:42] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:42] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=157.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:42] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:42] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:57:42] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:57:42] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:57:42] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:57:42] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:57:42] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:57:42] [INFO] [LastChance] Found player: Player
+[17:57:42] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:57:42] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:57:42] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:57:42] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (819.1007, 693.0817) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (815.9045, 599.5029) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (785.402, 630.2703) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (752.6097, 643.568) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (831.7396, 748.188) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (767.951, 640.9177) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (891.8048, 807.8942) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (895.8218, 670.2645) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (874.4927, 790.3038) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (887.1938, 620.953) (added to group)
+[17:57:42] [INFO] [BloodDecal] Blood puddle created at (833.8879, 699.7306) (added to group)
+[17:57:43] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:57:43] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:43] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:57:43] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:57:43] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:57:43] [ENEMY] [Enemy1] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:57:43] [ENEMY] [Enemy2] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:57:43] [ENEMY] [Enemy3] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:57:43] [ENEMY] [Enemy4] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:57:43] [ENEMY] [Enemy5] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:57:43] [ENEMY] [Enemy6] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:57:43] [ENEMY] [Enemy7] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:57:43] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:43] [ENEMY] [Enemy8] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:57:43] [ENEMY] [Enemy9] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:57:43] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:43] [ENEMY] [Enemy10] Death animation component initialized
+[17:57:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:43] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:57:43] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:57:43] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:57:43] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:57:43] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:57:43] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:57:43] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:57:43] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:57:43] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:57:43] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:57:43] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:57:43] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[17:57:43] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:57:43] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:57:43] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:57:43] [INFO] [ScoreManager] Level started with 10 enemies
+[17:57:43] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:57:43] [INFO] [CinemaEffects] Found player node: Player
+[17:57:43] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 21)
+[17:57:43] [ENEMY] [Enemy1] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[17:57:43] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 22)
+[17:57:43] [ENEMY] [Enemy2] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[17:57:43] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 23)
+[17:57:43] [ENEMY] [Enemy3] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[17:57:43] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 24)
+[17:57:43] [ENEMY] [Enemy4] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[17:57:43] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 25)
+[17:57:43] [ENEMY] [Enemy5] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 3, behavior: GUARD
+[17:57:43] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 26)
+[17:57:43] [ENEMY] [Enemy6] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[17:57:43] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 27)
+[17:57:43] [ENEMY] [Enemy7] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[17:57:43] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 28)
+[17:57:43] [ENEMY] [Enemy8] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[17:57:43] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 29)
+[17:57:43] [ENEMY] [Enemy9] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:57:43] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:57:43] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 30)
+[17:57:43] [ENEMY] [Enemy10] Registered as sound listener
+[17:57:43] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[17:57:43] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:57:43] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:43] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:43] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:43] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:43] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:43] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:43] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:43] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:43] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:57:43] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:57:43] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:57:43] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:57:43] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:57:43] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:57:43] [INFO] [LastChance] Found player: Player
+[17:57:43] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:57:43] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:57:43] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:57:43] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:57:44] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:44] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:57:44] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,841), corner_timer=0.30
+[17:57:44] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,841), corner_timer=0.30
+[17:57:44] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=164.4°, current=123.7°, player=(450,819), corner_timer=0.00
+[17:57:44] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:57:44] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=166.8°, current=-64.9°, player=(450,808), corner_timer=0.00
+[17:57:44] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(481,750), corner_timer=-0.02
+[17:57:44] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:44] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(481,750), corner_timer=-0.02
+[17:57:44] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:57:44] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(485,746), corner_timer=0.30
+[17:57:44] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(485,746), corner_timer=0.30
+[17:57:45] [ENEMY] [Enemy4] Memory: high confidence (0.86) - transitioning to PURSUING
+[17:57:45] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[17:57:45] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-145.0°, current=-101.3°, player=(531,711), corner_timer=0.00
+[17:57:45] [ENEMY] [Enemy4] PURSUING corner check: angle -100.7°
+[17:57:45] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-159.2°, current=-111.8°, player=(542,700), corner_timer=0.00
+[17:57:45] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(562,680), corner_timer=-0.02
+[17:57:45] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:57:45] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(684.4503, 753.7664), source=ENEMY (Enemy3), range=1469, listeners=30
+[17:57:45] [INFO] [SoundPropagation] Cleaned up 20 invalid listeners
+[17:57:45] [ENEMY] [Enemy2] Heard gunshot at (684.4503, 753.7664), source_type=1, intensity=0.02, distance=350
+[17:57:45] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:45] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(566,676), corner_timer=0.30
+[17:57:45] [INFO] [LastChance] Threat detected: Bullet
+[17:57:45] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:45] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:45] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=35.9°, current=-157.5°, player=(569,672), corner_timer=0.00
+[17:57:45] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(684.4503, 753.7664), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:45] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:45] [INFO] [LastChance] Threat detected: @Area2D@1969
+[17:57:45] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:45] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:45] [ENEMY] [Enemy2] Hit taken, damage: 1, health: 3/3 -> 2/3
+[17:57:45] [ENEMY] [Enemy2] ImpactEffectsManager found, calling spawn_blood_effect
+[17:57:45] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.838036, -0.545615), lethal=false
+[17:57:45] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:45] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:45] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[17:57:45] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=25.9°, current=33.1°, player=(597,645), corner_timer=0.00
+[17:57:45] [ENEMY] [Enemy2] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=22.0°, current=21.9°, player=(608,633), corner_timer=0.00
+[17:57:45] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(633.3474, 707.0016), shooter_id=650301670763, bullet_pos=(523.6631, 581.514)
+[17:57:45] [INFO] [Bullet] Using shooter_position, distance=166.66667175293
+[17:57:45] [INFO] [Bullet] Distance to wall: 166.66667175293 (11.3486401526422% of viewport)
+[17:57:45] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:45] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(685.0893, 761.593), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:45] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:45] [INFO] [LastChance] Threat detected: Bullet
+[17:57:45] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:45] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:45] [INFO] [Player] Spawning blood effect at (624.5321, 615.35516), dir=(1, 0), lethal=False (C#)
+[17:57:45] [INFO] [ImpactEffects] spawn_blood_effect called at (624.5321, 615.3552), dir=(1, 0), lethal=false
+[17:57:45] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:45] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:45] [INFO] [ImpactEffects] Blood effect spawned at (624.5321, 615.3552) (scale=1)
+[17:57:45] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[17:57:45] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[17:57:45] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[17:57:45] [ENEMY] [Enemy2] State: RETREATING -> IN_COVER
+[17:57:45] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(628,610), corner_timer=-0.02
+[17:57:45] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:57:45] [ENEMY] [Enemy2] State: IN_COVER -> SUPPRESSED
+[17:57:45] [ENEMY] [Enemy4] PURSUING corner check: angle -94.0°
+[17:57:45] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(630,608), corner_timer=0.30
+[17:57:45] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(685.1022, 762.1378), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:45] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:45] [INFO] [LastChance] Threat detected: Bullet
+[17:57:45] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:45] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:45] [ENEMY] [Enemy1] Memory: high confidence (0.88) - transitioning to PURSUING
+[17:57:45] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:57:45] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=37.3°, current=-33.8°, player=(634,604), corner_timer=0.00
+[17:57:45] [INFO] [Player] Spawning blood effect at (635.3661, 603.2034), dir=(1, 0), lethal=False (C#)
+[17:57:45] [INFO] [ImpactEffects] spawn_blood_effect called at (635.3661, 603.2034), dir=(1, 0), lethal=false
+[17:57:45] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:45] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:45] [INFO] [ImpactEffects] Blood effect spawned at (635.3661, 603.2034) (scale=1)
+[17:57:45] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[17:57:45] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[17:57:45] [ENEMY] [Enemy1] PURSUING corner check: angle -50.9°
+[17:57:45] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(684.7665, 766.6196), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:45] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:45] [INFO] [LastChance] Threat detected: Bullet
+[17:57:45] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:45] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:45] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(633.3474, 707.0016), shooter_id=650301670763, bullet_pos=(893.8719, 56.39367)
+[17:57:45] [INFO] [Bullet] Using shooter_position, distance=700.830688476563
+[17:57:45] [INFO] [Bullet] Distance to wall: 700.830688476563 (47.7208502923693% of viewport)
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (336.4789, 554.1398) (added to group)
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (298.5208, 508.4532) (added to group)
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (355.9977, 520.4779) (added to group)
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (668.1145, 642.1116) (added to group)
+[17:57:45] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(683.2341, 770.4436), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:45] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (677.7946, 616.1982) (added to group)
+[17:57:45] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(633.3474, 707.0016), shooter_id=650301670763, bullet_pos=(1009.049, 201.9649)
+[17:57:45] [INFO] [Bullet] Using shooter_position, distance=629.455017089844
+[17:57:45] [INFO] [Bullet] Distance to wall: 629.455017089844 (42.8607495793612% of viewport)
+[17:57:45] [INFO] [LastChance] Threat detected: @Area2D@1980
+[17:57:45] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:45] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (725.5206, 621.751) (added to group)
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (323.7411, 503.2081) (added to group)
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (311.9073, 517.7568) (added to group)
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (271.2908, 570.0368) (added to group)
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (675.8173, 632.8552) (added to group)
+[17:57:45] [INFO] [Player] Spawning blood effect at (637.55896, 600.74384), dir=(1, 0), lethal=False (C#)
+[17:57:45] [INFO] [ImpactEffects] spawn_blood_effect called at (637.559, 600.7438), dir=(1, 0), lethal=false
+[17:57:45] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:45] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:45] [INFO] [ImpactEffects] Blood effect spawned at (637.559, 600.7438) (scale=1)
+[17:57:45] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:57:45] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:57:45] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:57:45] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:57:45] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:57:45] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:57:45] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:57:45] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:57:45] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:57:45] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:57:45] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:57:45] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(637,600), corner_timer=-0.02
+[17:57:45] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (706.6254, 641.8532) (added to group)
+[17:57:45] [INFO] [BloodDecal] Blood puddle created at (676.157, 623.1472) (added to group)
+[17:57:45] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(637,600), corner_timer=0.30
+[17:57:45] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(658.7246, 703.7356), shooter_id=650301670763, bullet_pos=(527.3308, 242.9359)
+[17:57:45] [INFO] [Bullet] Using shooter_position, distance=479.166687011719
+[17:57:45] [INFO] [Bullet] Distance to wall: 479.166687011719 (32.6273408284711% of viewport)
+[17:57:45] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:45] [INFO] [Bullet] Starting wall penetration at (527.3308, 242.9359)
+[17:57:45] [INFO] [Bullet] Raycast forward hit penetrating body at distance 2.97993206977844
+[17:57:46] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[17:57:46] [INFO] [Bullet] Exiting penetration at (523.6746, 230.1136) after traveling 8.33333396911621 pixels through wall
+[17:57:46] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:57:46] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(633.3474, 707.0016), shooter_id=650301670763, bullet_pos=(1093.185, 67.60322)
+[17:57:46] [INFO] [Bullet] Using shooter_position, distance=787.579345703125
+[17:57:46] [INFO] [Bullet] Distance to wall: 787.579345703125 (53.6277258796408% of viewport)
+[17:57:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(682.6241, 771.9714), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:46] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:46] [INFO] [LastChance] Threat detected: Bullet
+[17:57:46] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:46] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (260.5341, 538.8155) (added to group)
+[17:57:46] [ENEMY] [Enemy1] PURSUING corner check: angle -51.8°
+[17:57:46] [INFO] [Player] Spawning blood effect at (637.55896, 600.74384), dir=(1, 0), lethal=True (C#)
+[17:57:46] [INFO] [ImpactEffects] spawn_blood_effect called at (637.559, 600.7438), dir=(1, 0), lethal=true
+[17:57:46] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:46] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:46] [INFO] [ImpactEffects] Blood effect spawned at (637.559, 600.7438) (scale=1.5)
+[17:57:46] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:57:46] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:57:46] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:57:46] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:57:46] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:57:46] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:57:46] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:57:46] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:57:46] [INFO] [LastChance] Player died
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (759.7943, 596.9653) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (739.1388, 678.5128) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (770.3929, 680.453) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (696.5653, 645.1403) (added to group)
+[17:57:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(679.2482, 775.6054), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:46] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (242.3873, 568.1137) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (187.8544, 616.2506) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (781.6573, 685.2747) (added to group)
+[17:57:46] [INFO] [LastChance] Threat detected: Bullet
+[17:57:46] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:46] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (292.8504, 483.7036) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (705.7879, 676.0654) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (716.5912, 674.8829) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (714.4861, 634.5725) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (768.3066, 750.8054) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (755.1121, 614.0012) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (782.7047, 660.876) (added to group)
+[17:57:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(675.0581, 780.111), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:46] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:46] [INFO] [LastChance] Threat detected: Bullet
+[17:57:46] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:46] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:46] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-76.4°, current=-124.1°, player=(637,600), corner_timer=0.02
+[17:57:46] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[17:57:46] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-76.0°, current=-10.4°, player=(637,600), corner_timer=0.02
+[17:57:46] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(637,600), corner_timer=-0.01
+[17:57:46] [ENEMY] [Enemy10] PATROL corner check: angle 1.0°
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (760.3851, 650.4143) (added to group)
+[17:57:46] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.0°, current=4.6°, player=(637,600), corner_timer=0.30
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (772.2947, 667.1403) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (721.9501, 639.4224) (added to group)
+[17:57:46] [ENEMY] [Enemy1] PURSUING corner check: angle 153.1°
+[17:57:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(671.8327, 784.5466), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:46] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (752.9559, 661.3882) (added to group)
+[17:57:46] [INFO] [LastChance] Threat detected: Bullet
+[17:57:46] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:46] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (695.2524, 628.7601) (added to group)
+[17:57:46] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-78.9°, current=-29.6°, player=(637,600), corner_timer=0.02
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (872.6718, 664.1339) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (744.8362, 687.652) (added to group)
+[17:57:46] [INFO] [BloodDecal] Blood puddle created at (711.7999, 610.2321) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (749.045, 688.1451) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (776.1229, 716.9114) (added to group)
+[17:57:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(671.8327, 784.5466), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:47] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (708.2193, 653.2361) (added to group)
+[17:57:47] [INFO] [LastChance] Threat detected: Bullet
+[17:57:47] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:47] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (780.7164, 644.816) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (724.9182, 688.4113) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (801.0717, 605.9745) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (729.1024, 638.4064) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (786.2693, 624.1461) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (777.9345, 690.8922) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (725.3453, 617.114) (added to group)
+[17:57:47] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:57:47] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:47] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:57:47] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:57:47] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:57:47] [INFO] [CinemaEffects] Death effects reset
+[17:57:47] [ENEMY] [Enemy1] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:57:47] [ENEMY] [Enemy2] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:57:47] [ENEMY] [Enemy3] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:57:47] [ENEMY] [Enemy4] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:57:47] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:47] [ENEMY] [Enemy5] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:57:47] [ENEMY] [Enemy6] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:57:47] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:47] [ENEMY] [Enemy7] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:57:47] [ENEMY] [Enemy8] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:57:47] [ENEMY] [Enemy9] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:57:47] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:47] [ENEMY] [Enemy10] Death animation component initialized
+[17:57:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:47] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:57:47] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:57:47] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:57:47] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:57:47] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:57:47] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:57:47] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:57:47] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:57:47] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:57:47] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:57:47] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:57:47] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[17:57:47] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:57:47] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:57:47] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:57:47] [INFO] [ScoreManager] Level started with 10 enemies
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (832.256, 685.0658) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (763.2925, 609.8911) (added to group)
+[17:57:47] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:57:47] [INFO] [CinemaEffects] Found player node: Player
+[17:57:47] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:57:47] [ENEMY] [Enemy1] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[17:57:47] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:57:47] [ENEMY] [Enemy2] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[17:57:47] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:57:47] [ENEMY] [Enemy3] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[17:57:47] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:57:47] [ENEMY] [Enemy4] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[17:57:47] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:57:47] [ENEMY] [Enemy5] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[17:57:47] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:57:47] [ENEMY] [Enemy6] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[17:57:47] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:57:47] [ENEMY] [Enemy7] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[17:57:47] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:57:47] [ENEMY] [Enemy8] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[17:57:47] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:57:47] [ENEMY] [Enemy9] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[17:57:47] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:57:47] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:57:47] [ENEMY] [Enemy10] Registered as sound listener
+[17:57:47] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[17:57:47] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:57:47] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:47] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=45.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:47] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:47] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:47] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:47] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:47] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:47] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:47] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:57:47] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:57:47] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:57:47] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:57:47] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:57:47] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:57:47] [INFO] [LastChance] Found player: Player
+[17:57:47] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:57:47] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:57:47] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:57:47] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (856.3865, 801.1558) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (753.0007, 698.2034) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (770.423, 714.4432) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (822.8129, 695.3276) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (756.4512, 660.918) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (783.5194, 676.1028) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (729.4733, 691.4366) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (730.5056, 688.3135) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (778.6851, 610.9774) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (794.9315, 683.8392) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (749.5662, 641.3346) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (871.6485, 734.6615) (added to group)
+[17:57:47] [INFO] [BloodDecal] Blood puddle created at (838.1598, 737.3407) (added to group)
+[17:57:48] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:48] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:57:48] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1023), corner_timer=0.30
+[17:57:48] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1023), corner_timer=0.30
+[17:57:49] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,918), corner_timer=-0.02
+[17:57:49] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:49] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,918), corner_timer=-0.02
+[17:57:49] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:57:49] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,913), corner_timer=0.30
+[17:57:49] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,913), corner_timer=0.30
+[17:57:49] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=164.0°, current=-168.8°, player=(453,820), corner_timer=0.00
+[17:57:49] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:57:49] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=165.9°, current=-9.6°, player=(456,811), corner_timer=0.00
+[17:57:49] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(456,811), corner_timer=-0.02
+[17:57:49] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:57:49] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(458,806), corner_timer=0.30
+[17:57:49] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=57.4°, current=45.0°, player=(520,738), corner_timer=0.00
+[17:57:49] [ENEMY] [Enemy2] State: IDLE -> COMBAT
+[17:57:49] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(528,731), corner_timer=-0.02
+[17:57:49] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:57:49] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(532,727), corner_timer=0.30
+[17:57:49] [ENEMY] [Enemy4] Memory: high confidence (0.86) - transitioning to PURSUING
+[17:57:49] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[17:57:49] [ENEMY] [Enemy1] Memory: high confidence (0.90) - transitioning to PURSUING
+[17:57:49] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:57:49] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-145.2°, current=-101.3°, player=(540,719), corner_timer=0.00
+[17:57:49] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=56.3°, current=-157.5°, player=(544,715), corner_timer=0.00
+[17:57:49] [ENEMY] [Enemy4] PURSUING corner check: angle -100.7°
+[17:57:49] [ENEMY] [Enemy1] PURSUING corner check: angle -63.3°
+[17:57:49] [ENEMY] [Enemy3] State: COMBAT -> PURSUING
+[17:57:50] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(578,641), corner_timer=-0.02
+[17:57:50] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:57:50] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(578,636), corner_timer=0.30
+[17:57:50] [ENEMY] [Enemy2] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=22.2°, current=22.1°, player=(578,622), corner_timer=0.00
+[17:57:50] [ENEMY] [Enemy1] PURSUING corner check: angle -58.4°
+[17:57:50] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:57:50] [ENEMY] [Enemy4] PURSUING corner check: angle -94.0°
+[17:57:50] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-124.6°, current=-172.0°, player=(578,591), corner_timer=0.00
+[17:57:50] [ENEMY] [Enemy3] State: PURSUING -> COMBAT
+[17:57:50] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(578,590), corner_timer=-0.02
+[17:57:50] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:57:50] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(578,590), corner_timer=0.30
+[17:57:50] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:50] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-87.5°, current=-136.8°, player=(578,599), corner_timer=0.02
+[17:57:50] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[17:57:50] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-87.1°, current=-34.1°, player=(578,605), corner_timer=0.02
+[17:57:50] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-88.3°, current=-40.0°, player=(578,611), corner_timer=0.02
+[17:57:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(689.7003, 752.7737), source=ENEMY (Enemy3), range=1469, listeners=20
+[17:57:50] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:57:50] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:50] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(578,622), corner_timer=-0.02
+[17:57:50] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:57:50] [INFO] [LastChance] Threat detected: Bullet
+[17:57:50] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:50] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:50] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(578,623), corner_timer=0.30
+[17:57:50] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=22.8°, current=22.5°, player=(578,625), corner_timer=0.00
+[17:57:50] [INFO] [Player] Spawning blood effect at (578.3401, 625.9377), dir=(1, 0), lethal=False (C#)
+[17:57:50] [INFO] [ImpactEffects] spawn_blood_effect called at (578.3401, 625.9377), dir=(1, 0), lethal=false
+[17:57:50] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:50] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:50] [INFO] [ImpactEffects] Blood effect spawned at (578.3401, 625.9377) (scale=1)
+[17:57:50] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:57:50] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:57:50] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:57:50] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:57:50] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:57:50] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:57:50] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:57:50] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:57:50] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:57:50] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:57:50] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:57:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(689.7003, 752.7737), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:51] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:51] [INFO] [LastChance] Threat detected: Bullet
+[17:57:51] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:51] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:51] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:51] [INFO] [Player] Spawning blood effect at (578.3401, 627.0212), dir=(1, 0), lethal=True (C#)
+[17:57:51] [INFO] [ImpactEffects] spawn_blood_effect called at (578.3401, 627.0212), dir=(1, 0), lethal=true
+[17:57:51] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:51] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:51] [INFO] [ImpactEffects] Blood effect spawned at (578.3401, 627.0212) (scale=1.5)
+[17:57:51] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:57:51] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:57:51] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:57:51] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:57:51] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:57:51] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:57:51] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:57:51] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:57:51] [INFO] [LastChance] Player died
+[17:57:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(686.2046, 762.9944), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:51] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:51] [INFO] [LastChance] Threat detected: Bullet
+[17:57:51] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:51] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:51] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(638.0819, 714.882), shooter_id=753900981999, bullet_pos=(508.6071, 551.6672)
+[17:57:51] [INFO] [Bullet] Using shooter_position, distance=208.333343505859
+[17:57:51] [INFO] [Bullet] Distance to wall: 208.333343505859 (14.1858004505525% of viewport)
+[17:57:51] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(686.2046, 762.9944), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:51] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:51] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.9°, current=174.7°, player=(578,627), corner_timer=-0.00
+[17:57:51] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[17:57:52] [INFO] [LastChance] Threat detected: @Area2D@2302
+[17:57:52] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:52] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:52] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=177.5°, player=(578,627), corner_timer=0.30
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (678.6061, 655.4921) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (645.9758, 662.0553) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (624.1315, 621.277) (added to group)
+[17:57:52] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(638.0819, 714.882), shooter_id=753900981999, bullet_pos=(508.6071, 551.6672)
+[17:57:52] [INFO] [Bullet] Using shooter_position, distance=208.333343505859
+[17:57:52] [INFO] [Bullet] Distance to wall: 208.333343505859 (14.1858004505525% of viewport)
+[17:57:52] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (655.8615, 606.8598) (added to group)
+[17:57:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(685.2275, 765.3766), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:52] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:52] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:52] [INFO] [LastChance] Threat detected: @Area2D@2309
+[17:57:52] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:52] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(583.4036, 863.1121), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:52] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (647.5553, 651.8169) (added to group)
+[17:57:52] [INFO] [LastChance] Threat detected: @Area2D@2311
+[17:57:52] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:52] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (694.7798, 644.4985) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (680.262, 684.4619) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (682.9846, 704.912) (added to group)
+[17:57:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(684.9648, 766.9276), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:52] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (740.6746, 613.5751) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (651.3364, 650.2251) (added to group)
+[17:57:52] [INFO] [LastChance] Threat detected: @Area2D@2317
+[17:57:52] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:52] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(583.4036, 863.1121), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:52] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (736.2125, 738.9348) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (746.0717, 645.5342) (added to group)
+[17:57:52] [INFO] [LastChance] Threat detected: @Area2D@2321
+[17:57:52] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:52] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (693.8826, 695.298) (added to group)
+[17:57:52] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(638.0819, 714.882), shooter_id=753900981999, bullet_pos=(1012.717, 46.97174)
+[17:57:52] [INFO] [Bullet] Using shooter_position, distance=765.803771972656
+[17:57:52] [INFO] [Bullet] Distance to wall: 765.803771972656 (52.1449870225839% of viewport)
+[17:57:52] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:57:52] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:52] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:57:52] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:57:52] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:57:52] [INFO] [CinemaEffects] Death effects reset
+[17:57:52] [ENEMY] [Enemy1] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:57:52] [ENEMY] [Enemy2] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:57:52] [ENEMY] [Enemy3] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:57:52] [ENEMY] [Enemy4] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:57:52] [ENEMY] [Enemy5] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:57:52] [ENEMY] [Enemy6] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:57:52] [ENEMY] [Enemy7] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:57:52] [ENEMY] [Enemy8] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:57:52] [ENEMY] [Enemy9] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:57:52] [ENEMY] [Enemy10] Death animation component initialized
+[17:57:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:52] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:57:52] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:57:52] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:57:52] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:57:52] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:57:52] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:57:52] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:57:52] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:57:52] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:57:52] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:57:52] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:57:52] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[17:57:52] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:57:52] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:57:52] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:57:52] [INFO] [ScoreManager] Level started with 10 enemies
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (735.5522, 693.3448) (added to group)
+[17:57:52] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:57:52] [INFO] [CinemaEffects] Found player node: Player
+[17:57:52] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:57:52] [ENEMY] [Enemy1] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[17:57:52] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:57:52] [ENEMY] [Enemy2] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[17:57:52] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:57:52] [ENEMY] [Enemy3] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[17:57:52] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:57:52] [ENEMY] [Enemy4] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[17:57:52] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:57:52] [ENEMY] [Enemy5] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[17:57:52] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:57:52] [ENEMY] [Enemy6] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[17:57:52] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:57:52] [ENEMY] [Enemy7] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[17:57:52] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:57:52] [ENEMY] [Enemy8] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[17:57:52] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:57:52] [ENEMY] [Enemy9] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:57:52] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:57:52] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:57:52] [ENEMY] [Enemy10] Registered as sound listener
+[17:57:52] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[17:57:52] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:57:52] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:52] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:52] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:52] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:52] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:52] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:52] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:52] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:52] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:57:52] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:57:52] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:57:52] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:57:52] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:57:52] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:57:52] [INFO] [LastChance] Found player: Player
+[17:57:52] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:57:52] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:57:52] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:57:52] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (694.5426, 749.2231) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (680.9896, 738.7684) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (740.9036, 653.8952) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (714.6005, 686.6573) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (741.2882, 763.2932) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (665.235, 672.8788) (added to group)
+[17:57:52] [INFO] [BloodyFeet:Enemy3] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (705.2519, 725.0398) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (782.2372, 663.6205) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (700.2237, 708.951) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (732.3865, 732.511) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (777.395, 751.8569) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (705.6353, 730.2657) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (780.1964, 636.5601) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (782.8343, 654.4167) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (800.079, 768.8246) (added to group)
+[17:57:52] [INFO] [BloodDecal] Blood puddle created at (781.5211, 812.1339) (added to group)
+[17:57:53] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:53] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:57:53] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1001), corner_timer=0.30
+[17:57:53] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1001), corner_timer=0.30
+[17:57:54] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,896), corner_timer=-0.02
+[17:57:54] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:54] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,896), corner_timer=-0.02
+[17:57:54] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:57:54] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,891), corner_timer=0.30
+[17:57:54] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,891), corner_timer=0.30
+[17:57:54] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=163.7°, current=123.7°, player=(470,817), corner_timer=0.00
+[17:57:54] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:57:54] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(483,801), corner_timer=-0.02
+[17:57:54] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:57:54] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(483,797), corner_timer=0.30
+[17:57:54] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=168.6°, current=-135.0°, player=(484,793), corner_timer=0.00
+[17:57:54] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(534,724), corner_timer=-0.02
+[17:57:54] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:57:54] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(537,721), corner_timer=0.30
+[17:57:54] [ENEMY] [Enemy4] Memory: high confidence (0.87) - transitioning to PURSUING
+[17:57:54] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[17:57:54] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-144.4°, current=168.8°, player=(542,715), corner_timer=0.00
+[17:57:54] [ENEMY] [Enemy4] PURSUING corner check: angle -100.7°
+[17:57:54] [ENEMY] [Enemy3] State: COMBAT -> PURSUING
+[17:57:55] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-162.3°, current=-112.5°, player=(553,703), corner_timer=0.00
+[17:57:55] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(557,698), corner_timer=-0.02
+[17:57:55] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:57:55] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(557,698), corner_timer=0.30
+[17:57:55] [ENEMY] [Enemy3] State: PURSUING -> COMBAT
+[17:57:55] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-116.3°, current=-71.1°, player=(557,698), corner_timer=-0.02
+[17:57:55] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[17:57:55] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-114.2°, current=-55.8°, player=(557,698), corner_timer=-0.02
+[17:57:55] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(557,698), corner_timer=-0.02
+[17:57:55] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:57:55] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(557,698), corner_timer=0.30
+[17:57:55] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-114.2°, current=-65.8°, player=(557,698), corner_timer=-0.02
+[17:57:55] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:55] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=20
+[17:57:55] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:57:55] [ENEMY] [Enemy2] Heard gunshot at (700, 750), source_type=1, intensity=0.02, distance=361
+[17:57:55] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:55] [INFO] [LastChance] Threat detected: Bullet
+[17:57:55] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:55] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:55] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=43.2°, current=-101.3°, player=(557,698), corner_timer=0.00
+[17:57:55] [INFO] [Player] Spawning blood effect at (557.99084, 698.2845), dir=(1, 0), lethal=False (C#)
+[17:57:55] [INFO] [ImpactEffects] spawn_blood_effect called at (557.9908, 698.2845), dir=(1, 0), lethal=false
+[17:57:55] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:55] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:55] [INFO] [ImpactEffects] Blood effect spawned at (557.9908, 698.2845) (scale=1)
+[17:57:55] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[17:57:55] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[17:57:55] [ENEMY] [Enemy1] Memory: medium confidence (0.62) - transitioning to PURSUING
+[17:57:55] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:57:55] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=53.5°, current=-157.5°, player=(557,698), corner_timer=0.00
+[17:57:56] [ENEMY] [Enemy1] PURSUING corner check: angle -63.3°
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(652.4423, 908.2896), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:56] [INFO] [LastChance] Threat detected: Bullet
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [LastChance] Threat detected: @Area2D@2598
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [Player] Spawning blood effect at (557.99084, 698.2845), dir=(1, 0), lethal=False (C#)
+[17:57:56] [INFO] [ImpactEffects] spawn_blood_effect called at (557.9908, 698.2845), dir=(1, 0), lethal=false
+[17:57:56] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:56] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:56] [INFO] [ImpactEffects] Blood effect spawned at (557.9908, 698.2845) (scale=1)
+[17:57:56] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[17:57:56] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[17:57:56] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(557,698), corner_timer=-0.02
+[17:57:56] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:57:56] [INFO] [Player] Spawning blood effect at (557.99084, 698.2845), dir=(1, 0), lethal=False (C#)
+[17:57:56] [INFO] [ImpactEffects] spawn_blood_effect called at (557.9908, 698.2845), dir=(1, 0), lethal=false
+[17:57:56] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:56] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:57:56] [INFO] [ImpactEffects] Blood effect spawned at (557.9908, 698.2845) (scale=1)
+[17:57:56] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:57:56] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:57:56] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:57:56] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:57:56] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:57:56] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:57:56] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:57:56] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:57:56] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:57:56] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:57:56] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:57:56] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(557,698), corner_timer=0.30
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(706.4047, 758.6364), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(652.4423, 908.2896), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:56] [INFO] [LastChance] Threat detected: Bullet
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [LastChance] Threat detected: @Area2D@2603
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [Player] Spawning blood effect at (557.99084, 698.2845), dir=(1, 0), lethal=True (C#)
+[17:57:56] [INFO] [ImpactEffects] spawn_blood_effect called at (557.9908, 698.2845), dir=(1, 0), lethal=true
+[17:57:56] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:57:56] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:57:56] [INFO] [ImpactEffects] Blood effect spawned at (557.9908, 698.2845) (scale=1.5)
+[17:57:56] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:57:56] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:57:56] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:57:56] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:57:56] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:57:56] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:57:56] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:57:56] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:57:56] [INFO] [LastChance] Player died
+[17:57:56] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=43.2°, current=-6.5°, player=(557,698), corner_timer=0.00
+[17:57:56] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (621.3989, 683.1285) (added to group)
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(706.4047, 758.6364), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(649.5698, 919.3704), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:56] [INFO] [LastChance] Threat detected: Bullet
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (649.2809, 761.727) (added to group)
+[17:57:56] [INFO] [LastChance] Threat detected: @Area2D@2608
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (645.1271, 753.572) (added to group)
+[17:57:56] [ENEMY] [Enemy1] PURSUING corner check: angle -58.9°
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(707.5712, 766.3896), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(648.7151, 922.2644), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (651.8303, 705.0209) (added to group)
+[17:57:56] [INFO] [LastChance] Threat detected: Bullet
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [LastChance] Threat detected: @Area2D@2613
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (636.1816, 730.5286) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (679.6335, 783.7083) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (611.3153, 717.661) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (604.793, 720.7833) (added to group)
+[17:57:56] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(557,698), corner_timer=-0.02
+[17:57:56] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (670.3313, 677.2031) (added to group)
+[17:57:56] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(557,698), corner_timer=0.30
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (660.8292, 684.1707) (added to group)
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(707.5712, 766.3896), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(647.8496, 924.7054), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (645.2305, 736.5712) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (647.2029, 673.3432) (added to group)
+[17:57:56] [INFO] [LastChance] Threat detected: Bullet
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (660.6705, 684.6975) (added to group)
+[17:57:56] [INFO] [LastChance] Threat detected: @Area2D@2625
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(400, 550), source=ENEMY (Enemy2), range=1469, listeners=10
+[17:57:56] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (697.4415, 687.0419) (added to group)
+[17:57:56] [INFO] [LastChance] Threat detected: @Area2D@2631
+[17:57:56] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:56] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (714.2823, 700.0994) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (681.8654, 720.4391) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (694.1912, 721.0961) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (637.2336, 783.9104) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (626.9453, 736.1162) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (630.4298, 743.5355) (added to group)
+[17:57:56] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (669.6639, 746.0398) (added to group)
+[17:57:56] [INFO] [BloodDecal] Blood puddle created at (649.8285, 732.5191) (added to group)
+[17:57:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(705.9332, 772.5388), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:57:57] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:57:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(645.967, 931.1295), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:57:57] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (632.0745, 732.3658) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (704.3054, 771.4659) (added to group)
+[17:57:57] [INFO] [LastChance] Threat detected: Bullet
+[17:57:57] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:57] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:57] [INFO] [LastChance] Threat detected: @Area2D@2649
+[17:57:57] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:57] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(400, 550), source=ENEMY (Enemy2), range=1469, listeners=10
+[17:57:57] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (684.302, 754.5735) (added to group)
+[17:57:57] [INFO] [LastChance] Threat detected: @Area2D@2654
+[17:57:57] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:57:57] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (663.0002, 805.6038) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (632.5125, 729.9438) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (638.0034, 728.0984) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (790.9485, 780.0272) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (671.3043, 709.9076) (added to group)
+[17:57:57] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:57:57] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:57:57] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:57:57] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:57:57] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:57:57] [INFO] [CinemaEffects] Death effects reset
+[17:57:57] [ENEMY] [Enemy1] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:57:57] [ENEMY] [Enemy2] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:57:57] [ENEMY] [Enemy3] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:57:57] [ENEMY] [Enemy4] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:57:57] [ENEMY] [Enemy5] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:57:57] [ENEMY] [Enemy6] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:57:57] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:57:57] [ENEMY] [Enemy7] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:57:57] [ENEMY] [Enemy8] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:57:57] [ENEMY] [Enemy9] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:57:57] [ENEMY] [Enemy10] Death animation component initialized
+[17:57:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:57:57] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:57:57] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:57:57] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:57:57] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:57:57] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:57:57] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:57:57] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:57:57] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:57:57] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:57:57] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:57:57] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:57:57] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[17:57:57] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:57:57] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:57:57] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:57:57] [INFO] [ScoreManager] Level started with 10 enemies
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (757.0809, 766.1805) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (702.6405, 798.2923) (added to group)
+[17:57:57] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:57:57] [INFO] [CinemaEffects] Found player node: Player
+[17:57:57] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:57:57] [ENEMY] [Enemy1] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[17:57:57] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:57:57] [ENEMY] [Enemy2] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[17:57:57] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:57:57] [ENEMY] [Enemy3] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[17:57:57] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:57:57] [ENEMY] [Enemy4] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[17:57:57] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:57:57] [ENEMY] [Enemy5] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[17:57:57] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:57:57] [ENEMY] [Enemy6] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[17:57:57] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:57:57] [ENEMY] [Enemy7] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[17:57:57] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:57:57] [ENEMY] [Enemy8] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[17:57:57] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:57:57] [ENEMY] [Enemy9] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[17:57:57] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:57:57] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:57:57] [ENEMY] [Enemy10] Registered as sound listener
+[17:57:57] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[17:57:57] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:57:57] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:57] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:57] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:57] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:57] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:57] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:57] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:57] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:57:57] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:57:57] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:57:57] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:57:57] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:57:57] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:57:57] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:57:57] [INFO] [LastChance] Found player: Player
+[17:57:57] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:57:57] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:57:57] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:57:57] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (689.6266, 750.5861) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (712.7938, 783.4562) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (703.9861, 777.8668) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (715.9507, 779.7115) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (696.6923, 713.044) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (668.7023, 726.2842) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (723.1387, 786.2006) (added to group)
+[17:57:57] [INFO] [BloodyFeet:Enemy3] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (656.4853, 804.7329) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (687.4435, 721.6038) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (682.1414, 740.9777) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (670.2119, 817.7632) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (668.142, 795.0197) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (656.3402, 800.9412) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (669.1279, 846.9647) (added to group)
+[17:57:57] [INFO] [BloodDecal] Blood puddle created at (745.6082, 778.2799) (added to group)
+[17:57:58] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:58] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:57:58] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1012), corner_timer=0.30
+[17:57:58] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1012), corner_timer=0.30
+[17:57:58] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,907), corner_timer=-0.02
+[17:57:58] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:57:58] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,907), corner_timer=-0.02
+[17:57:58] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:57:59] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,902), corner_timer=0.30
+[17:57:59] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,902), corner_timer=0.30
+[17:57:59] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(481,810), corner_timer=-0.02
+[17:57:59] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:57:59] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(483,806), corner_timer=0.30
+[17:57:59] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(529,733), corner_timer=-0.02
+[17:57:59] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:57:59] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(533,729), corner_timer=0.30
+[17:57:59] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(591,670), corner_timer=-0.02
+[17:57:59] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:58:00] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(593,669), corner_timer=0.30
+[17:58:00] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(596,665), corner_timer=-0.02
+[17:58:00] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:58:00] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(596,665), corner_timer=0.30
+[17:58:00] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:00] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(664,665), corner_timer=-0.02
+[17:58:00] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:58:00] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(669,665), corner_timer=0.30
+[17:58:00] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=-115.9°, current=-101.3°, player=(686,665), corner_timer=0.00
+[17:58:00] [ENEMY] [Enemy4] State: IDLE -> COMBAT
+[17:58:00] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-114.1°, current=138.3°, player=(697,665), corner_timer=0.00
+[17:58:01] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:01] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=-80.7°, current=-33.8°, player=(713,665), corner_timer=0.00
+[17:58:01] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:58:01] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(774,665), corner_timer=-0.02
+[17:58:01] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[17:58:01] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(779,665), corner_timer=0.30
+[17:58:01] [ENEMY] [Enemy1] Memory: high confidence (0.90) - transitioning to PURSUING
+[17:58:01] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:58:01] [ENEMY] [Enemy2] Memory: high confidence (0.90) - transitioning to PURSUING
+[17:58:01] [ENEMY] [Enemy2] State: IDLE -> PURSUING
+[17:58:01] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=32.3°, current=-33.8°, player=(799,665), corner_timer=0.00
+[17:58:01] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=16.1°, current=168.8°, player=(799,665), corner_timer=0.00
+[17:58:01] [ENEMY] [Enemy1] PURSUING corner check: angle -50.9°
+[17:58:01] [ENEMY] [Enemy2] PURSUING corner check: angle -90.0°
+[17:58:01] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-86.2°, current=-134.0°, player=(806,665), corner_timer=0.00
+[17:58:01] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:01] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(792.016, 887.4346), source=ENEMY (Enemy4), range=1469, listeners=20
+[17:58:01] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:58:01] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=1, below_threshold=7
+[17:58:01] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(831,665), corner_timer=-0.02
+[17:58:01] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[17:58:01] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(831,665), corner_timer=0.30
+[17:58:01] [INFO] [LastChance] Threat detected: Bullet
+[17:58:01] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:01] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:01] [INFO] [Player] Spawning blood effect at (831.511, 665.3704), dir=(1, 0), lethal=False (C#)
+[17:58:01] [INFO] [ImpactEffects] spawn_blood_effect called at (831.511, 665.3704), dir=(1, 0), lethal=false
+[17:58:01] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:01] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:01] [INFO] [ImpactEffects] Wall found for blood splatter at (912, 665.3704) (dist=80 px)
+[17:58:01] [INFO] [BloodDecal] Blood puddle created at (911, 665.3704) (added to group)
+[17:58:01] [INFO] [ImpactEffects] Blood effect spawned at (831.511, 665.3704) (scale=1)
+[17:58:01] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[17:58:01] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[17:58:01] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:01] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:01] [INFO] [LastChance] Threat detected: @Area2D@2935
+[17:58:01] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:01] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:01] [ENEMY] [Enemy1] PURSUING corner check: angle -51.1°
+[17:58:01] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(792.016, 887.4346), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:01] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=1, below_threshold=7
+[17:58:01] [INFO] [Player] Spawning blood effect at (831.511, 665.3704), dir=(1, 0), lethal=False (C#)
+[17:58:01] [INFO] [ImpactEffects] spawn_blood_effect called at (831.511, 665.3704), dir=(1, 0), lethal=false
+[17:58:01] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:01] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:01] [INFO] [ImpactEffects] Wall found for blood splatter at (912, 665.3704) (dist=80 px)
+[17:58:01] [INFO] [BloodDecal] Blood puddle created at (911, 665.3704) (added to group)
+[17:58:01] [INFO] [ImpactEffects] Blood effect spawned at (831.511, 665.3704) (scale=1)
+[17:58:01] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:58:01] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:58:01] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:58:01] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:58:01] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:58:01] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:58:01] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:58:01] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:58:01] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:58:01] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:58:01] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:58:01] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:01] [INFO] [LastChance] Threat detected: Bullet
+[17:58:01] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:01] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [INFO] [Player] Spawning blood effect at (831.511, 665.3704), dir=(1, 0), lethal=True (C#)
+[17:58:02] [INFO] [ImpactEffects] spawn_blood_effect called at (831.511, 665.3704), dir=(1, 0), lethal=true
+[17:58:02] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:02] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:58:02] [INFO] [ImpactEffects] Wall found for blood splatter at (912, 665.3704) (dist=80 px)
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (911, 665.3704) (added to group)
+[17:58:02] [INFO] [ImpactEffects] Blood effect spawned at (831.511, 665.3704) (scale=1.5)
+[17:58:02] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:58:02] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:58:02] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:58:02] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:58:02] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:58:02] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:58:02] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:58:02] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:58:02] [INFO] [LastChance] Player died
+[17:58:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:02] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:02] [INFO] [LastChance] Threat detected: Bullet
+[17:58:02] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.5513, 893.1532), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:02] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:02] [INFO] [LastChance] Threat detected: @Area2D@2943
+[17:58:02] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(694.571, 746.2886), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:02] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:02] [INFO] [LastChance] Threat detected: Bullet
+[17:58:02] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.8°, current=89.7°, player=(831,665), corner_timer=-0.01
+[17:58:02] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (880.8071, 679.2086) (added to group)
+[17:58:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.5513, 893.1532), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:02] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:02] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=92.5°, player=(831,665), corner_timer=0.30
+[17:58:02] [INFO] [LastChance] Threat detected: @Area2D@2947
+[17:58:02] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (895.311, 685.0784) (added to group)
+[17:58:02] [ENEMY] [Enemy1] PURSUING corner check: angle 153.2°
+[17:58:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(694.3885, 746.2375), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:02] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:02] [INFO] [LastChance] Threat detected: Bullet
+[17:58:02] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (872.7298, 687.6038) (added to group)
+[17:58:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(780.6837, 902.2989), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:02] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:02] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (910.7515, 701.6594) (added to group)
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (903.9453, 654.5616) (added to group)
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (902.9933, 653.9512) (added to group)
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (879.2761, 692.5862) (added to group)
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (902.1323, 684.77) (added to group)
+[17:58:02] [INFO] [LastChance] Threat detected: @Area2D@2952
+[17:58:02] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (911.9639, 721.2752) (added to group)
+[17:58:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(688.744, 741.3995), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:02] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (899.9587, 695.9976) (added to group)
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (907.9659, 669.7466) (added to group)
+[17:58:02] [INFO] [LastChance] Threat detected: Bullet
+[17:58:02] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(780.6837, 902.2989), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:02] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:02] [INFO] [BloodDecal] Blood puddle created at (906.3819, 731.9633) (added to group)
+[17:58:02] [INFO] [LastChance] Threat detected: @Area2D@2968
+[17:58:02] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(688.744, 741.3995), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:02] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:02] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.9°, current=89.3°, player=(831,665), corner_timer=-0.02
+[17:58:02] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[17:58:02] [INFO] [LastChance] Threat detected: Bullet
+[17:58:02] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:02] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:02] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=92.2°, player=(831,665), corner_timer=0.30
+[17:58:02] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:58:02] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:02] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:58:02] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:58:02] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:58:02] [INFO] [CinemaEffects] Death effects reset
+[17:58:02] [ENEMY] [Enemy1] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:58:02] [ENEMY] [Enemy2] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:58:02] [ENEMY] [Enemy3] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:58:02] [ENEMY] [Enemy4] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:58:02] [ENEMY] [Enemy5] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:58:02] [ENEMY] [Enemy6] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:58:02] [ENEMY] [Enemy7] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:58:02] [ENEMY] [Enemy8] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:58:02] [ENEMY] [Enemy9] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:58:02] [ENEMY] [Enemy10] Death animation component initialized
+[17:58:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:02] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:58:02] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:58:02] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:58:02] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:58:02] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:58:02] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:58:02] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:58:02] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:58:02] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:58:02] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:58:02] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:58:02] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[17:58:02] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:58:02] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:58:02] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:58:02] [INFO] [ScoreManager] Level started with 10 enemies
+[17:58:02] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:58:02] [INFO] [CinemaEffects] Found player node: Player
+[17:58:02] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:58:02] [ENEMY] [Enemy1] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[17:58:02] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:58:02] [ENEMY] [Enemy2] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[17:58:02] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:58:02] [ENEMY] [Enemy3] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[17:58:02] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:58:02] [ENEMY] [Enemy4] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[17:58:02] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:58:02] [ENEMY] [Enemy5] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[17:58:02] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:58:02] [ENEMY] [Enemy6] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[17:58:02] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:58:02] [ENEMY] [Enemy7] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[17:58:02] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:58:02] [ENEMY] [Enemy8] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[17:58:02] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:58:02] [ENEMY] [Enemy9] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:58:02] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:58:02] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:58:02] [ENEMY] [Enemy10] Registered as sound listener
+[17:58:02] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[17:58:02] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:58:02] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:02] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:02] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:02] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:02] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:02] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:02] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:02] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:02] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:58:02] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:58:02] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:58:02] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:58:02] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:58:02] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:58:02] [INFO] [LastChance] Found player: Player
+[17:58:02] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:58:02] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:58:02] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:58:02] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:58:04] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:04] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:58:04] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,957), corner_timer=0.30
+[17:58:04] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,957), corner_timer=0.30
+[17:58:04] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,852), corner_timer=-0.02
+[17:58:04] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:04] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,852), corner_timer=-0.02
+[17:58:04] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:58:04] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,847), corner_timer=0.30
+[17:58:04] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,847), corner_timer=0.30
+[17:58:04] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(489,759), corner_timer=-0.02
+[17:58:04] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:58:04] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(493,755), corner_timer=0.30
+[17:58:05] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(567,681), corner_timer=-0.02
+[17:58:05] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:58:05] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(571,677), corner_timer=0.30
+[17:58:05] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=-126.7°, current=-78.7°, player=(614,634), corner_timer=0.00
+[17:58:05] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:58:05] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-114.3°, current=-180.0°, player=(637,611), corner_timer=0.00
+[17:58:05] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(645,603), corner_timer=-0.02
+[17:58:05] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:58:05] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(649,599), corner_timer=0.30
+[17:58:05] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=-115.8°, current=-67.5°, player=(652,595), corner_timer=0.00
+[17:58:05] [ENEMY] [Enemy4] State: IDLE -> COMBAT
+[17:58:05] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-114.4°, current=171.8°, player=(660,587), corner_timer=0.00
+[17:58:05] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-95.6°, current=-143.7°, player=(681,564), corner_timer=0.00
+[17:58:05] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-107.8°, current=-155.6°, player=(686,559), corner_timer=0.00
+[17:58:05] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(695,548), corner_timer=-0.02
+[17:58:05] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:58:05] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(696,547), corner_timer=0.30
+[17:58:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=20
+[17:58:05] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:58:05] [ENEMY] [Enemy2] Heard gunshot at (700, 750), source_type=1, intensity=0.02, distance=361
+[17:58:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:05] [INFO] [LastChance] Threat detected: Bullet
+[17:58:05] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:05] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:05] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-0.6°, current=168.8°, player=(697,547), corner_timer=0.00
+[17:58:06] [INFO] [Player] Spawning blood effect at (697.1975, 547.0006), dir=(1, 0), lethal=False (C#)
+[17:58:06] [INFO] [ImpactEffects] spawn_blood_effect called at (697.1975, 547.0006), dir=(1, 0), lethal=false
+[17:58:06] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:06] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:06] [INFO] [ImpactEffects] Blood effect spawned at (697.1975, 547.0006) (scale=1)
+[17:58:06] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[17:58:06] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [INFO] [LastChance] Threat detected: Bullet
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(786.3157, 794.8491), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [INFO] [Player] Spawning blood effect at (697.1975, 547.0006), dir=(1, 0), lethal=False (C#)
+[17:58:06] [INFO] [ImpactEffects] spawn_blood_effect called at (697.1975, 547.0006), dir=(1, 0), lethal=false
+[17:58:06] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:06] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:06] [INFO] [ImpactEffects] Blood effect spawned at (697.1975, 547.0006) (scale=1)
+[17:58:06] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[17:58:06] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[17:58:06] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:06] [INFO] [LastChance] Threat detected: @Area2D@3229
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(691.7519, 758.9863), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [INFO] [LastChance] Threat detected: Bullet
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [INFO] [Player] Spawning blood effect at (697.1975, 547.0006), dir=(1, 0), lethal=False (C#)
+[17:58:06] [INFO] [ImpactEffects] spawn_blood_effect called at (697.1975, 547.0006), dir=(1, 0), lethal=false
+[17:58:06] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:06] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:06] [INFO] [ImpactEffects] Blood effect spawned at (697.1975, 547.0006) (scale=1)
+[17:58:06] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:58:06] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:58:06] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:58:06] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:58:06] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:58:06] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:58:06] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:58:06] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:58:06] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:58:06] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:58:06] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:58:06] [ENEMY] [Enemy1] Memory: medium confidence (0.61) - transitioning to PURSUING
+[17:58:06] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(793.8051, 769.3198), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=26.4°, current=168.8°, player=(697,547), corner_timer=0.00
+[17:58:06] [ENEMY] [Enemy1] PURSUING corner check: angle -50.9°
+[17:58:06] [INFO] [LastChance] Threat detected: @Area2D@3234
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [INFO] [Player] Spawning blood effect at (697.1975, 547.0006), dir=(1, 0), lethal=True (C#)
+[17:58:06] [INFO] [ImpactEffects] spawn_blood_effect called at (697.1975, 547.0006), dir=(1, 0), lethal=true
+[17:58:06] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:06] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:58:06] [INFO] [ImpactEffects] Blood effect spawned at (697.1975, 547.0006) (scale=1.5)
+[17:58:06] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:58:06] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:58:06] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:58:06] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:58:06] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:58:06] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:58:06] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:58:06] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:58:06] [INFO] [LastChance] Player died
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (731.5512, 544.3633) (added to group)
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(691.7519, 758.9863), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (740.0325, 581.9076) (added to group)
+[17:58:06] [INFO] [LastChance] Threat detected: Bullet
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(802.1357, 743.0182), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-127.8°, player=(697,547), corner_timer=-0.00
+[17:58:06] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:58:06] [INFO] [LastChance] Threat detected: @Area2D@3239
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-130.7°, player=(697,547), corner_timer=0.30
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (748.1172, 564.6272) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (770.816, 536.6847) (added to group)
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(834.9373, 741.0347), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (764.1095, 614.7701) (added to group)
+[17:58:06] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(692.4548, 785.9335), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (742.3607, 539.7103) (added to group)
+[17:58:06] [INFO] [LastChance] Threat detected: @Area2D@3244
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (794.6964, 627.0673) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (777.0308, 602.6578) (added to group)
+[17:58:06] [INFO] [LastChance] Threat detected: @Area2D@3248
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (773.1428, 529.8982) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (741.5569, 582.7286) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (736.4716, 548.8981) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (731.7229, 574.0018) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (840.1461, 588.9662) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (777.3317, 595.9934) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (853.9534, 617.0219) (added to group)
+[17:58:06] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(701.2853, 691.6089), shooter_id=1128049676314, bullet_pos=(717.3354, 66.81491)
+[17:58:06] [INFO] [Bullet] Using shooter_position, distance=625.000061035156
+[17:58:06] [INFO] [Bullet] Distance to wall: 625.000061035156 (42.5574034296557% of viewport)
+[17:58:06] [INFO] [Bullet] Distance-based penetration chance: 97.0163626654017%
+[17:58:06] [INFO] [Bullet] Starting wall penetration at (717.3354, 66.81491)
+[17:58:06] [ENEMY] [Enemy1] PURSUING corner check: angle -51.9°
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(843.4188, 741.8715), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [INFO] [Bullet] Raycast backward hit penetrating body at distance 11.8402738571167
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (777.6928, 647.1516) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (778.2462, 580.7653) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (750.2479, 584.2792) (added to group)
+[17:58:06] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:58:06] [INFO] [Bullet] Exiting penetration at (718.5338, 20.16363) after traveling 41.6666679382324 pixels through wall
+[17:58:06] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(694.0058, 764.6412), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (802.6396, 611.3192) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (809.83, 611.4202) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (778.2046, 540.5854) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (800.0078, 569.927) (added to group)
+[17:58:06] [INFO] [LastChance] Threat detected: @Area2D@3262
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [INFO] [LastChance] Threat detected: @Area2D@3268
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (818.0328, 573.1552) (added to group)
+[17:58:06] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(845.7896, 751.5999), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:06] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.2°, current=174.7°, player=(697,547), corner_timer=-0.02
+[17:58:06] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[17:58:06] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=177.6°, player=(697,547), corner_timer=0.30
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (906.6493, 631.2062) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (815.5455, 633.1637) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (836.8599, 592.9649) (added to group)
+[17:58:06] [INFO] [LastChance] Threat detected: Bullet
+[17:58:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (798.6667, 638.9716) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (777.9618, 642.4092) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (791.9178, 641.0529) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (847.4462, 580.5261) (added to group)
+[17:58:06] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(701.595, 718.2027), shooter_id=1128049676314, bullet_pos=(794.0647, 57.98011)
+[17:58:06] [INFO] [Bullet] Using shooter_position, distance=666.666748046875
+[17:58:06] [INFO] [Bullet] Distance to wall: 666.666748046875 (45.394564766565% of viewport)
+[17:58:06] [INFO] [Bullet] Distance-based penetration chance: 93.7063411056742%
+[17:58:06] [INFO] [Bullet] Starting wall penetration at (794.0647, 57.98011)
+[17:58:06] [INFO] [Bullet] Raycast backward hit penetrating body at distance 20.4329624176025
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (866.8344, 580.7414) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (850.183, 603.3231) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (774.5892, 634.7636) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (785.3237, 576.1909) (added to group)
+[17:58:06] [INFO] [BloodDecal] Blood puddle created at (798.5389, 600.9319) (added to group)
+[17:58:06] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:58:06] [INFO] [Bullet] Exiting penetration at (800.5376, 11.76454) after traveling 41.6666679382324 pixels through wall
+[17:58:06] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:58:06] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:58:06] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:06] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:58:06] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:58:06] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:58:06] [INFO] [CinemaEffects] Death effects reset
+[17:58:06] [ENEMY] [Enemy1] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:58:06] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:58:06] [ENEMY] [Enemy2] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:58:06] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:58:06] [ENEMY] [Enemy3] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:58:06] [ENEMY] [Enemy4] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:58:06] [ENEMY] [Enemy5] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:58:06] [ENEMY] [Enemy6] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:58:06] [ENEMY] [Enemy7] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:58:06] [ENEMY] [Enemy8] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:58:06] [ENEMY] [Enemy9] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:58:06] [ENEMY] [Enemy10] Death animation component initialized
+[17:58:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:06] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:58:06] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:58:06] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:58:07] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:58:07] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:58:07] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:58:07] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:58:07] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:58:07] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:58:07] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:58:07] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:58:07] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[17:58:07] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:58:07] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:58:07] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:58:07] [INFO] [ScoreManager] Level started with 10 enemies
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (891.5788, 607.4239) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (833.0352, 594.8666) (added to group)
+[17:58:07] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:58:07] [INFO] [CinemaEffects] Found player node: Player
+[17:58:07] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:58:07] [ENEMY] [Enemy1] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[17:58:07] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:58:07] [ENEMY] [Enemy2] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[17:58:07] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:58:07] [ENEMY] [Enemy3] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[17:58:07] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:58:07] [ENEMY] [Enemy4] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[17:58:07] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:58:07] [ENEMY] [Enemy5] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[17:58:07] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:58:07] [ENEMY] [Enemy6] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[17:58:07] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:58:07] [ENEMY] [Enemy7] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[17:58:07] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:58:07] [ENEMY] [Enemy8] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[17:58:07] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:58:07] [ENEMY] [Enemy9] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:58:07] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:58:07] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:58:07] [ENEMY] [Enemy10] Registered as sound listener
+[17:58:07] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[17:58:07] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:58:07] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:07] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:07] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:07] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:07] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:07] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=225.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:07] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=157.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:07] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:07] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:58:07] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:58:07] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:58:07] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:58:07] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:58:07] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:58:07] [INFO] [LastChance] Found player: Player
+[17:58:07] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:58:07] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:58:07] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:58:07] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (839.0844, 685.4478) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (893.1497, 562.2385) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (898.7636, 621.1632) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (822.4399, 688.9507) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (831.684, 675.9695) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (794.4417, 613.9378) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (854.9125, 563.5725) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (890.1542, 580.1525) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (894.0947, 618.6439) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (886.0956, 743.4556) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (814.8456, 670.7249) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (832.1441, 680.7729) (added to group)
+[17:58:07] [INFO] [BloodDecal] Blood puddle created at (893.4024, 623.557) (added to group)
+[17:58:08] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:08] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:58:08] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,968), corner_timer=0.30
+[17:58:08] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,968), corner_timer=0.30
+[17:58:08] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,863), corner_timer=-0.02
+[17:58:08] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:08] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,863), corner_timer=-0.02
+[17:58:08] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:58:08] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,858), corner_timer=0.30
+[17:58:08] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,858), corner_timer=0.30
+[17:58:09] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(501,774), corner_timer=-0.02
+[17:58:09] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:58:09] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(505,771), corner_timer=0.30
+[17:58:09] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=-173.5°, current=-123.8°, player=(544,732), corner_timer=0.00
+[17:58:09] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:58:09] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-162.7°, current=135.0°, player=(567,708), corner_timer=0.00
+[17:58:09] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(579,697), corner_timer=-0.02
+[17:58:09] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:58:09] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(582,693), corner_timer=0.30
+[17:58:09] [ENEMY] [Enemy4] Memory: high confidence (0.89) - transitioning to PURSUING
+[17:58:09] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[17:58:09] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-134.5°, current=-101.3°, player=(588,685), corner_timer=0.00
+[17:58:09] [ENEMY] [Enemy4] PURSUING corner check: angle -100.7°
+[17:58:09] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(615,651), corner_timer=-0.02
+[17:58:09] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:58:09] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(615,651), corner_timer=0.30
+[17:58:09] [ENEMY] [Enemy3] State: COMBAT -> PURSUING
+[17:58:09] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-130.7°, current=-180.0°, player=(615,651), corner_timer=0.00
+[17:58:10] [ENEMY] [Enemy4] PURSUING corner check: angle -94.0°
+[17:58:10] [ENEMY] [Enemy3] State: PURSUING -> COMBAT
+[17:58:10] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(615,651), corner_timer=-0.02
+[17:58:10] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:58:10] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(615,651), corner_timer=0.30
+[17:58:10] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:10] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-78.6°, current=-128.2°, player=(615,651), corner_timer=0.02
+[17:58:10] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[17:58:10] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-78.1°, current=-16.6°, player=(615,651), corner_timer=0.02
+[17:58:10] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(615,651), corner_timer=-0.02
+[17:58:10] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:58:10] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-77.6°, current=-29.9°, player=(615,651), corner_timer=0.02
+[17:58:10] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(615,651), corner_timer=0.30
+[17:58:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=20
+[17:58:10] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:58:10] [ENEMY] [Enemy2] Heard gunshot at (700, 750), source_type=1, intensity=0.02, distance=361
+[17:58:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:10] [INFO] [LastChance] Threat detected: Bullet
+[17:58:10] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:10] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=25.3°, current=-101.3°, player=(615,651), corner_timer=0.00
+[17:58:10] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(649.9973, 703.8445), shooter_id=1201819093989, bullet_pos=(514.118, 545.9216)
+[17:58:10] [INFO] [Bullet] Using shooter_position, distance=208.333450317383
+[17:58:10] [INFO] [Bullet] Distance to wall: 208.333450317383 (14.1858077235456% of viewport)
+[17:58:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:58:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:10] [INFO] [LastChance] Threat detected: @Area2D@3560
+[17:58:10] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(649.9973, 703.8445), shooter_id=1201819093989, bullet_pos=(514.118, 545.9216)
+[17:58:10] [INFO] [Bullet] Using shooter_position, distance=208.333450317383
+[17:58:10] [INFO] [Bullet] Distance to wall: 208.333450317383 (14.1858077235456% of viewport)
+[17:58:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(697.394, 757.9645), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:11] [INFO] [LastChance] Threat detected: @Area2D@3563
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(615,651), corner_timer=-0.02
+[17:58:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[17:58:11] [INFO] [Player] Spawning blood effect at (615.3589, 651.62756), dir=(1, 0), lethal=False (C#)
+[17:58:11] [INFO] [ImpactEffects] spawn_blood_effect called at (615.3589, 651.6276), dir=(1, 0), lethal=false
+[17:58:11] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:11] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:11] [INFO] [ImpactEffects] Blood effect spawned at (615.3589, 651.6276) (scale=1)
+[17:58:11] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[17:58:11] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[17:58:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(615,651), corner_timer=0.30
+[17:58:11] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=25.3°, current=-24.4°, player=(615,651), corner_timer=0.00
+[17:58:11] [ENEMY] [Enemy1] Memory: high confidence (0.90) - transitioning to PURSUING
+[17:58:11] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:58:11] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=43.7°, current=-157.5°, player=(615,651), corner_timer=0.00
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(697.394, 757.9645), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:11] [INFO] [LastChance] Threat detected: @Area2D@3565
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [ENEMY] [Enemy1] PURSUING corner check: angle -50.9°
+[17:58:11] [INFO] [Player] Spawning blood effect at (615.3589, 651.62756), dir=(1, 0), lethal=False (C#)
+[17:58:11] [INFO] [ImpactEffects] spawn_blood_effect called at (615.3589, 651.6276), dir=(1, 0), lethal=false
+[17:58:11] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:11] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:11] [INFO] [ImpactEffects] Blood effect spawned at (615.3589, 651.6276) (scale=1)
+[17:58:11] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[17:58:11] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[17:58:11] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(563.1744, 889.0617), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(649.9973, 703.8445), shooter_id=1201819093989, bullet_pos=(1071.958, 46.48052)
+[17:58:11] [INFO] [Bullet] Using shooter_position, distance=781.138977050781
+[17:58:11] [INFO] [Bullet] Distance to wall: 781.138977050781 (53.189189335309% of viewport)
+[17:58:11] [INFO] [Bullet] Distance-based penetration chance: 84.6126124421395%
+[17:58:11] [INFO] [Bullet] Penetration failed (distance roll)
+[17:58:11] [INFO] [LastChance] Threat detected: @Area2D@3568
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(695.825, 763.1251), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:11] [INFO] [LastChance] Threat detected: Bullet
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(649.9973, 703.8445), shooter_id=1201819093989, bullet_pos=(885.3127, 65.54137)
+[17:58:11] [INFO] [Bullet] Using shooter_position, distance=680.297241210938
+[17:58:11] [INFO] [Bullet] Distance to wall: 680.297241210938 (46.3226901103728% of viewport)
+[17:58:11] [INFO] [Player] Spawning blood effect at (615.3589, 651.62756), dir=(1, 0), lethal=False (C#)
+[17:58:11] [INFO] [ImpactEffects] spawn_blood_effect called at (615.3589, 651.6276), dir=(1, 0), lethal=false
+[17:58:11] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:11] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:11] [INFO] [ImpactEffects] Blood effect spawned at (615.3589, 651.6276) (scale=1)
+[17:58:11] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:58:11] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:58:11] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:58:11] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:58:11] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:58:11] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:58:11] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:58:11] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:58:11] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:58:11] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:58:11] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:58:11] [INFO] [Player] Spawning blood effect at (615.3589, 651.62756), dir=(1, 0), lethal=True (C#)
+[17:58:11] [INFO] [ImpactEffects] spawn_blood_effect called at (615.3589, 651.6276), dir=(1, 0), lethal=true
+[17:58:11] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:11] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:58:11] [INFO] [ImpactEffects] Blood effect spawned at (615.3589, 651.6276) (scale=1.5)
+[17:58:11] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:58:11] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:58:11] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:58:11] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:58:11] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:58:11] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:58:11] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:58:11] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:58:11] [INFO] [LastChance] Player died
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(563.1744, 889.0617), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:11] [INFO] [LastChance] Threat detected: Bullet
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(695.5662, 766.4987), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (698.3307, 689.6997) (added to group)
+[17:58:11] [INFO] [LastChance] Threat detected: @Area2D@3582
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(400, 550), source=ENEMY (Enemy2), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[17:58:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(615,651), corner_timer=-0.02
+[17:58:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[17:58:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(615,651), corner_timer=0.30
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (668.1581, 699.1368) (added to group)
+[17:58:11] [INFO] [LastChance] Threat detected: @Area2D@3587
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(649.9973, 703.8445), shooter_id=1201819093989, bullet_pos=(1081.812, 259.2674)
+[17:58:11] [INFO] [Bullet] Using shooter_position, distance=619.76806640625
+[17:58:11] [INFO] [Bullet] Distance to wall: 619.76806640625 (42.2011472945836% of viewport)
+[17:58:11] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(559.2255, 891.1793), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (693.1383, 713.0654) (added to group)
+[17:58:11] [INFO] [LastChance] Threat detected: Bullet
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [ENEMY] [Enemy1] PURSUING corner check: angle -51.1°
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (661.5536, 696.0468) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (665.3438, 691.187) (added to group)
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(400, 550), source=ENEMY (Enemy2), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (680.7678, 670.4226) (added to group)
+[17:58:11] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (746.7632, 751.0383) (added to group)
+[17:58:11] [INFO] [LastChance] Threat detected: @Area2D@3602
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (697.6455, 672.1324) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (658.1462, 657.4048) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (679.0759, 667.3141) (added to group)
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(558.1284, 892.4268), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (738.248, 724.7427) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (677.6156, 702.1555) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (693.3016, 665.7227) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (752.4686, 663.6885) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (698.8227, 649.4082) (added to group)
+[17:58:11] [INFO] [LastChance] Threat detected: Bullet
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (684.4366, 708.2065) (added to group)
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(392.9985, 547.1173), source=ENEMY (Enemy2), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (730.5381, 697.2111) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (695.2404, 692.3902) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (721.113, 726.466) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (716.2266, 689.7057) (added to group)
+[17:58:11] [INFO] [LastChance] Threat detected: @Area2D@3622
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (688.1082, 680.7644) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (685.4628, 658.8318) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (673.0273, 694.0708) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (693.1222, 683.1569) (added to group)
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(555.2235, 894.7697), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:11] [INFO] [LastChance] Threat detected: Bullet
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [ENEMY] [Enemy2] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=26.9°, current=27.1°, player=(615,651), corner_timer=0.00
+[17:58:11] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:58:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(615,651), corner_timer=-0.02
+[17:58:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (787.422, 714.4853) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (689.991, 714.636) (added to group)
+[17:58:11] [INFO] [LastChance] Threat detected: @Area2D@3560
+[17:58:11] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:11] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(615,651), corner_timer=0.30
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (839.3915, 821.6561) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (698.9227, 717.8581) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (761.2474, 702.0901) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (773.4464, 687.3301) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (733.7225, 728.8772) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (778.6846, 745.9904) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (750.4109, 640.8484) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (711.9503, 703.3828) (added to group)
+[17:58:11] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(553.2743, 895.9024), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:11] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:58:11] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:11] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:58:11] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:58:11] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:58:11] [INFO] [CinemaEffects] Death effects reset
+[17:58:11] [ENEMY] [Enemy1] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:58:11] [ENEMY] [Enemy2] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:58:11] [ENEMY] [Enemy3] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:58:11] [ENEMY] [Enemy4] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:58:11] [ENEMY] [Enemy5] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:58:11] [ENEMY] [Enemy6] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:58:11] [ENEMY] [Enemy7] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:58:11] [ENEMY] [Enemy8] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:58:11] [ENEMY] [Enemy9] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:58:11] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:58:11] [ENEMY] [Enemy10] Death animation component initialized
+[17:58:11] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:11] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:58:11] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:58:11] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:58:11] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:58:11] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:58:11] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:58:11] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:58:11] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:58:11] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:58:11] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:58:11] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:58:11] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[17:58:11] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:58:11] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:58:11] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:58:11] [INFO] [ScoreManager] Level started with 10 enemies
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (738.8152, 679.0427) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (729.2968, 691.6068) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (742.7938, 658.5495) (added to group)
+[17:58:11] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:58:11] [INFO] [CinemaEffects] Found player node: Player
+[17:58:11] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:58:11] [ENEMY] [Enemy1] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[17:58:11] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:58:11] [ENEMY] [Enemy2] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[17:58:11] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:58:11] [ENEMY] [Enemy3] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[17:58:11] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:58:11] [ENEMY] [Enemy4] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[17:58:11] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:58:11] [ENEMY] [Enemy5] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[17:58:11] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:58:11] [ENEMY] [Enemy6] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[17:58:11] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:58:11] [ENEMY] [Enemy7] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[17:58:11] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:58:11] [ENEMY] [Enemy8] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[17:58:11] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:58:11] [ENEMY] [Enemy9] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:58:11] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:58:11] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:58:11] [ENEMY] [Enemy10] Registered as sound listener
+[17:58:11] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[17:58:11] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:58:11] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:11] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:11] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:11] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:11] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:11] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:11] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:11] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:11] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:58:11] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:58:11] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:58:11] [INFO] [LastChance] Found player: Player
+[17:58:11] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:58:11] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:58:11] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:58:11] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (710.4096, 700.4996) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (732.5803, 762.6176) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (799.7443, 703.0475) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (728.0793, 760.9556) (added to group)
+[17:58:11] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:58:11] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:58:11] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (766.6045, 731.1884) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (742.1362, 755.9338) (added to group)
+[17:58:11] [INFO] [BloodyFeet:Enemy3] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (836.9185, 796.7508) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (794.9819, 706.6793) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (797.7048, 828.9537) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (783.1443, 700.219) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (763.8809, 726.1902) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (720.514, 750.2328) (added to group)
+[17:58:11] [INFO] [BloodDecal] Blood puddle created at (851.4732, 765.7151) (added to group)
+[17:58:13] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:13] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:58:13] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,979), corner_timer=0.30
+[17:58:13] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,979), corner_timer=0.30
+[17:58:13] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,874), corner_timer=-0.02
+[17:58:13] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:13] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,874), corner_timer=-0.02
+[17:58:13] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:58:13] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,869), corner_timer=0.30
+[17:58:13] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,869), corner_timer=0.30
+[17:58:14] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(474,774), corner_timer=-0.02
+[17:58:14] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:58:14] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(477,770), corner_timer=0.30
+[17:58:14] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(551,696), corner_timer=-0.02
+[17:58:14] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:58:14] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(555,692), corner_timer=0.30
+[17:58:14] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(629,619), corner_timer=-0.02
+[17:58:14] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:58:14] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(633,615), corner_timer=0.30
+[17:58:14] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=-115.9°, current=-101.3°, player=(652,595), corner_timer=0.00
+[17:58:14] [ENEMY] [Enemy4] State: IDLE -> COMBAT
+[17:58:14] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-114.8°, current=137.9°, player=(658,588), corner_timer=0.00
+[17:58:14] [ENEMY] [Enemy3] Memory: high confidence (0.89) - transitioning to PURSUING
+[17:58:14] [ENEMY] [Enemy3] State: IDLE -> PURSUING
+[17:58:14] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-98.1°, current=-33.8°, player=(674,570), corner_timer=0.00
+[17:58:14] [ENEMY] [Enemy3] PURSUING corner check: angle 141.3°
+[17:58:15] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(680,564), corner_timer=-0.02
+[17:58:15] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:58:15] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(680,563), corner_timer=0.30
+[17:58:15] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-110.4°, current=-159.9°, player=(681,562), corner_timer=0.00
+[17:58:15] [INFO] [BloodyFeet:Enemy4] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[17:58:15] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-69.7°, current=-119.5°, player=(681,562), corner_timer=0.02
+[17:58:15] [ENEMY] [Enemy3] State: PURSUING -> COMBAT
+[17:58:15] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(783.7574, 805.5694), source=ENEMY (Enemy4), range=1469, listeners=20
+[17:58:15] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:58:15] [ENEMY] [Enemy2] Heard gunshot at (783.7574, 805.5694), source_type=1, intensity=0.01, distance=461
+[17:58:15] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:15] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=2.6°, current=-157.5°, player=(681,562), corner_timer=0.00
+[17:58:15] [INFO] [LastChance] Threat detected: Bullet
+[17:58:15] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:15] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:15] [ENEMY] [Enemy1] Memory: high confidence (0.90) - transitioning to PURSUING
+[17:58:15] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:58:15] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=29.1°, current=168.8°, player=(681,562), corner_timer=0.00
+[17:58:15] [INFO] [Player] Spawning blood effect at (681.6411, 562.557), dir=(1, 0), lethal=False (C#)
+[17:58:15] [INFO] [ImpactEffects] spawn_blood_effect called at (681.6411, 562.557), dir=(1, 0), lethal=false
+[17:58:15] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:15] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:15] [INFO] [ImpactEffects] Blood effect spawned at (681.6411, 562.557) (scale=1)
+[17:58:15] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[17:58:15] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[17:58:15] [ENEMY] [Enemy1] PURSUING corner check: angle -63.3°
+[17:58:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(786.9009, 784.2754), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:15] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:15] [INFO] [LastChance] Threat detected: Bullet
+[17:58:15] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:15] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:15] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(681,562), corner_timer=-0.02
+[17:58:15] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:58:15] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(681,562), corner_timer=0.30
+[17:58:15] [INFO] [Player] Spawning blood effect at (681.6411, 562.557), dir=(1, 0), lethal=False (C#)
+[17:58:15] [INFO] [ImpactEffects] spawn_blood_effect called at (681.6411, 562.557), dir=(1, 0), lethal=false
+[17:58:15] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:15] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:15] [INFO] [ImpactEffects] Blood effect spawned at (681.6411, 562.557) (scale=1)
+[17:58:15] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[17:58:15] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[17:58:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(772.2123, 789.2858), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:15] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:15] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[17:58:15] [INFO] [LastChance] Threat detected: Bullet
+[17:58:15] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:15] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:15] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:15] [INFO] [Player] Spawning blood effect at (681.6411, 562.557), dir=(1, 0), lethal=False (C#)
+[17:58:15] [INFO] [ImpactEffects] spawn_blood_effect called at (681.6411, 562.557), dir=(1, 0), lethal=false
+[17:58:15] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:15] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:15] [INFO] [ImpactEffects] Blood effect spawned at (681.6411, 562.557) (scale=1)
+[17:58:15] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:58:15] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:58:15] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:58:15] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:58:15] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:58:15] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:58:15] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:58:15] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:58:15] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:58:15] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:58:15] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:58:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(772.2123, 789.2858), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:15] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:16] [INFO] [LastChance] Threat detected: Bullet
+[17:58:16] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:16] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (754.5316, 546.5813) (added to group)
+[17:58:16] [INFO] [Player] Spawning blood effect at (681.6411, 562.557), dir=(1, 0), lethal=True (C#)
+[17:58:16] [INFO] [ImpactEffects] spawn_blood_effect called at (681.6411, 562.557), dir=(1, 0), lethal=true
+[17:58:16] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:16] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:58:16] [INFO] [ImpactEffects] Blood effect spawned at (681.6411, 562.557) (scale=1.5)
+[17:58:16] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:58:16] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:58:16] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:58:16] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:58:16] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:58:16] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:58:16] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:58:16] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:58:16] [INFO] [LastChance] Player died
+[17:58:16] [ENEMY] [Enemy1] PURSUING corner check: angle -59.2°
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (771.0375, 541.9023) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (761.572, 553.4721) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (729.5892, 590.6435) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (756.327, 568.0961) (added to group)
+[17:58:16] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(781.7121, 799.7731), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:16] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (759.1801, 556.6434) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (723.8406, 575.347) (added to group)
+[17:58:16] [INFO] [LastChance] Threat detected: Bullet
+[17:58:16] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:16] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:16] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=174.7°, player=(681,562), corner_timer=-0.00
+[17:58:16] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (771.0613, 640.0303) (added to group)
+[17:58:16] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=176.6°, player=(681,562), corner_timer=0.30
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (754.9755, 617.9565) (added to group)
+[17:58:16] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (794.1575, 585.8199) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (744.1964, 578.5264) (added to group)
+[17:58:16] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(781.7121, 799.7731), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:16] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (804.5959, 618.079) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (773.715, 627.9364) (added to group)
+[17:58:16] [INFO] [LastChance] Threat detected: @Area2D@3941
+[17:58:16] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:16] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (775.1405, 592.8534) (added to group)
+[17:58:16] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (784.9374, 599.847) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (735.7485, 597.3612) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (827.4962, 694.7762) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (796.4902, 674.0308) (added to group)
+[17:58:16] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0626, 812.5015), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:16] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:16] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(748.2502, 740.5201), shooter_id=1289882701060, bullet_pos=(521.5167, 203.054)
+[17:58:16] [INFO] [Bullet] Using shooter_position, distance=583.33349609375
+[17:58:16] [INFO] [Bullet] Distance to wall: 583.33349609375 (39.7202504047384% of viewport)
+[17:58:16] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:58:16] [INFO] [Bullet] Starting wall penetration at (521.5167, 203.054)
+[17:58:16] [INFO] [Bullet] Raycast backward hit penetrating body at distance 43.3521118164063
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (832.6079, 661.5786) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (759.7771, 610.1635) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (748.9556, 573.9548) (added to group)
+[17:58:16] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:58:16] [INFO] [Bullet] Exiting penetration at (503.3781, 160.0567) after traveling 41.6666679382324 pixels through wall
+[17:58:16] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (752.5117, 596.0311) (added to group)
+[17:58:16] [INFO] [LastChance] Threat detected: @Area2D@3952
+[17:58:16] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:16] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (846.5887, 652.4478) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (735.7693, 614.5374) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (779.5613, 570.1609) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (738.0685, 598.5867) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (763.826, 553.1218) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (746.4526, 605.287) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (782.0745, 631.6051) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (738.9173, 569.847) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (777.7983, 642.2492) (added to group)
+[17:58:16] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0626, 812.5015), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:16] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (750.368, 616.3582) (added to group)
+[17:58:16] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(748.2502, 740.5201), shooter_id=1289882701060, bullet_pos=(521.5167, 203.054)
+[17:58:16] [INFO] [Bullet] Using shooter_position, distance=583.33349609375
+[17:58:16] [INFO] [Bullet] Distance to wall: 583.33349609375 (39.7202504047384% of viewport)
+[17:58:16] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:58:16] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.8°, current=122.2°, player=(681,562), corner_timer=-0.02
+[17:58:16] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[17:58:16] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=125.1°, player=(681,562), corner_timer=0.30
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (838.8487, 593.3052) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (815.5776, 705.3091) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (749.6028, 592.9054) (added to group)
+[17:58:16] [INFO] [BloodDecal] Blood puddle created at (777.0235, 635.7967) (added to group)
+[17:58:17] [INFO] [LastChance] Threat detected: Bullet
+[17:58:17] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:17] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (831.8412, 675.969) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (817.4663, 640.3007) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (809.4124, 654.3687) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (840.96, 565.3157) (added to group)
+[17:58:17] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(748.2502, 740.5201), shooter_id=1289882701060, bullet_pos=(603.0052, 40.22287)
+[17:58:17] [INFO] [Bullet] Using shooter_position, distance=715.200927734375
+[17:58:17] [INFO] [Bullet] Distance to wall: 715.200927734375 (48.6993463079737% of viewport)
+[17:58:17] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:58:17] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:17] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:58:17] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:58:17] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:58:17] [INFO] [CinemaEffects] Death effects reset
+[17:58:17] [ENEMY] [Enemy1] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:58:17] [ENEMY] [Enemy2] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:58:17] [ENEMY] [Enemy3] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:58:17] [ENEMY] [Enemy4] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:58:17] [ENEMY] [Enemy5] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:58:17] [ENEMY] [Enemy6] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:58:17] [ENEMY] [Enemy7] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:58:17] [ENEMY] [Enemy8] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:58:17] [ENEMY] [Enemy9] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:58:17] [ENEMY] [Enemy10] Death animation component initialized
+[17:58:17] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:17] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:58:17] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:58:17] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:58:17] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:58:17] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:58:17] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:58:17] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:58:17] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:58:17] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:58:17] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:58:17] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:58:17] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[17:58:17] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:58:17] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:58:17] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:58:17] [INFO] [ScoreManager] Level started with 10 enemies
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (793.0514, 642.5634) (added to group)
+[17:58:17] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:58:17] [INFO] [CinemaEffects] Found player node: Player
+[17:58:17] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:58:17] [ENEMY] [Enemy1] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[17:58:17] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:58:17] [ENEMY] [Enemy2] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[17:58:17] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:58:17] [ENEMY] [Enemy3] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[17:58:17] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:58:17] [ENEMY] [Enemy4] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[17:58:17] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:58:17] [ENEMY] [Enemy5] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 3, behavior: GUARD
+[17:58:17] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:58:17] [ENEMY] [Enemy6] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[17:58:17] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:58:17] [ENEMY] [Enemy7] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[17:58:17] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:58:17] [ENEMY] [Enemy8] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[17:58:17] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:58:17] [ENEMY] [Enemy9] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[17:58:17] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:58:17] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:58:17] [ENEMY] [Enemy10] Registered as sound listener
+[17:58:17] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[17:58:17] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:58:17] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:17] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:17] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:17] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:17] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:17] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=225.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:17] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:17] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:17] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:58:17] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:58:17] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:58:17] [INFO] [LastChance] Found player: Player
+[17:58:17] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:58:17] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:58:17] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:58:17] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (875.2543, 652.354) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (863.924, 563.4383) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (786.1631, 642.1838) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (831.6338, 637.5097) (added to group)
+[17:58:17] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:58:17] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:58:17] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (828.8855, 618.4222) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (813.821, 743.9194) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (778.7101, 652.6367) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (881.3247, 615.0483) (added to group)
+[17:58:17] [INFO] [BloodDecal] Blood puddle created at (852.5581, 660.8029) (added to group)
+[17:58:18] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:18] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:58:18] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1001), corner_timer=0.30
+[17:58:18] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1001), corner_timer=0.30
+[17:58:18] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,896), corner_timer=-0.02
+[17:58:18] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:18] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,896), corner_timer=-0.02
+[17:58:18] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:58:18] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,891), corner_timer=0.30
+[17:58:18] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,891), corner_timer=0.30
+[17:58:19] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=163.9°, current=-168.8°, player=(461,818), corner_timer=0.00
+[17:58:19] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:58:19] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=167.0°, current=-132.5°, player=(474,802), corner_timer=0.00
+[17:58:19] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(477,798), corner_timer=-0.02
+[17:58:19] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:58:19] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(481,794), corner_timer=0.30
+[17:58:19] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(555,720), corner_timer=-0.02
+[17:58:19] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:58:19] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(559,716), corner_timer=0.30
+[17:58:19] [ENEMY] [Enemy4] Memory: high confidence (0.86) - transitioning to PURSUING
+[17:58:19] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[17:58:19] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-140.6°, current=-67.5°, player=(567,708), corner_timer=0.00
+[17:58:19] [ENEMY] [Enemy4] PURSUING corner check: angle -100.7°
+[17:58:19] [ENEMY] [Enemy3] State: COMBAT -> PURSUING
+[17:58:19] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-131.8°, current=-84.8°, player=(617,658), corner_timer=0.00
+[17:58:19] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(632,645), corner_timer=-0.02
+[17:58:19] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:58:19] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(635,642), corner_timer=0.30
+[17:58:20] [ENEMY] [Enemy3] State: PURSUING -> COMBAT
+[17:58:20] [ENEMY] [Enemy4] PURSUING corner check: angle -94.0°
+[17:58:20] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(658,621), corner_timer=-0.02
+[17:58:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:58:20] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(658,621), corner_timer=0.30
+[17:58:20] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-71.4°, current=-120.2°, player=(658,621), corner_timer=0.02
+[17:58:20] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[17:58:20] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-71.0°, current=-1.4°, player=(658,621), corner_timer=0.02
+[17:58:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=20
+[17:58:20] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:58:20] [ENEMY] [Enemy2] Heard gunshot at (700, 750), source_type=1, intensity=0.02, distance=361
+[17:58:20] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:20] [INFO] [LastChance] Threat detected: Bullet
+[17:58:20] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:20] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:20] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=15.5°, current=-67.5°, player=(658,621), corner_timer=0.00
+[17:58:20] [INFO] [Player] Spawning blood effect at (658.85675, 621.72003), dir=(1, 0), lethal=False (C#)
+[17:58:20] [INFO] [ImpactEffects] spawn_blood_effect called at (658.8568, 621.72), dir=(1, 0), lethal=false
+[17:58:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:20] [INFO] [ImpactEffects] Blood effect spawned at (658.8568, 621.72) (scale=1)
+[17:58:20] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[17:58:20] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[17:58:20] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-73.3°, current=-23.4°, player=(658,621), corner_timer=0.02
+[17:58:20] [ENEMY] [Enemy1] Memory: medium confidence (0.62) - transitioning to PURSUING
+[17:58:20] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:58:20] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=37.1°, current=-157.5°, player=(658,621), corner_timer=0.00
+[17:58:20] [ENEMY] [Enemy1] PURSUING corner check: angle -50.9°
+[17:58:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:20] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:20] [INFO] [LastChance] Threat detected: Bullet
+[17:58:20] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:20] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:20] [INFO] [Player] Spawning blood effect at (658.85675, 621.72003), dir=(1, 0), lethal=False (C#)
+[17:58:20] [INFO] [ImpactEffects] spawn_blood_effect called at (658.8568, 621.72), dir=(1, 0), lethal=false
+[17:58:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:20] [INFO] [ImpactEffects] Blood effect spawned at (658.8568, 621.72) (scale=1)
+[17:58:20] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[17:58:20] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[17:58:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(658,621), corner_timer=-0.02
+[17:58:20] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:58:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(658,621), corner_timer=0.30
+[17:58:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(696.1089, 758.3087), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:20] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:20] [INFO] [LastChance] Threat detected: Bullet
+[17:58:20] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:20] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:20] [INFO] [Player] Spawning blood effect at (658.85675, 621.72003), dir=(1, 0), lethal=False (C#)
+[17:58:20] [INFO] [ImpactEffects] spawn_blood_effect called at (658.8568, 621.72), dir=(1, 0), lethal=false
+[17:58:20] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:20] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:20] [INFO] [ImpactEffects] Blood effect spawned at (658.8568, 621.72) (scale=1)
+[17:58:20] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:58:20] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:58:20] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:58:20] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:58:20] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:58:20] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:58:20] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:58:20] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:58:20] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:58:20] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:58:20] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:58:21] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:21] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(696.1089, 758.3087), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:21] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:21] [INFO] [LastChance] Threat detected: Bullet
+[17:58:21] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:21] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:21] [INFO] [Player] Spawning blood effect at (658.85675, 621.72003), dir=(1, 0), lethal=True (C#)
+[17:58:21] [INFO] [ImpactEffects] spawn_blood_effect called at (658.8568, 621.72), dir=(1, 0), lethal=true
+[17:58:21] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:21] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:58:21] [INFO] [ImpactEffects] Blood effect spawned at (658.8568, 621.72) (scale=1.5)
+[17:58:21] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:58:21] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:58:21] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:58:21] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:58:21] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:58:21] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:58:21] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:58:21] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:58:21] [INFO] [LastChance] Player died
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (769.2652, 667.5322) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (707.3227, 627.2826) (added to group)
+[17:58:21] [ENEMY] [Enemy1] PURSUING corner check: angle -51.5°
+[17:58:21] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(693.2384, 764.8109), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:21] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (721.8993, 608.1437) (added to group)
+[17:58:21] [INFO] [LastChance] Threat detected: Bullet
+[17:58:21] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:21] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (788.2906, 612.8632) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (741.5394, 631.7731) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (817.1047, 672.2691) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (725.8021, 636.2075) (added to group)
+[17:58:21] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:58:21] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(589.1646, 854.2244), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:21] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:21] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.2°, current=173.4°, player=(658,621), corner_timer=-0.01
+[17:58:21] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[17:58:21] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=176.2°, player=(658,621), corner_timer=0.30
+[17:58:21] [INFO] [LastChance] Threat detected: Bullet
+[17:58:21] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:21] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:21] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(692.3824, 769.0695), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:21] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (764.9053, 730.4902) (added to group)
+[17:58:21] [INFO] [LastChance] Threat detected: @Area2D@4256
+[17:58:21] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:21] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (752.3513, 658.7184) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (730.2388, 637.2773) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (734.3428, 702.8073) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (741.0004, 641.5069) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (755.8839, 671.8524) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (737.0231, 628.3994) (added to group)
+[17:58:21] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (738.0895, 640.6637) (added to group)
+[17:58:21] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(589.1646, 854.2244), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:21] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (792.3171, 710.9407) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (718.8378, 626.2566) (added to group)
+[17:58:21] [INFO] [BloodDecal] Blood puddle created at (759.4067, 663.5614) (added to group)
+[17:58:22] [INFO] [LastChance] Threat detected: Bullet
+[17:58:22] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:22] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(691.2173, 774.6531), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:22] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (757.9907, 739.0145) (added to group)
+[17:58:22] [INFO] [LastChance] Threat detected: @Area2D@4270
+[17:58:22] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:22] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (872.4458, 767.7206) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (770.1792, 684.1183) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (734.5654, 725.9132) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (741.8632, 607.5078) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (805.8577, 662.7124) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (720.4257, 663.7053) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (769.5421, 608.2239) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (722.7698, 625.6739) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (738.8791, 657.4469) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (750.9606, 604.614) (added to group)
+[17:58:22] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (731.2013, 621.6926) (added to group)
+[17:58:22] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(583.4374, 856.7496), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:22] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (841.4324, 616.0543) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (802.7996, 709.1088) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (743.2838, 640.4744) (added to group)
+[17:58:22] [ENEMY] [Enemy1] PURSUING corner check: angle 153.3°
+[17:58:22] [INFO] [LastChance] Threat detected: Bullet
+[17:58:22] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:22] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (785.8334, 655.0474) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (764.24, 762.1912) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (767.7459, 746.9572) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (733.5952, 688.4342) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (772.9385, 707.6023) (added to group)
+[17:58:22] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.8°, current=121.7°, player=(658,621), corner_timer=-0.02
+[17:58:22] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[17:58:22] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:58:22] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:22] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:58:22] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:58:22] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:58:22] [INFO] [CinemaEffects] Death effects reset
+[17:58:22] [ENEMY] [Enemy1] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:58:22] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:58:22] [ENEMY] [Enemy2] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:58:22] [ENEMY] [Enemy3] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:58:22] [ENEMY] [Enemy4] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:58:22] [ENEMY] [Enemy5] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:58:22] [ENEMY] [Enemy6] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:58:22] [ENEMY] [Enemy7] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:58:22] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:58:22] [ENEMY] [Enemy8] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:58:22] [ENEMY] [Enemy9] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:58:22] [ENEMY] [Enemy10] Death animation component initialized
+[17:58:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:22] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:58:22] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:58:22] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:58:22] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:58:22] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:58:22] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:58:22] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:58:22] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:58:22] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:58:22] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:58:22] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:58:22] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[17:58:22] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:58:22] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:58:22] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:58:22] [INFO] [ScoreManager] Level started with 10 enemies
+[17:58:22] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:58:22] [INFO] [CinemaEffects] Found player node: Player
+[17:58:22] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:58:22] [ENEMY] [Enemy1] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[17:58:22] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:58:22] [ENEMY] [Enemy2] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[17:58:22] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:58:22] [ENEMY] [Enemy3] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[17:58:22] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:58:22] [ENEMY] [Enemy4] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[17:58:22] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:58:22] [ENEMY] [Enemy5] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[17:58:22] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:58:22] [ENEMY] [Enemy6] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[17:58:22] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:58:22] [ENEMY] [Enemy7] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[17:58:22] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:58:22] [ENEMY] [Enemy8] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[17:58:22] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:58:22] [ENEMY] [Enemy9] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:58:22] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:58:22] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:58:22] [ENEMY] [Enemy10] Registered as sound listener
+[17:58:22] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[17:58:22] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:58:22] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:22] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:22] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:22] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:22] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:22] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:22] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:22] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:22] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:58:22] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:58:22] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:58:22] [INFO] [LastChance] Found player: Player
+[17:58:22] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:58:22] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:58:22] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:58:22] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (763.8759, 739.8754) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (801.9704, 652.361) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (750.0593, 702.0661) (added to group)
+[17:58:22] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:58:22] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:58:22] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (758.7321, 769.1226) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (750.0446, 683.0538) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (749.0422, 725.4044) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (792.9192, 727.7112) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (817.1686, 681.2169) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (795.5767, 725.975) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (765.5594, 707.0122) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (845.4252, 632.5908) (added to group)
+[17:58:22] [INFO] [BloodDecal] Blood puddle created at (806.0897, 782.8637) (added to group)
+[17:58:23] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:23] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:58:23] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1050), corner_timer=0.30
+[17:58:23] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1050), corner_timer=0.30
+[17:58:24] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,946), corner_timer=-0.02
+[17:58:24] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:24] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,946), corner_timer=-0.02
+[17:58:24] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:58:24] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,940), corner_timer=0.30
+[17:58:24] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,940), corner_timer=0.30
+[17:58:24] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(477,847), corner_timer=-0.02
+[17:58:24] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:58:24] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(481,843), corner_timer=0.30
+[17:58:24] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=163.8°, current=123.7°, player=(483,812), corner_timer=0.00
+[17:58:24] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:58:24] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=169.6°, current=-135.0°, player=(484,789), corner_timer=0.00
+[17:58:24] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(493,769), corner_timer=-0.02
+[17:58:24] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:58:24] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(495,766), corner_timer=0.30
+[17:58:24] [ENEMY] [Enemy4] Memory: high confidence (0.88) - transitioning to PURSUING
+[17:58:24] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[17:58:24] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-154.5°, current=-67.5°, player=(502,758), corner_timer=0.00
+[17:58:24] [ENEMY] [Enemy4] PURSUING corner check: angle -100.7°
+[17:58:25] [ENEMY] [Enemy3] State: COMBAT -> PURSUING
+[17:58:25] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(568,692), corner_timer=-0.02
+[17:58:25] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:58:25] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(572,688), corner_timer=0.30
+[17:58:25] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-152.1°, current=-106.2°, player=(575,684), corner_timer=0.00
+[17:58:25] [ENEMY] [Enemy4] PURSUING corner check: angle -89.8°
+[17:58:25] [ENEMY] [Enemy3] State: PURSUING -> COMBAT
+[17:58:25] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(645,614), corner_timer=-0.02
+[17:58:25] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:58:25] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(649,610), corner_timer=0.30
+[17:58:25] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:25] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-68.1°, current=-116.5°, player=(743,517), corner_timer=-0.02
+[17:58:25] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[17:58:25] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-67.2°, current=36.5°, player=(750,509), corner_timer=-0.02
+[17:58:25] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(770,489), corner_timer=-0.02
+[17:58:25] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:58:25] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(774,486), corner_timer=0.30
+[17:58:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=20
+[17:58:26] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:58:26] [ENEMY] [Enemy2] Heard gunshot at (700, 750), source_type=1, intensity=0.02, distance=361
+[17:58:26] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:26] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-10.6°, current=168.8°, player=(782,478), corner_timer=0.00
+[17:58:26] [INFO] [LastChance] Threat detected: Bullet
+[17:58:26] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:26] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:26] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:26] [INFO] [Player] Spawning blood effect at (805.39557, 454.92847), dir=(1, 0), lethal=False (C#)
+[17:58:26] [INFO] [ImpactEffects] spawn_blood_effect called at (805.3956, 454.9285), dir=(1, 0), lethal=false
+[17:58:26] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:26] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:26] [INFO] [ImpactEffects] Blood effect spawned at (805.3956, 454.9285) (scale=1)
+[17:58:26] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:58:26] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:58:26] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:58:26] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:58:26] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:58:26] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:58:26] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:58:26] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:58:26] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:58:26] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:58:26] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:58:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:26] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:26] [INFO] [LastChance] Threat detected: @Area2D@4564
+[17:58:26] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:26] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:26] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-64.3°, current=-14.3°, player=(824,435), corner_timer=-0.02
+[17:58:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(689.3737, 753.1381), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:27] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:27] [INFO] [Player] Spawning blood effect at (834.5272, 426.99887), dir=(1, 0), lethal=True (C#)
+[17:58:27] [INFO] [ImpactEffects] spawn_blood_effect called at (834.5272, 426.9989), dir=(1, 0), lethal=true
+[17:58:27] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:27] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:58:27] [INFO] [ImpactEffects] Blood effect spawned at (834.5272, 426.9989) (scale=1.5)
+[17:58:27] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:58:27] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:58:27] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:58:27] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:58:27] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:58:27] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:58:27] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:58:27] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:58:27] [INFO] [LastChance] Player died
+[17:58:27] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=175.9°, current=173.1°, player=(848,419), corner_timer=-0.01
+[17:58:27] [ENEMY] [Enemy7] PATROL corner check: angle 89.0°
+[17:58:27] [INFO] [LastChance] Threat detected: Bullet
+[17:58:27] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:27] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:27] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.0°, current=175.9°, player=(853,417), corner_timer=0.30
+[17:58:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(689.3737, 753.1381), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:27] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:27] [ENEMY] [Enemy1] Memory: medium confidence (0.60) - transitioning to PURSUING
+[17:58:27] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:58:27] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=6.2°, current=168.8°, player=(873,412), corner_timer=0.00
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (870.3774, 456.9016) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (869.4442, 464.1657) (added to group)
+[17:58:27] [ENEMY] [Enemy1] PURSUING corner check: angle -50.9°
+[17:58:27] [INFO] [LastChance] Threat detected: @Area2D@4568
+[17:58:27] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:27] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:27] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(682.3862, 757.299), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:27] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(654.6464, 797.2338), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:27] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:27] [ENEMY] [Enemy3] Hit taken, damage: 1, health: 4/4 -> 3/4
+[17:58:27] [ENEMY] [Enemy3] ImpactEffectsManager found, calling spawn_blood_effect
+[17:58:27] [INFO] [ImpactEffects] spawn_blood_effect called at (682.3862, 757.299), dir=(0.537961, -0.842969), lethal=false
+[17:58:27] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:27] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:27] [INFO] [ImpactEffects] Blood effect spawned at (682.3862, 757.299) (scale=1)
+[17:58:27] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-57.1°, current=122.5°, player=(905,412), corner_timer=0.00
+[17:58:27] [ENEMY] [Enemy3] State: COMBAT -> PURSUING
+[17:58:27] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (901.9658, 469.7) (added to group)
+[17:58:27] [INFO] [LastChance] Threat detected: Bullet
+[17:58:27] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:27] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (925.4286, 442.7515) (added to group)
+[17:58:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(675.6768, 766.3967), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:27] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (918.9137, 431.8946) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (897.6418, 432.7677) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (905.1444, 423.5279) (added to group)
+[17:58:27] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(726.5034, 696.2012), shooter_id=1509966219412, bullet_pos=(1042.785, 62.40124)
+[17:58:27] [INFO] [Bullet] Using shooter_position, distance=708.33349609375
+[17:58:27] [INFO] [Bullet] Distance to wall: 708.33349609375 (48.2317302594703% of viewport)
+[17:58:27] [INFO] [Bullet] Distance-based penetration chance: 90.3963146972846%
+[17:58:27] [INFO] [Bullet] Starting wall penetration at (1042.785, 62.40124)
+[17:58:27] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.3°, current=121.6°, player=(955,412), corner_timer=-0.02
+[17:58:27] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:58:27] [INFO] [Bullet] Raycast backward hit penetrating body at distance 12.690299987793
+[17:58:27] [INFO] [Bullet] Body exited signal received for penetrating body
+[17:58:27] [INFO] [Bullet] Exiting penetration at (1063.622, 20.64501) after traveling 41.6666679382324 pixels through wall
+[17:58:27] [INFO] [Bullet] Damage multiplier after penetration: 0.9
+[17:58:27] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=124.5°, player=(960,412), corner_timer=0.30
+[17:58:27] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(724.4227, 703.9017), shooter_id=1509966219412, bullet_pos=(986.5718, 278.1341)
+[17:58:27] [INFO] [Bullet] Using shooter_position, distance=500.000244140625
+[17:58:27] [INFO] [Bullet] Distance to wall: 500.000244140625 (34.0459360429118% of viewport)
+[17:58:27] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[17:58:27] [ENEMY] [Enemy3] State: PURSUING -> RETREATING
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (927.8522, 572.8743) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (918.3478, 445.4752) (added to group)
+[17:58:27] [INFO] [LastChance] Threat detected: @Area2D@4578
+[17:58:27] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:27] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(691.5305, 735.6233), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:27] [ENEMY] [Enemy3] Heard gunshot at (691.5305, 735.6233), source_type=1, intensity=1.00, distance=23
+[17:58:27] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:27] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (985.6266, 441.4377) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (692.6401, 692.2753) (added to group)
+[17:58:27] [ENEMY] [Enemy1] PURSUING corner check: angle -51.1°
+[17:58:27] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=48.9°, current=90.8°, player=(988,412), corner_timer=0.00
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (993.0561, 504.4498) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (950.9966, 539.6699) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (747.4854, 727.7244) (added to group)
+[17:58:27] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (925.8242, 484.8285) (added to group)
+[17:58:27] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:58:27] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:27] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:58:27] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:58:27] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:58:27] [INFO] [CinemaEffects] Death effects reset
+[17:58:27] [ENEMY] [Enemy1] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:58:27] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:58:27] [ENEMY] [Enemy2] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:58:27] [ENEMY] [Enemy3] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:58:27] [ENEMY] [Enemy4] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:58:27] [ENEMY] [Enemy5] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:58:27] [ENEMY] [Enemy6] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:58:27] [ENEMY] [Enemy7] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:58:27] [ENEMY] [Enemy8] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:58:27] [ENEMY] [Enemy9] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:58:27] [ENEMY] [Enemy10] Death animation component initialized
+[17:58:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:27] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:58:27] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:58:27] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:58:27] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:58:27] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:58:27] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:58:27] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:58:27] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:58:27] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:58:27] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:58:27] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:58:27] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[17:58:27] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:58:27] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:58:27] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:58:27] [INFO] [ScoreManager] Level started with 10 enemies
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (992.4531, 513.1369) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (979.7552, 559.2659) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (962.069, 503.722) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (954.3619, 494.2808) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (916.3329, 505.6934) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (927.2134, 498.5851) (added to group)
+[17:58:27] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:58:27] [INFO] [CinemaEffects] Found player node: Player
+[17:58:27] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:58:27] [ENEMY] [Enemy1] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[17:58:27] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:58:27] [ENEMY] [Enemy2] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[17:58:27] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:58:27] [ENEMY] [Enemy3] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[17:58:27] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:58:27] [ENEMY] [Enemy4] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[17:58:27] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:58:27] [ENEMY] [Enemy5] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[17:58:27] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:58:27] [ENEMY] [Enemy6] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[17:58:27] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:58:27] [ENEMY] [Enemy7] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[17:58:27] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:58:27] [ENEMY] [Enemy8] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[17:58:27] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:58:27] [ENEMY] [Enemy9] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[17:58:27] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:58:27] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:58:27] [ENEMY] [Enemy10] Registered as sound listener
+[17:58:27] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[17:58:27] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:58:27] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:27] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:27] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:27] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:27] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:27] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:27] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=213.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:27] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:27] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:58:27] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:58:27] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:58:27] [INFO] [LastChance] Found player: Player
+[17:58:27] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:58:27] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:58:27] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:58:27] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (907.2577, 598.4324) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (976.8381, 467.1379) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (931.661, 467.2354) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (946.9944, 459.3944) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (1002.883, 454.2727) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (753.243, 716.6352) (added to group)
+[17:58:27] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:58:27] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:58:27] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (916.2656, 575.1523) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (946.757, 503.5048) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (965.9611, 541.682) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (742.1109, 662.8192) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (740.0294, 760.6873) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (1047.256, 579.5185) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (982.3892, 598.8718) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (982.1233, 513.993) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (740.4012, 722.6351) (added to group)
+[17:58:27] [INFO] [BloodDecal] Blood puddle created at (748.918, 694.4426) (added to group)
+[17:58:28] [INFO] [BloodDecal] Blood puddle created at (793.1761, 685.9844) (added to group)
+[17:58:28] [INFO] [BloodDecal] Blood puddle created at (700.1838, 737.6161) (added to group)
+[17:58:28] [INFO] [BloodDecal] Blood puddle created at (709.271, 636.1921) (added to group)
+[17:58:28] [INFO] [BloodyFeet:Enemy3] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[17:58:29] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:29] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:58:29] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(656,1064), corner_timer=0.30
+[17:58:29] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(656,1064), corner_timer=0.30
+[17:58:29] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(554,1060), corner_timer=-0.02
+[17:58:29] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:29] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(554,1060), corner_timer=-0.02
+[17:58:29] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:58:29] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(548,1060), corner_timer=0.30
+[17:58:29] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(548,1060), corner_timer=0.30
+[17:58:29] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(464,1013), corner_timer=-0.02
+[17:58:29] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:58:29] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(460,1009), corner_timer=0.30
+[17:58:30] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(410,925), corner_timer=-0.02
+[17:58:30] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:58:30] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(410,920), corner_timer=0.30
+[17:58:30] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(446,830), corner_timer=-0.02
+[17:58:30] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:58:30] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(449,826), corner_timer=0.30
+[17:58:30] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=163.6°, current=-168.8°, player=(453,822), corner_timer=0.00
+[17:58:30] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:58:30] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=164.8°, current=-10.3°, player=(461,814), corner_timer=0.00
+[17:58:30] [ENEMY] [Enemy4] Memory: high confidence (0.88) - transitioning to PURSUING
+[17:58:30] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[17:58:30] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-157.5°, current=-101.3°, player=(500,775), corner_timer=0.00
+[17:58:30] [ENEMY] [Enemy4] PURSUING corner check: angle -100.7°
+[17:58:30] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(523,752), corner_timer=-0.02
+[17:58:30] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:58:30] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(527,748), corner_timer=0.30
+[17:58:31] [ENEMY] [Enemy3] State: COMBAT -> PURSUING
+[17:58:31] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:31] [ENEMY] [Enemy4] PURSUING corner check: angle -94.0°
+[17:58:31] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(648,628), corner_timer=-0.02
+[17:58:31] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:58:31] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(652,624), corner_timer=0.30
+[17:58:31] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:31] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(723,554), corner_timer=-0.02
+[17:58:31] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[17:58:31] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(726,552), corner_timer=0.30
+[17:58:31] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-78.0°, current=-126.7°, player=(733,546), corner_timer=0.00
+[17:58:31] [ENEMY] [Enemy3] State: PURSUING -> COMBAT
+[17:58:31] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-64.1°, current=-113.8°, player=(740,540), corner_timer=0.02
+[17:58:31] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[17:58:31] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:32] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-63.6°, current=12.4°, player=(742,538), corner_timer=0.02
+[17:58:32] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-65.1°, current=-17.3°, player=(743,537), corner_timer=0.02
+[17:58:32] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(743,537), corner_timer=-0.02
+[17:58:32] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[17:58:32] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(743,537), corner_timer=0.30
+[17:58:32] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(689.7374, 752.908), source=ENEMY (Enemy3), range=1469, listeners=20
+[17:58:32] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:58:32] [ENEMY] [Enemy2] Heard gunshot at (689.7374, 752.908), source_type=1, intensity=0.02, distance=354
+[17:58:32] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:32] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(743,537), corner_timer=-0.02
+[17:58:32] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[17:58:32] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-2.1°, current=-157.5°, player=(743,537), corner_timer=0.00
+[17:58:32] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(743,537), corner_timer=0.30
+[17:58:32] [INFO] [LastChance] Threat detected: Bullet
+[17:58:32] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:32] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(641.9699, 755.7933), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:32] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:32] [INFO] [Player] Spawning blood effect at (743.6316, 537.1494), dir=(1, 0), lethal=False (C#)
+[17:58:32] [INFO] [ImpactEffects] spawn_blood_effect called at (743.6316, 537.1494), dir=(1, 0), lethal=false
+[17:58:32] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:32] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:32] [INFO] [ImpactEffects] Blood effect spawned at (743.6316, 537.1494) (scale=1)
+[17:58:32] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 3.0
+[17:58:32] [INFO] [LastChance] Player health updated (C# Damaged): 3.0
+[17:58:32] [INFO] [LastChance] Threat detected: @Area2D@4878
+[17:58:32] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:32] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(689.7374, 752.908), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:32] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:32] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:32] [INFO] [LastChance] Threat detected: Bullet
+[17:58:32] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:32] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:32] [INFO] [Player] Spawning blood effect at (743.6316, 537.1494), dir=(1, 0), lethal=False (C#)
+[17:58:32] [INFO] [ImpactEffects] spawn_blood_effect called at (743.6316, 537.1494), dir=(1, 0), lethal=false
+[17:58:32] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:32] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:32] [INFO] [ImpactEffects] Blood effect spawned at (743.6316, 537.1494) (scale=1)
+[17:58:32] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[17:58:32] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[17:58:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(641.9699, 755.7933), source=ENEMY (Enemy4), range=1469, listeners=10
+[17:58:32] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:32] [INFO] [Player] Spawning blood effect at (743.6316, 537.1494), dir=(1, 0), lethal=False (C#)
+[17:58:32] [INFO] [ImpactEffects] spawn_blood_effect called at (743.6316, 537.1494), dir=(1, 0), lethal=false
+[17:58:32] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:32] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:32] [INFO] [ImpactEffects] Blood effect spawned at (743.6316, 537.1494) (scale=1)
+[17:58:32] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:58:32] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:58:32] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:58:32] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:58:32] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:58:32] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:58:32] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:58:32] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:58:32] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:58:32] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:58:32] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:58:32] [INFO] [LastChance] Threat detected: @Area2D@4882
+[17:58:32] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:32] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:32] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[17:58:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(688.144, 758.6783), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:32] [ENEMY] [Enemy4] Heard gunshot at (688.144, 758.6783), source_type=1, intensity=0.94, distance=52
+[17:58:32] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:32] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[17:58:32] [INFO] [LastChance] Threat detected: Bullet
+[17:58:32] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:32] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:33] [INFO] [Player] Spawning blood effect at (743.6316, 537.1494), dir=(1, 0), lethal=True (C#)
+[17:58:33] [INFO] [ImpactEffects] spawn_blood_effect called at (743.6316, 537.1494), dir=(1, 0), lethal=true
+[17:58:33] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:33] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:58:33] [INFO] [ImpactEffects] Blood effect spawned at (743.6316, 537.1494) (scale=1.5)
+[17:58:33] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:58:33] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:58:33] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:58:33] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:58:33] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:58:33] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:58:33] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:58:33] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:58:33] [INFO] [LastChance] Player died
+[17:58:33] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[17:58:33] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.3°, current=89.6°, player=(743,537), corner_timer=-0.01
+[17:58:33] [ENEMY] [Enemy7] PATROL corner check: angle 89.1°
+[17:58:33] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.1°, current=92.5°, player=(743,537), corner_timer=0.30
+[17:58:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(709.5637, 785.9338), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:33] [ENEMY] [Enemy4] Heard gunshot at (709.5637, 785.9338), source_type=1, intensity=1.00, distance=41
+[17:58:33] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:33] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (822.2983, 531.6039) (added to group)
+[17:58:33] [INFO] [LastChance] Threat detected: Bullet
+[17:58:33] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:33] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (816.7468, 598.2936) (added to group)
+[17:58:33] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (799.6498, 551.426) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (821.9728, 610.2756) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (813.323, 519.4449) (added to group)
+[17:58:33] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (803.8657, 543.8165) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (816.6223, 563.9064) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (833.5836, 627.8822) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (822.1937, 568.6306) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (823.9198, 572.509) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (836.358, 573.1262) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (842.3211, 621.1765) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (832.8035, 570.923) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (901.5051, 622.7582) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (866.0765, 609.3391) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (861.6049, 601.1561) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (825.4188, 572.6285) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (873.6639, 522.3724) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (845.4156, 624.8319) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (807.827, 548.4513) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (865.6007, 585.5405) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (872.1967, 583.0477) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (837.1441, 564.1302) (added to group)
+[17:58:33] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-20.4°, current=-67.8°, player=(743,537), corner_timer=0.00
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (826.3744, 609.3304) (added to group)
+[17:58:33] [INFO] [BloodyFeet:Enemy4] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[17:58:33] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.1°, player=(743,537), corner_timer=-0.02
+[17:58:33] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (830.0068, 654.7902) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (900.8234, 605.4745) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (811.0477, 560.598) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (843.2188, 553.0634) (added to group)
+[17:58:33] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=92.0°, player=(743,537), corner_timer=0.30
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (907.0397, 582.73) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (890.433, 553.1292) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (858.2447, 599.2663) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (866.5242, 624.3197) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (886.2036, 694.2378) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (848.8129, 571.0089) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (898.3931, 625.2335) (added to group)
+[17:58:33] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:58:33] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:33] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:58:33] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:58:33] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:58:33] [INFO] [CinemaEffects] Death effects reset
+[17:58:33] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[17:58:33] [ENEMY] [Enemy1] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:58:33] [ENEMY] [Enemy2] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:58:33] [ENEMY] [Enemy3] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:58:33] [ENEMY] [Enemy4] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:58:33] [ENEMY] [Enemy5] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:58:33] [ENEMY] [Enemy6] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:58:33] [ENEMY] [Enemy7] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:58:33] [ENEMY] [Enemy8] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:58:33] [ENEMY] [Enemy9] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:58:33] [ENEMY] [Enemy10] Death animation component initialized
+[17:58:33] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:33] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:58:33] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:58:33] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:58:33] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:58:33] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:58:33] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:58:33] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:58:33] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:58:33] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:58:33] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:58:33] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:58:33] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[17:58:33] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:58:33] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:58:33] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:58:33] [INFO] [ScoreManager] Level started with 10 enemies
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (854.3676, 696.1185) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (875.3561, 649.1539) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (837.9811, 595.6647) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (828.7512, 554.9517) (added to group)
+[17:58:33] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:58:33] [INFO] [CinemaEffects] Found player node: Player
+[17:58:33] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:58:33] [ENEMY] [Enemy1] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[17:58:33] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:58:33] [ENEMY] [Enemy2] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[17:58:33] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:58:33] [ENEMY] [Enemy3] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[17:58:33] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:58:33] [ENEMY] [Enemy4] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[17:58:33] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:58:33] [ENEMY] [Enemy5] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 4, behavior: GUARD
+[17:58:33] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:58:33] [ENEMY] [Enemy6] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[17:58:33] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:58:33] [ENEMY] [Enemy7] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[17:58:33] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:58:33] [ENEMY] [Enemy8] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[17:58:33] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:58:33] [ENEMY] [Enemy9] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[17:58:33] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:58:33] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:58:33] [ENEMY] [Enemy10] Registered as sound listener
+[17:58:33] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[17:58:33] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:58:33] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:33] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=45.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:33] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:33] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:33] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:33] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:33] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:33] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:33] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:58:33] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:58:33] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:58:33] [INFO] [LastChance] Found player: Player
+[17:58:33] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:58:33] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:58:33] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:58:33] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (835.2496, 592.4559) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (918.5007, 597.2882) (added to group)
+[17:58:33] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:58:33] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:58:33] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (898.3733, 618.1748) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (849.9337, 607.3477) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (909.1536, 609.6317) (added to group)
+[17:58:33] [INFO] [BloodDecal] Blood puddle created at (875.7642, 655.7437) (added to group)
+[17:58:35] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:35] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:58:35] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1250), corner_timer=0.30
+[17:58:35] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1250), corner_timer=0.30
+[17:58:35] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1250), corner_timer=-0.02
+[17:58:35] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:35] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1250), corner_timer=-0.02
+[17:58:35] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[17:58:35] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1250), corner_timer=0.30
+[17:58:35] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1250), corner_timer=0.30
+[17:58:35] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,1250), corner_timer=-0.02
+[17:58:35] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[17:58:35] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,1250), corner_timer=0.30
+[17:58:36] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(450,1250), corner_timer=-0.02
+[17:58:36] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[17:58:36] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(450,1250), corner_timer=0.30
+[17:58:36] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(450,1250), corner_timer=-0.02
+[17:58:36] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[17:58:36] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(450,1250), corner_timer=0.30
+[17:58:36] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(450,1250), corner_timer=-0.02
+[17:58:36] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[17:58:36] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(450,1250), corner_timer=0.30
+[17:58:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:37] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(450,1250), corner_timer=-0.02
+[17:58:37] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[17:58:37] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(450,1250), corner_timer=0.30
+[17:58:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:37] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(450,1250), corner_timer=-0.02
+[17:58:37] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[17:58:37] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(450,1250), corner_timer=0.30
+[17:58:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:38] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(450,1250), corner_timer=-0.02
+[17:58:38] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[17:58:38] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(450,1250), corner_timer=0.30
+[17:58:38] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:38] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(450,1250), corner_timer=-0.02
+[17:58:38] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[17:58:38] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(450,1250), corner_timer=0.30
+[17:58:38] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:38] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(450,1250), corner_timer=-0.02
+[17:58:38] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[17:58:38] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(450,1250), corner_timer=0.30
+[17:58:38] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(450,1250), corner_timer=-0.02
+[17:58:39] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[17:58:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(450,1250), corner_timer=0.30
+[17:58:39] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(450,1250), corner_timer=-0.02
+[17:58:39] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[17:58:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:39] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(450,1250), corner_timer=-0.02
+[17:58:39] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:39] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:40] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[17:58:40] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:40] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:40] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:40] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[17:58:40] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:40] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:40] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:40] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[17:58:40] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:40] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:40] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:41] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[17:58:41] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:41] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:41] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:41] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[17:58:41] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:41] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:41] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:41] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[17:58:41] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:41] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:41] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:42] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[17:58:42] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:42] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:42] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:42] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[17:58:42] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:42] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:42] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:42] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[17:58:42] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:42] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[17:58:42] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:43] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1249), corner_timer=-0.02
+[17:58:43] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:43] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1249), corner_timer=0.30
+[17:58:43] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:43] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1177), corner_timer=-0.02
+[17:58:43] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:43] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1171), corner_timer=0.30
+[17:58:43] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:43] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1067), corner_timer=-0.02
+[17:58:43] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:43] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1061), corner_timer=0.30
+[17:58:43] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:44] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,957), corner_timer=-0.02
+[17:58:44] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:44] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,951), corner_timer=0.30
+[17:58:44] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:44] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,847), corner_timer=-0.02
+[17:58:44] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:44] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(451,842), corner_timer=0.30
+[17:58:44] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:44] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(512,763), corner_timer=-0.02
+[17:58:44] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:44] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(516,759), corner_timer=0.30
+[17:58:44] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:45] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(590,685), corner_timer=-0.02
+[17:58:45] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:45] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(594,681), corner_timer=0.30
+[17:58:45] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:45] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=-126.7°, current=-78.7°, player=(625,650), corner_timer=0.00
+[17:58:45] [ENEMY] [Enemy3] State: IDLE -> COMBAT
+[17:58:45] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-112.5°, current=-180.0°, player=(649,627), corner_timer=0.00
+[17:58:45] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(668,607), corner_timer=-0.02
+[17:58:45] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:45] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(672,603), corner_timer=0.30
+[17:58:45] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-90.1°, current=-138.7°, player=(699,576), corner_timer=0.00
+[17:58:45] [ENEMY] [Enemy4] Memory: high confidence (0.90) - transitioning to PURSUING
+[17:58:45] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[17:58:45] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:45] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-106.4°, current=168.8°, player=(703,572), corner_timer=0.00
+[17:58:45] [ENEMY] [Enemy4] PURSUING corner check: angle 139.7°
+[17:58:45] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(736,536), corner_timer=-0.02
+[17:58:45] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[17:58:45] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(738,534), corner_timer=0.30
+[17:58:45] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=20
+[17:58:45] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[17:58:45] [ENEMY] [Enemy2] Heard gunshot at (700, 750), source_type=1, intensity=0.02, distance=361
+[17:58:45] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:45] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-3.9°, current=168.8°, player=(745,526), corner_timer=0.00
+[17:58:45] [INFO] [LastChance] Threat detected: Bullet
+[17:58:45] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:45] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:45] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:45] [INFO] [Player] Spawning blood effect at (747.68695, 524.01953), dir=(1, 0), lethal=False (C#)
+[17:58:45] [INFO] [ImpactEffects] spawn_blood_effect called at (747.687, 524.0195), dir=(1, 0), lethal=false
+[17:58:45] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:45] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[17:58:45] [INFO] [ImpactEffects] Blood effect spawned at (747.687, 524.0195) (scale=1)
+[17:58:45] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[17:58:45] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[17:58:45] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[17:58:45] [INFO] [PenultimateHit]   - Time scale: 0.10
+[17:58:45] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[17:58:45] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[17:58:45] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[17:58:45] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[17:58:45] [INFO] [PenultimateHit] Applying saturation to 10 enemies
+[17:58:45] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[17:58:45] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[17:58:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(700, 750), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:46] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:46] [INFO] [LastChance] Threat detected: Bullet
+[17:58:46] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:46] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:46] [INFO] [Player] Spawning blood effect at (747.7654, 523.9315), dir=(1, 0), lethal=True (C#)
+[17:58:46] [INFO] [ImpactEffects] spawn_blood_effect called at (747.7654, 523.9315), dir=(1, 0), lethal=true
+[17:58:46] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[17:58:46] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[17:58:46] [INFO] [ImpactEffects] Blood effect spawned at (747.7654, 523.9315) (scale=1.5)
+[17:58:46] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[17:58:46] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[17:58:46] [INFO] [CinemaEffects] Player died - triggering death effects
+[17:58:46] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn and end of reel
+[17:58:46] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[17:58:46] [INFO] [PenultimateHit] Ending penultimate hit effect
+[17:58:46] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[17:58:46] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[17:58:46] [INFO] [LastChance] Player died
+[17:58:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(696.7007, 754.1764), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:46] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:46] [INFO] [LastChance] Threat detected: Bullet
+[17:58:46] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:46] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:46] [ENEMY] [Enemy1] Memory: medium confidence (0.61) - transitioning to PURSUING
+[17:58:46] [ENEMY] [Enemy1] State: IDLE -> PURSUING
+[17:58:46] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=175.2°, current=89.4°, player=(747,523), corner_timer=-0.01
+[17:58:46] [ENEMY] [Enemy7] PATROL corner check: angle 88.8°
+[17:58:46] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=21.2°, current=-157.5°, player=(747,523), corner_timer=0.00
+[17:58:46] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=88.8°, current=92.3°, player=(747,523), corner_timer=0.30
+[17:58:46] [ENEMY] [Enemy1] PURSUING corner check: angle -50.9°
+[17:58:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(696.7007, 754.1764), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:46] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:46] [INFO] [LastChance] Threat detected: Bullet
+[17:58:46] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:46] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:46] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-96.4°, current=-46.6°, player=(747,523), corner_timer=0.23
+[17:58:46] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[17:58:46] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[17:58:46] [INFO] [BloodDecal] Blood puddle created at (838.6082, 505.3799) (added to group)
+[17:58:47] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-96.1°, current=-27.0°, player=(747,523), corner_timer=0.23
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (783.7219, 525.7035) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (810.2197, 528.1473) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (812.5758, 545.1054) (added to group)
+[17:58:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(690.2191, 758.0252), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:47] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (816.8181, 520.9648) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (805.0343, 534.1678) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (842.2828, 584.2476) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (830.3613, 584.0574) (added to group)
+[17:58:47] [INFO] [LastChance] Threat detected: Bullet
+[17:58:47] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:47] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (814.189, 548.1546) (added to group)
+[17:58:47] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (846.0065, 505.4086) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (866.016, 582.6202) (added to group)
+[17:58:47] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-97.9°, current=-50.7°, player=(747,523), corner_timer=0.23
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (846.5338, 539.5799) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (824.5435, 543.8072) (added to group)
+[17:58:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(690.2191, 758.0252), source=ENEMY (Enemy3), range=1469, listeners=10
+[17:58:47] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=1, self=1, below_threshold=5
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (850.4371, 540.7782) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (875.715, 611.4164) (added to group)
+[17:58:47] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=175.8°, current=88.8°, player=(747,523), corner_timer=-0.02
+[17:58:47] [ENEMY] [Enemy7] PATROL corner check: angle 89.0°
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (868.2106, 510.0704) (added to group)
+[17:58:47] [INFO] [LastChance] Threat detected: Bullet
+[17:58:47] [INFO] [LastChance] Not in hard mode - effect disabled
+[17:58:47] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[17:58:47] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.0°, current=91.7°, player=(747,523), corner_timer=0.30
+[17:58:47] [ENEMY] [Enemy1] PURSUING corner check: angle -51.1°
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (905.3796, 598.6433) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (845.0112, 615.1705) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (826.4421, 620.3831) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (835.7666, 576.5877) (added to group)
+[17:58:47] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[17:58:47] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[17:58:47] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[17:58:47] [INFO] [LastChance] Resetting all effects (scene change detected)
+[17:58:47] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[17:58:47] [INFO] [CinemaEffects] Death effects reset
+[17:58:47] [ENEMY] [Enemy1] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[17:58:47] [ENEMY] [Enemy2] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[17:58:47] [ENEMY] [Enemy3] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[17:58:47] [ENEMY] [Enemy4] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[17:58:47] [ENEMY] [Enemy5] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[17:58:47] [ENEMY] [Enemy6] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[17:58:47] [ENEMY] [Enemy7] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[17:58:47] [ENEMY] [Enemy8] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[17:58:47] [ENEMY] [Enemy9] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[17:58:47] [ENEMY] [Enemy10] Death animation component initialized
+[17:58:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[17:58:47] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[17:58:47] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[17:58:47] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[17:58:47] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[17:58:47] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[17:58:47] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[17:58:47] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[17:58:47] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[17:58:47] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[17:58:47] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[17:58:47] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[17:58:47] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[17:58:47] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[17:58:47] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[17:58:47] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[17:58:47] [INFO] [ScoreManager] Level started with 10 enemies
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (873.678, 606.2205) (added to group)
+[17:58:47] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[17:58:47] [INFO] [CinemaEffects] Found player node: Player
+[17:58:47] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[17:58:47] [ENEMY] [Enemy1] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[17:58:47] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[17:58:47] [ENEMY] [Enemy2] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[17:58:47] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[17:58:47] [ENEMY] [Enemy3] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[17:58:47] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[17:58:47] [ENEMY] [Enemy4] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[17:58:47] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 15)
+[17:58:47] [ENEMY] [Enemy5] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 3, behavior: GUARD
+[17:58:47] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[17:58:47] [ENEMY] [Enemy6] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[17:58:47] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[17:58:47] [ENEMY] [Enemy7] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[17:58:47] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[17:58:47] [ENEMY] [Enemy8] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[17:58:47] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[17:58:47] [ENEMY] [Enemy9] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[17:58:47] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[17:58:47] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[17:58:47] [ENEMY] [Enemy10] Registered as sound listener
+[17:58:47] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[17:58:47] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[17:58:47] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:47] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:47] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:47] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:47] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:47] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:47] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=157.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:47] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[17:58:47] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[17:58:47] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[17:58:47] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[17:58:47] [INFO] [LastChance] Found player: Player
+[17:58:47] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[17:58:47] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[17:58:47] [INFO] [LastChance] Connected to player Died signal (C#)
+[17:58:47] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (904.4129, 522.8351) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (879.204, 600.5778) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (880.9915, 542.5999) (added to group)
+[17:58:47] [INFO] [Player] Detecting weapon pose (frame 3)...
+[17:58:47] [INFO] [Player] Detected weapon: Rifle (default pose)
+[17:58:47] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (911.5223, 555.8107) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (848.5181, 611.6504) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (866.9033, 644.2239) (added to group)
+[17:58:47] [INFO] [BloodDecal] Blood puddle created at (958.5138, 541.745) (added to group)
+[17:58:48] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[17:58:48] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[17:58:48] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1250), corner_timer=0.30
+[17:58:48] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1250), corner_timer=0.30
+[17:58:49] [INFO] ------------------------------------------------------------
+[17:58:49] [INFO] GAME LOG ENDED: 2026-02-03T17:58:49
+[17:58:49] [INFO] ============================================================

--- a/docs/case-studies/issue-431/game_log_20260203_180051.txt
+++ b/docs/case-studies/issue-431/game_log_20260203_180051.txt
@@ -1,0 +1,290 @@
+[18:00:51] [INFO] ============================================================
+[18:00:51] [INFO] GAME LOG STARTED
+[18:00:51] [INFO] ============================================================
+[18:00:51] [INFO] Timestamp: 2026-02-03T18:00:51
+[18:00:51] [INFO] Log file: I:/Загрузки/godot exe/game_log_20260203_180051.txt
+[18:00:51] [INFO] Executable: I:/Загрузки/godot exe/Godot-Top-Down-Template.exe
+[18:00:51] [INFO] OS: Windows
+[18:00:51] [INFO] Debug build: false
+[18:00:51] [INFO] Engine version: 4.3-stable (official)
+[18:00:51] [INFO] Project: Godot Top-Down Template
+[18:00:51] [INFO] ------------------------------------------------------------
+[18:00:51] [INFO] [GameManager] GameManager ready
+[18:00:51] [INFO] [ScoreManager] ScoreManager ready
+[18:00:51] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[18:00:51] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[18:00:51] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[18:00:51] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[18:00:51] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[18:00:51] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[18:00:51] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[18:00:51] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[18:00:51] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[18:00:51] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[18:00:51] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[18:00:51] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[18:00:51] [INFO] [LastChance] Resetting all effects (scene change detected)
+[18:00:51] [INFO] [LastChance] Last chance shader loaded successfully
+[18:00:51] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[18:00:51] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[18:00:51] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[18:00:51] [INFO] [LastChance]   Sepia intensity: 0.70
+[18:00:51] [INFO] [LastChance]   Brightness: 0.60
+[18:00:51] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[18:00:51] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[18:00:51] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV enabled: true, Complex grenade throwing: false
+[18:00:51] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.0 - overlay approach with death effects)...
+[18:00:51] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[18:00:51] [INFO] [CinemaEffects] Created effects layer at layer 99
+[18:00:51] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[18:00:51] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[18:00:51] [INFO] [CinemaEffects] Cinema film effect initialized (v5.0) - Configuration:
+[18:00:51] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[18:00:51] [INFO] [CinemaEffects]   Grain intensity: 0.10
+[18:00:51] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[18:00:51] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[18:00:51] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[18:00:51] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[18:00:51] [INFO] [CinemaEffects]   Micro scratches: 0.35 intensity, 1.5% probability
+[18:00:51] [INFO] [CinemaEffects]   Death effects: cigarette burn + end of reel (activated on player death)
+[18:00:51] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[18:00:51] [ENEMY] [Enemy1] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[18:00:51] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[18:00:51] [ENEMY] [Enemy2] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[18:00:51] [ENEMY] [Enemy3] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[18:00:51] [ENEMY] [Enemy4] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[18:00:51] [ENEMY] [Enemy5] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[18:00:51] [ENEMY] [Enemy6] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[18:00:51] [ENEMY] [Enemy7] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[18:00:51] [ENEMY] [Enemy8] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[18:00:51] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[18:00:51] [ENEMY] [Enemy9] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[18:00:51] [ENEMY] [Enemy10] Death animation component initialized
+[18:00:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[18:00:51] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[18:00:51] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[18:00:51] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[18:00:51] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[18:00:51] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[18:00:51] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[18:00:51] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[18:00:51] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[18:00:51] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[18:00:51] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[18:00:51] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[18:00:51] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[18:00:51] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[18:00:51] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[18:00:51] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy5': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[18:00:51] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[18:00:51] [INFO] [ScoreManager] Level started with 10 enemies
+[18:00:51] [INFO] [CinemaEffects] Found player node: Player
+[18:00:51] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[18:00:51] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[18:00:51] [ENEMY] [Enemy1] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[18:00:51] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[18:00:51] [ENEMY] [Enemy2] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[18:00:51] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[18:00:51] [ENEMY] [Enemy3] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[18:00:51] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[18:00:51] [ENEMY] [Enemy4] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[18:00:51] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[18:00:51] [ENEMY] [Enemy5] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy5] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[18:00:51] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[18:00:51] [ENEMY] [Enemy6] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[18:00:51] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[18:00:51] [ENEMY] [Enemy7] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy7] Spawned at (1606.114, 893.8859), hp: 3, behavior: PATROL
+[18:00:51] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[18:00:51] [ENEMY] [Enemy8] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[18:00:51] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[18:00:51] [ENEMY] [Enemy9] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[18:00:51] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[18:00:51] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[18:00:51] [ENEMY] [Enemy10] Registered as sound listener
+[18:00:51] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[18:00:51] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[18:00:51] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[18:00:51] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[18:00:51] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[18:00:51] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[18:00:51] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[18:00:51] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[18:00:51] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[18:00:51] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[18:00:51] [INFO] [Player] Detecting weapon pose (frame 3)...
+[18:00:51] [INFO] [Player] Detected weapon: Rifle (default pose)
+[18:00:51] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[18:00:51] [INFO] [PenultimateHit] Shader warmup complete in 168 ms
+[18:00:51] [INFO] [LastChance] Shader warmup complete in 166 ms
+[18:00:51] [INFO] [CinemaEffects] Cinema shader warmup complete in 142 ms
+[18:00:51] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[18:00:51] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[18:00:51] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[18:00:51] [INFO] [LastChance] Found player: Player
+[18:00:51] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[18:00:51] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[18:00:51] [INFO] [LastChance] Connected to player Died signal (C#)
+[18:00:51] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[18:00:51] [INFO] [ImpactEffects] Particle shader warmup complete: 5 effects warmed up in 415 ms
+[18:00:52] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[18:00:52] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[18:00:53] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1250), corner_timer=0.30
+[18:00:53] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1250), corner_timer=0.30
+[18:00:53] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1250), corner_timer=-0.02
+[18:00:53] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[18:00:53] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1250), corner_timer=-0.02
+[18:00:53] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[18:00:53] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1250), corner_timer=0.30
+[18:00:53] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1250), corner_timer=0.30
+[18:00:53] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,1250), corner_timer=-0.02
+[18:00:53] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[18:00:53] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,1250), corner_timer=0.30
+[18:00:53] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(450,1250), corner_timer=-0.02
+[18:00:53] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[18:00:54] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(450,1250), corner_timer=0.30
+[18:00:54] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(450,1250), corner_timer=-0.02
+[18:00:54] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[18:00:54] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(450,1250), corner_timer=0.30
+[18:00:54] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(450,1250), corner_timer=-0.02
+[18:00:54] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[18:00:54] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(450,1250), corner_timer=0.30
+[18:00:54] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:55] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(450,1250), corner_timer=-0.02
+[18:00:55] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[18:00:55] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(450,1250), corner_timer=0.30
+[18:00:55] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:55] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(450,1250), corner_timer=-0.02
+[18:00:55] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[18:00:55] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(450,1250), corner_timer=0.30
+[18:00:55] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:55] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(450,1250), corner_timer=-0.02
+[18:00:55] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[18:00:55] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(450,1250), corner_timer=0.30
+[18:00:55] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:56] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(450,1250), corner_timer=-0.02
+[18:00:56] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[18:00:56] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(450,1250), corner_timer=0.30
+[18:00:56] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:56] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(450,1250), corner_timer=-0.02
+[18:00:56] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[18:00:56] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(450,1250), corner_timer=0.30
+[18:00:56] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:56] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(450,1250), corner_timer=-0.02
+[18:00:56] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[18:00:56] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(450,1250), corner_timer=0.30
+[18:00:56] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:57] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(450,1250), corner_timer=-0.02
+[18:00:57] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[18:00:57] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:00:57] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:57] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(450,1250), corner_timer=-0.02
+[18:00:57] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:00:57] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:00:57] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:57] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[18:00:57] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:00:57] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:00:57] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:58] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[18:00:58] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:00:58] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:00:58] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:58] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[18:00:58] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:00:58] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:00:58] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:58] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[18:00:58] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:00:58] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:00:58] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:59] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[18:00:59] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:00:59] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:00:59] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:59] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[18:00:59] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:00:59] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:00:59] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:00:59] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[18:00:59] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:00:59] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:00:59] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:01:00] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[18:01:00] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:01:00] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:01:00] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:01:00] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(450,1250), corner_timer=-0.02
+[18:01:00] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[18:01:00] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(450,1250), corner_timer=0.30
+[18:01:00] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[18:01:00] [INFO] ------------------------------------------------------------
+[18:01:00] [INFO] GAME LOG ENDED: 2026-02-03T18:01:00
+[18:01:00] [INFO] ============================================================

--- a/scripts/shaders/cinema_film.gdshader
+++ b/scripts/shaders/cinema_film.gdshader
@@ -1,10 +1,11 @@
 shader_type canvas_item;
 
 // ============================================================================
-// CINEMA FILM EFFECT SHADER v5.1
+// CINEMA FILM EFFECT SHADER v5.2
 // Simulates vintage film look with grain, warm tones, and film defects
 // v5.0: Added micro scratches, cigarette burn, and end of reel death effects
-// v5.1: Issue #431 fixes - increased grain, realistic micro dots, death effects in left corner
+// v5.1: Issue #431 fixes - increased grain, realistic micro dots, death effects
+// v5.2: Issue #431 feedback - top-right corner, expanding spots, visible specks
 //
 // APPROACH: OVERLAY-BASED (no screen_texture)
 // This shader creates visual overlays that blend on top of the rendered scene
@@ -21,8 +22,8 @@ shader_type canvas_item;
 // ============================================================================
 
 // --- Film Grain Parameters ---
-// Increased from 0.07 to 0.10 per Issue #431 request for more grain
-uniform float grain_intensity : hint_range(0.0, 0.5) = 0.10;
+// Issue #431: Increased from 0.07 to 0.15 for more visible grain
+uniform float grain_intensity : hint_range(0.0, 0.5) = 0.15;
 uniform bool grain_enabled = true;
 
 // --- Warm/Sunny Color Tint Parameters ---
@@ -48,11 +49,12 @@ uniform float dust_intensity : hint_range(0.0, 1.0) = 0.5;
 uniform float flicker_intensity : hint_range(0.0, 0.3) = 0.03;
 
 // --- Micro Specks/Dots Parameters (tiny dust-like particles on old film) ---
-// Issue #431: Changed to small dots instead of scratches, appearing rarely
+// Issue #431: White specks/motes like dust on old film - now more visible
 uniform bool micro_scratches_enabled = true;
-uniform float micro_scratch_intensity : hint_range(0.0, 1.0) = 0.35;
-// Reduced probability from 0.03 to 0.015 for rare appearance as requested
-uniform float micro_scratch_probability : hint_range(0.0, 0.2) = 0.015;
+// Increased intensity from 0.35 to 0.7 for visibility
+uniform float micro_scratch_intensity : hint_range(0.0, 1.0) = 0.7;
+// Increased probability from 0.015 to 0.04 for more frequent appearance
+uniform float micro_scratch_probability : hint_range(0.0, 0.2) = 0.04;
 
 // --- Death Effects Parameters ---
 // Cigarette burn: circular burn mark that appears on death
@@ -62,9 +64,16 @@ uniform vec2 cigarette_burn_position = vec2(0.5, 0.5);
 uniform float cigarette_burn_size : hint_range(0.0, 0.5) = 0.15;
 
 // End of reel: flickering countdown effect in the corner on death
+// Issue #431: Position changed to top-RIGHT corner as requested
 uniform bool end_of_reel_enabled = false;
 uniform float end_of_reel_intensity : hint_range(0.0, 1.0) = 0.0;
 uniform float end_of_reel_time : hint_range(0.0, 10.0) = 0.0;
+
+// --- Expanding Death Spots Parameters ---
+// Issue #431: Spots that gradually expand and multiply on death
+uniform bool death_spots_enabled = false;
+uniform float death_spots_intensity : hint_range(0.0, 1.0) = 0.0;
+uniform float death_spots_time : hint_range(0.0, 10.0) = 0.0;
 
 
 // ============================================================================
@@ -154,18 +163,19 @@ float projector_flicker(float time_val) {
 
 // ============================================================================
 // MICRO SCRATCHES (small dots/specks like on old film, Issue #431)
-// Changed from line scratches to small dot/speck particles that appear
-// rarely and briefly, simulating dust and tiny defects on vintage film.
+// White/light specks (motes) like dust particles on vintage film.
+// Issue #431 feedback: Made more visible with larger size and higher intensity.
 // ============================================================================
 
 // Generate small dots/specks (tiny particles like dust on old film)
+// Returns: positive values for white specks, negative for dark specks
 float micro_scratches(vec2 uv, float time_val) {
 	float scratch_total = 0.0;
-	// Slower frame rate for more stable appearance (8fps instead of 12fps)
-	float frame = floor(time_val * 8.0) + 1.0;
+	// Frame rate for appearance changes
+	float frame = floor(time_val * 6.0) + 1.0;
 
-	// Generate multiple tiny dot specks (like dust particles on old film)
-	for (int i = 0; i < 6; i++) {
+	// Generate multiple specks (like white dust/motes on old film)
+	for (int i = 0; i < 10; i++) {
 		float seed = float(i) * 73.156 + 1.0;
 		float scratch_seed = hash(vec2(frame + seed, frame * 0.3 + seed));
 
@@ -176,22 +186,21 @@ float micro_scratches(vec2 uv, float time_val) {
 			// Distance from current pixel to speck center
 			float dist = length(uv - speck_pos);
 
-			// Very small dot size (about 1-2px = 0.001 to 0.002 in UV space)
-			// Randomize size slightly for natural look
-			float speck_size = 0.001 + hash(vec2(seed + 0.5, frame + 0.5)) * 0.0015;
+			// Larger dot size for visibility (3-6px = 0.003 to 0.006 in UV space)
+			float speck_size = 0.003 + hash(vec2(seed + 0.5, frame + 0.5)) * 0.003;
 
-			// Create soft-edged tiny dot
+			// Create soft-edged dot
 			float speck = 1.0 - smoothstep(0.0, speck_size, dist);
 
-			// Some specks are lighter (white dust), some darker (dark specks)
-			// This creates more variety like real film artifacts
+			// Most specks are white (like dust motes in projector light)
+			// Some specks are dark (like film imperfections)
 			float brightness_var = hash(vec2(seed + 0.9, frame + 0.9));
-			if (brightness_var > 0.7) {
-				// Bright speck (white dust particle)
-				scratch_total = max(scratch_total, speck * 0.5);
+			if (brightness_var > 0.3) {
+				// White/bright speck (dust motes in light) - more common
+				scratch_total = max(scratch_total, speck * 0.8);
 			} else {
-				// Dark speck (tiny dark particle)
-				scratch_total = max(scratch_total, speck * 0.4);
+				// Dark speck (film imperfection) - less common
+				scratch_total = max(scratch_total, speck * 0.5);
 			}
 		}
 	}
@@ -253,11 +262,12 @@ vec3 cigarette_burn_color(vec2 uv, vec2 center, float size) {
 }
 
 // End of reel effect - flickering countdown markers in corner
+// Issue #431 feedback: Changed to top-RIGHT corner
 float end_of_reel(vec2 uv, float intensity, float time_val, float reel_time) {
 	if (intensity <= 0.0) return 0.0;
 
-	// Position in top-left corner (as per Issue #431 request)
-	vec2 corner = vec2(0.15, 0.15);
+	// Position in top-RIGHT corner (Issue #431 feedback)
+	vec2 corner = vec2(0.85, 0.15);
 	float corner_size = 0.12;
 
 	vec2 to_corner = uv - corner;
@@ -295,6 +305,72 @@ float end_of_reel(vec2 uv, float intensity, float time_val, float reel_time) {
 	float pulse = 0.5 + 0.5 * sin(reel_time * 6.28318);
 
 	return markers * intensity * flicker * pulse;
+}
+
+
+// ============================================================================
+// EXPANDING DEATH SPOTS (Issue #431)
+// Dark spots that gradually expand and multiply when player dies,
+// simulating film damage/burning spreading across the frame.
+// ============================================================================
+
+float death_spots(vec2 uv, float intensity, float time_val) {
+	if (intensity <= 0.0) return 0.0;
+
+	float spots_total = 0.0;
+
+	// Number of spots increases over time (starts with 2, grows to 8)
+	int num_spots = int(2.0 + time_val * 2.0);
+	num_spots = min(num_spots, 8);
+
+	for (int i = 0; i < 8; i++) {
+		if (i >= num_spots) break;
+
+		float seed = float(i) * 37.891 + 1.0;
+
+		// Each spot has a fixed position based on seed
+		vec2 spot_pos = hash2(vec2(seed + 0.3, seed * 0.7 + 0.5));
+
+		// Distance from current pixel to spot center
+		float dist = length(uv - spot_pos);
+
+		// Spot size grows over time
+		// Each spot starts appearing at different times (staggered)
+		float spot_delay = float(i) * 0.3;
+		float spot_time = max(0.0, time_val - spot_delay);
+
+		// Base size + growth over time (starts small, grows larger)
+		float base_size = 0.02 + hash(vec2(seed + 0.1, 0.1)) * 0.03;
+		float growth_rate = 0.015 + hash(vec2(seed + 0.2, 0.2)) * 0.01;
+		float spot_size = base_size + spot_time * growth_rate;
+		spot_size = min(spot_size, 0.15); // Cap maximum size
+
+		// Create irregular edges for organic look
+		float edge_noise = hash(uv * 30.0 + vec2(seed, spot_time)) * 0.3;
+		float norm_dist = dist / spot_size;
+		norm_dist += edge_noise * 0.2;
+
+		// Dark center with charred edges
+		float spot = 1.0 - smoothstep(0.0, 1.0, norm_dist);
+
+		// Pulsing/flickering effect
+		float pulse = 0.8 + 0.2 * sin(time_val * 3.0 + seed);
+
+		spots_total = max(spots_total, spot * pulse);
+	}
+
+	return spots_total * intensity;
+}
+
+// Get color for death spots (dark charred appearance)
+vec3 death_spots_color(vec2 uv, float time_val) {
+	// Dark brown/black charred color
+	vec3 center_color = vec3(0.02, 0.01, 0.005);
+	vec3 edge_color = vec3(0.15, 0.08, 0.02);
+
+	// Slight variation based on position
+	float variation = hash(uv * 20.0);
+	return mix(center_color, edge_color, variation * 0.5);
 }
 
 
@@ -392,13 +468,24 @@ void fragment() {
 		}
 	}
 
-	// End of reel countdown effect
+	// End of reel countdown effect (white circle in top-right corner)
 	if (end_of_reel_enabled && end_of_reel_intensity > 0.0) {
 		float reel = end_of_reel(UV, end_of_reel_intensity, TIME, end_of_reel_time);
 		if (reel > 0.0) {
-			vec3 reel_color = vec3(0.1, 0.08, 0.05); // Dark film leader color
+			// White/light color for the reel marker circle
+			vec3 reel_color = vec3(0.95, 0.92, 0.88);
 			overlay.rgb = mix(overlay.rgb, reel_color, reel);
-			overlay.a = max(overlay.a, reel * 0.8);
+			overlay.a = max(overlay.a, reel * 0.9);
+		}
+	}
+
+	// Expanding death spots (Issue #431 - spots that grow and multiply)
+	if (death_spots_enabled && death_spots_intensity > 0.0) {
+		float spots = death_spots(UV, death_spots_intensity, death_spots_time);
+		if (spots > 0.0) {
+			vec3 spots_color = death_spots_color(UV, death_spots_time);
+			overlay.rgb = mix(overlay.rgb, spots_color, spots);
+			overlay.a = max(overlay.a, spots * 0.95);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes Issue #431 - Cinema film effects improvements based on user feedback.

### v5.2 Changes (Latest)

1. **White circle (end of reel) moved to TOP-RIGHT corner** - Changed from top-left to top-right as requested
2. **Expanding death spots** - Dark spots that gradually expand and multiply over time when player dies:
   - Starts with 2 spots, grows to 8 spots
   - Each spot starts small and expands
   - Staggered appearance for dramatic effect
   - Irregular edges for organic look
3. **White specks/motes now visible** - Increased visibility significantly:
   - Size increased from 1-2px to 3-6px
   - Intensity increased from 0.35 to 0.7
   - Probability increased from 1.5% to 4%
   - 70% white specks (like dust motes in projector light)
4. **More film grain** - Increased from 0.10 to 0.15

### Previous v5.1 Changes

- Fixed death signal connection (supports C# "Died" naming)
- Changed micro scratches to small dots/specks
- Increased grain from 0.07 to 0.10

### Files Changed

- `scripts/shaders/cinema_film.gdshader` - v5.0 → v5.2
- `scripts/autoload/cinema_effects_manager.gd` - v5.0 → v5.2
- `docs/case-studies/issue-431/` - Updated documentation with game logs

### Test Plan

- [ ] Start game and verify:
  - [ ] Film grain is more visible
  - [ ] White specks/motes appear regularly and are noticeable
- [ ] Get player killed and verify:
  - [ ] Cigarette burn effect appears (random center position)
  - [ ] End of reel (white circle) appears in **TOP-RIGHT** corner
  - [ ] Dark spots appear and gradually **expand** over time
  - [ ] More spots appear as time passes
  - [ ] All effects fade in smoothly

Fixes #431

---
*Generated with [Claude Code](https://claude.com/claude-code)*