### PR TITLE
fix: rename 'ACTIVE' to 'SPECIAL' in armory menu sidebar

### DIFF
--- a/scripts/ui/armory_menu.gd
+++ b/scripts/ui/armory_menu.gd
@@ -1038,7 +1038,7 @@ func _update_active_item_stats() -> void:
 	var item_desc: String = item_data.get("description", "No active item equipped.")
 
 	var bbcode: String = ""
-	bbcode += "[b][color=#d4c896]ACTIVE: %s[/color][/b]\n" % item_name
+	bbcode += "[b][color=#d4c896]SPECIAL: %s[/color][/b]\n" % item_name
 	bbcode += "[color=#aab0b8]%s[/color]\n" % item_desc
 	if _pending_active_item_type != 0:  # Not "None" (ActiveItemType.NONE)
 		var activation_hint: String = item_data.get("activation_hint", "Hold Space to activate")


### PR DESCRIPTION
## Summary

Fixes #726 by renaming the 'ACTIVE' label to 'SPECIAL' in the armory menu sidebar, translating the Russian 'Особые' to English.

## Changes

- Updated sidebar label from 'ACTIVE:' to 'SPECIAL:' in armory_menu.gd line 1041
- This makes the sidebar consistent with the section header which already showed 'SPECIAL'
- Maintains all existing functionality while updating the UI text

## Test Plan

- [x] Manual code review confirms text change is correct
- [x] No functional code changes, only UI text updates  
- [x] CI should pass as this is a minimal text change
- [x] Change addresses issue requirement exactly as specified

## Screenshots

N/A - This is a text change in the UI that will be visible when opening the Armory menu and viewing the active item stats.

---

*This PR was created with assistance from the AI issue solver*