### PR TITLE
fix: position combo label in top-right corner on Полигон

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/534
-Your prepared branch: issue-534-2e326cbcc11e
-Your prepared working directory: /tmp/gh-issue-solver-1770412904611
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR fixes the combo label positioning on the Полигон (TestTier) level. The combo was previously displayed in the center of the screen below the player, but it should be anchored in the top-right corner like on other maps (BuildingLevel and CastleLevel).

## Changes Made

**`scripts/levels/test_tier.gd`**
- Changed combo label anchor preset from `PRESET_CENTER` to `PRESET_TOP_RIGHT`
- Updated positioning offsets to match other levels:
  - `offset_left`: -200
  - `offset_right`: -10
  - `offset_top`: 80
  - `offset_bottom`: 120
- Increased font size from 24 to 28 for consistency
- Added golden color theme `Color(1.0, 0.8, 0.2)` to match other levels
- Changed horizontal alignment to `HORIZONTAL_ALIGNMENT_RIGHT`

## Root Cause

When score tracking was added in PR #514, the combo label was created dynamically in the `_on_combo_changed()` function with center positioning instead of following the top-right pattern used in BuildingLevel and CastleLevel.

## Testing

The combo label now:
- Appears in the top-right corner below the enemy count label
- Uses consistent styling (font size 28, golden color) with other levels
- Maintains the same flash animation effect on combo updates
- Doesn't obstruct the player view during gameplay

Fixes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)