### PR TITLE
fix: add Release configuration to solution file for CI build (Issue #490)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/490
-Your prepared branch: issue-490-9e5b28667a07
-Your prepared working directory: /tmp/gh-issue-solver-1770247608585
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary

- Added `Release|Any CPU` configuration to `GodotTopDownTemplate.sln` that maps to `ExportRelease` project configuration

## Problem

The `build-windows.yml` workflow runs `dotnet build --configuration Release`, but the solution file only defined `Debug`, `ExportDebug`, and `ExportRelease` configurations.

This caused CI failure with error:
```
error MSB4126: The specified solution configuration "Release|Any CPU" is invalid.
```

## Solution

Added the missing `Release|Any CPU` configuration to the solution file as recommended in PR #430. The Release configuration maps to the `ExportRelease` project configuration, which is the correct Godot release build configuration.

## Test plan

- [x] CI Windows build passes (`dotnet build --configuration Release`)
- [x] All other CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes Jhon-Crow/godot-topdown-MVP#490