### PR TITLE
fix: simplify death circle to ~160x160px ring that blinks 2 times (Issue #440)

### DIFF
--- a/scripts/autoload/cinema_effects_manager.gd
+++ b/scripts/autoload/cinema_effects_manager.gd
@@ -33,9 +33,10 @@ extends Node
 ## - Increased grain intensity further to 0.15
 ##
 ## v5.3 FIXES (Issue #440):
-## - Simplified end of reel effect to a clean ~160x160 pixel white circle ring
+## - Simplified end of reel effect to a clean ~80x80 pixel white circle ring
 ## - Changed from complex countdown markers to simple ring outline
 ## - Circle now blinks exactly 2 times then stays visible
+## - Updated: Made circle 2x smaller per feedback (was ~160x160, now ~80x80)
 
 # ============================================================================
 # DEFAULT VALUES

--- a/scripts/shaders/cinema_film.gdshader
+++ b/scripts/shaders/cinema_film.gdshader
@@ -6,8 +6,8 @@ shader_type canvas_item;
 // v5.0: Added micro scratches, cigarette burn, and end of reel death effects
 // v5.1: Issue #431 fixes - increased grain, realistic micro dots, death effects
 // v5.2: Issue #431 feedback - top-right corner, expanding spots, visible specks
-// v5.3: Issue #440 fix - simplified end of reel to ~160x160 white circle ring
-//       that blinks exactly 2 times
+// v5.3: Issue #440 fix - simplified end of reel to ~80x80 white circle ring
+//       that blinks exactly 2 times (updated: made 2x smaller per feedback)
 //
 // APPROACH: OVERLAY-BASED (no screen_texture)
 // This shader creates visual overlays that blend on top of the rendered scene
@@ -67,7 +67,7 @@ uniform float cigarette_burn_size : hint_range(0.0, 0.5) = 0.15;
 
 // End of reel: white circle ring in the corner on death
 // Issue #431: Position changed to top-RIGHT corner
-// Issue #440: Simplified to ~160x160 pixel white ring that blinks 2 times
+// Issue #440: Simplified to ~80x80 pixel white ring that blinks 2 times (updated: 2x smaller)
 uniform bool end_of_reel_enabled = false;
 uniform float end_of_reel_intensity : hint_range(0.0, 1.0) = 0.0;
 uniform float end_of_reel_time : hint_range(0.0, 10.0) = 0.0;
@@ -265,16 +265,16 @@ vec3 cigarette_burn_color(vec2 uv, vec2 center, float size) {
 }
 
 // End of reel effect - simple white circle outline in corner
-// Issue #440: Changed to a simple ~160x160 pixel white ring that blinks 2 times
+// Issue #440: Changed to a simple ~80x80 pixel white ring that blinks 2 times
 // Position: top-RIGHT corner
 float end_of_reel(vec2 uv, float intensity, float time_val, float reel_time) {
 	if (intensity <= 0.0) return 0.0;
 
 	// Position in top-RIGHT corner with some padding
-	// Circle size: ~160x160 pixels on 1280x720 viewport
-	// For a 160px circle: radius = 80px, in UV space ≈ 80/720 = 0.111 for Y
+	// Circle size: ~80x80 pixels on 1280x720 viewport
+	// For an 80px circle: radius = 40px, in UV space ≈ 40/720 = 0.056 for Y
 	// Using average for circle appearance on different aspect ratios
-	float circle_radius = 0.11;  // ~160px diameter on 720p
+	float circle_radius = 0.055;  // ~80px diameter on 720p (2x smaller than before)
 	float ring_thickness = 0.008;  // Thin ring outline (~6px)
 
 	// Position: top-right corner with padding (circle center)


### PR DESCRIPTION
## Summary
- Simplified end of reel death effect from complex countdown markers to a clean white circle ring
- Circle is now ~80x80 pixels (2x smaller than initial implementation, per feedback)
- Circle blinks exactly 2 times before staying visible
- Added aspect ratio correction for proper round appearance

## Changes
### cinema_film.gdshader
- Rewrote `end_of_reel()` function to draw a simple ring outline instead of multiple countdown markers with crosshairs
- Added aspect ratio correction (1.78 for 1280x720) to ensure circle appears round
- Implemented 2-blink pattern: 0.4s visible, 0.2s hidden per cycle, then stays visible after 1.2s
- Updated circle size to ~80x80 pixels (radius 0.055) per maintainer feedback
- Updated shader version to v5.3

### cinema_effects_manager.gd  
- Updated version comments to v5.3
- Updated logging messages to reflect new death circle behavior

## Test plan
- [ ] Play the game and let the player die
- [ ] Verify white circle ring appears in top-right corner
- [ ] Verify circle is approximately 80x80 pixels (round shape, 2x smaller than before)
- [ ] Verify circle blinks 2 times then stays visible
- [ ] Verify circle looks similar to reference images from issue

## Issue Reference
Fixes #440

🤖 Generated with [Claude Code](https://claude.ai/code)