### PR TITLE
Fix grenade/reload tutorial hints, add revolver hammer hint, update Laboratory tutorial (Issue #808)

### DIFF
--- a/scripts/levels/labyrinth_level.gd
+++ b/scripts/levels/labyrinth_level.gd
@@ -68,15 +68,47 @@ var _enemies: Array = []
 ## Cached reference to the ReplayManager autoload (C# singleton).
 var _replay_manager: Node = null
 
-## Tutorial hint labels for the Laboratory level (Issue #808).
-## Keys: "move", "shoot", "reload" — each dismissed when the action is performed.
+## ============================================================
+## Tutorial hint system for the Laboratory level (Issue #808)
+## Mirrors tutorial_level.gd: weapon-dependent hints, grenade hint, no walk/shoot hints.
+## ============================================================
+
+## Tutorial hint labels: hint_key -> Label node.
 var _tutorial_hints: Dictionary = {}
 
-## Whether the player has shot at least once (to dismiss shoot hint).
-var _tutorial_shot_fired: bool = false
+## Tutorial state machine (same as tutorial_level.gd).
+enum TutorialStep {
+	RELOAD,
+	THROW_GRENADE,
+	COMPLETED
+}
 
-## Whether the player has reloaded at least once (to dismiss reload hint).
-var _tutorial_reloaded: bool = false
+## Current tutorial step.
+var _tutorial_step: TutorialStep = TutorialStep.RELOAD
+
+## Whether the player has reloaded (for step tracking).
+var _tutorial_has_reloaded: bool = false
+
+## Whether the player has thrown a grenade (for step tracking).
+var _tutorial_has_thrown_grenade: bool = false
+
+## Whether the player has a shotgun (shotgun-specific reload hint).
+var _tutorial_has_shotgun: bool = false
+
+## Whether the player has a sniper rifle (bolt-cycle hint).
+var _tutorial_has_sniper_rifle: bool = false
+
+## Whether the player has a revolver (hammer cock hint).
+var _tutorial_has_revolver: bool = false
+
+## Whether the player has a Makarov PM (R->R reload hint).
+var _tutorial_has_makarov_pm: bool = false
+
+## Hint keys (same as tutorial_level.gd).
+const TUTORIAL_HINT_RELOAD := "reload"
+const TUTORIAL_HINT_GRENADE := "grenade"
+const TUTORIAL_HINT_HAMMER_COCK := "hammer_cock"
+const TUTORIAL_HINT_BOLT_CYCLE := "bolt_cycle"
 
 ## Vertical spacing between stacked tutorial hints (pixels).
 const TUTORIAL_HINT_SPACING: float = 35.0
@@ -479,6 +511,8 @@ func _setup_player_tracking() -> void:
 	if weapon == null:
 		weapon = _player.get_node_or_null("AssaultRifle")
 	if weapon == null:
+		weapon = _player.get_node_or_null("Revolver")
+	if weapon == null:
 		weapon = _player.get_node_or_null("MakarovPM")
 	if weapon != null:
 		if weapon.has_signal("AmmoChanged"):
@@ -496,6 +530,22 @@ func _setup_player_tracking() -> void:
 			_update_magazines_label(mag_counts)
 		_configure_silenced_pistol_ammo(weapon)
 		_configure_makarov_pm_ammo(weapon)
+
+		# Detect weapon type for tutorial hints (Issue #808)
+		match weapon.name:
+			"Shotgun":
+				_tutorial_has_shotgun = true
+			"SniperRifle":
+				_tutorial_has_sniper_rifle = true
+				if weapon.has_signal("BoltStepChanged"):
+					weapon.BoltStepChanged.connect(_on_tutorial_sniper_bolt_step_changed)
+			"Revolver":
+				_tutorial_has_revolver = true
+				# Connect to HammerCocked signal to dismiss hammer hint (Issue #808)
+				if weapon.has_signal("HammerCocked"):
+					weapon.HammerCocked.connect(_on_tutorial_hammer_cocked)
+			"MakarovPM":
+				_tutorial_has_makarov_pm = true
 	else:
 		if _player.has_signal("ammo_changed"):
 			_player.ammo_changed.connect(_on_player_ammo_changed)
@@ -517,6 +567,12 @@ func _setup_player_tracking() -> void:
 		_player.AmmoDepleted.connect(_on_player_ammo_depleted)
 	elif _player.has_signal("ammo_depleted"):
 		_player.ammo_depleted.connect(_on_player_ammo_depleted)
+
+	# Connect to grenade thrown signal for grenade tutorial hint (Issue #808)
+	if _player.has_signal("GrenadeThrown"):
+		_player.GrenadeThrown.connect(_on_tutorial_grenade_thrown)
+	elif _player.has_signal("grenade_thrown"):
+		_player.grenade_thrown.connect(_on_tutorial_grenade_thrown)
 
 
 ## Setup tracking for all enemies in the scene.
@@ -732,10 +788,6 @@ func _on_enemy_hit() -> void:
 func _on_shot_fired() -> void:
 	if GameManager:
 		GameManager.register_shot()
-	# Dismiss shoot tutorial hint on first shot (Issue #808)
-	if not _tutorial_shot_fired:
-		_tutorial_shot_fired = true
-		_dismiss_tutorial_hint("shoot")
 
 
 ## Called when player ammo changes (GDScript Player).
@@ -743,10 +795,6 @@ func _on_player_ammo_changed(current: int, maximum: int) -> void:
 	_update_ammo_label(current, maximum)
 	if GameManager:
 		GameManager.register_shot()
-	# Dismiss shoot tutorial hint on first shot (Issue #808)
-	if not _tutorial_shot_fired:
-		_tutorial_shot_fired = true
-		_dismiss_tutorial_hint("shoot")
 
 
 ## Called when weapon ammo changes (C# Player).
@@ -799,10 +847,8 @@ func _on_player_reload_started() -> void:
 func _on_player_reload_completed() -> void:
 	_broadcast_player_reloading(false)
 	_broadcast_player_ammo_empty(false)
-	# Dismiss reload tutorial hint on first reload (Issue #808)
-	if not _tutorial_reloaded:
-		_tutorial_reloaded = true
-		_dismiss_tutorial_hint("reload")
+	# Tutorial: handle reload step (Issue #808)
+	_on_tutorial_reload_completed()
 
 
 ## Broadcast player reloading state to all enemies.
@@ -1430,21 +1476,102 @@ func _disable_player_controls() -> void:
 
 ## ============================================================
 ## Tutorial hints for the Laboratory level (Issue #808)
+## Weapon-dependent hints mirroring tutorial_level.gd behavior.
+## No walk/shoot hints. Shows: reload (weapon-specific), hammer cock (revolver),
+## bolt cycle (sniper), and grenade throw — same as Tutorial level.
 ## ============================================================
 
 
-## Create and show basic control tutorial hints at level start.
-## Shows: movement (WASD), shooting (LMB), reloading (R).
-## Each hint disappears independently when the player performs the action.
+## Create and show weapon-dependent tutorial hints at level start (Issue #808).
+## Mirrors tutorial_level.gd: shows reload + weapon-feature + grenade hints.
+## No movement or shooting hints (owner request).
 func _setup_tutorial_hints() -> void:
 	var canvas_layer := get_node_or_null("CanvasLayer")
 	if canvas_layer == null:
 		return
 
-	_add_tutorial_hint("move", "[WASD] Двигайся", canvas_layer)
-	_add_tutorial_hint("shoot", "[ЛКМ] Стреляй", canvas_layer)
-	_add_tutorial_hint("reload", "[R] Перезаряжайся", canvas_layer)
-	print("[LabyrinthLevel] Tutorial hints shown for Laboratory level (Issue #808)")
+	_tutorial_step = TutorialStep.RELOAD
+	_add_tutorial_reload_hints(canvas_layer)
+	print("[LabyrinthLevel] Weapon-dependent tutorial hints shown (Issue #808)")
+
+
+## Add reload-related hints for the current weapon type, plus grenade hint.
+## Mirrors _add_reload_hints() from tutorial_level.gd.
+func _add_tutorial_reload_hints(canvas_layer: Node) -> void:
+	if _tutorial_has_shotgun:
+		_add_tutorial_hint(TUTORIAL_HINT_RELOAD, "[ПКМ↑ открыть] [СКМ+ПКМ↓ x8] [ПКМ↓ закрыть]", canvas_layer)
+	elif _tutorial_has_sniper_rifle:
+		_add_tutorial_hint(TUTORIAL_HINT_RELOAD, "[R] [F] [R] Перезарядись", canvas_layer)
+		_add_tutorial_hint(TUTORIAL_HINT_BOLT_CYCLE, "[←↓↑→] Передёрни затвор", canvas_layer)
+	elif _tutorial_has_revolver:
+		_add_tutorial_hint(TUTORIAL_HINT_RELOAD, "[R открыть] [ПКМ↑ патрон] [скролл] [R закрыть]", canvas_layer)
+		_add_tutorial_hint(TUTORIAL_HINT_HAMMER_COCK, "[ПКМ] Взведи курок", canvas_layer)
+	elif _tutorial_has_makarov_pm:
+		_add_tutorial_hint(TUTORIAL_HINT_RELOAD, "[R] [R] Перезарядись", canvas_layer)
+	else:
+		_add_tutorial_hint(TUTORIAL_HINT_RELOAD, "[R] [F] [R] Перезарядись", canvas_layer)
+
+	# Always show grenade hint alongside reload (Issue #808)
+	if not _tutorial_hints.has(TUTORIAL_HINT_GRENADE):
+		_add_tutorial_hint(TUTORIAL_HINT_GRENADE, "[G+ПКМ вправо] [G+ПКМ→отпусти G] [ПКМ бросок]", canvas_layer)
+
+
+## Called when sniper bolt step changes (Issue #808 - Lab sniper tutorial).
+func _on_tutorial_sniper_bolt_step_changed(step: int, total_steps: int) -> void:
+	if _tutorial_step != TutorialStep.RELOAD:
+		return
+	if step >= total_steps and not _tutorial_has_reloaded:
+		_tutorial_has_reloaded = true
+		_dismiss_tutorial_hint(TUTORIAL_HINT_RELOAD)
+		_dismiss_tutorial_hint(TUTORIAL_HINT_BOLT_CYCLE)
+		if _tutorial_has_thrown_grenade:
+			_tutorial_step = TutorialStep.COMPLETED
+			_dismiss_all_tutorial_hints()
+		else:
+			_tutorial_step = TutorialStep.THROW_GRENADE
+
+
+## Called when revolver hammer is cocked — dismisses hammer hint (Issue #808).
+func _on_tutorial_hammer_cocked() -> void:
+	_dismiss_tutorial_hint(TUTORIAL_HINT_HAMMER_COCK)
+
+
+## Called on tutorial reload completion (Issue #808).
+func _on_tutorial_reload_completed() -> void:
+	if _tutorial_step != TutorialStep.RELOAD:
+		return
+	if not _tutorial_has_reloaded:
+		_tutorial_has_reloaded = true
+		_dismiss_tutorial_hint(TUTORIAL_HINT_RELOAD)
+		_dismiss_tutorial_hint(TUTORIAL_HINT_HAMMER_COCK)
+		if _tutorial_has_thrown_grenade:
+			_tutorial_step = TutorialStep.COMPLETED
+			_dismiss_all_tutorial_hints()
+		else:
+			_tutorial_step = TutorialStep.THROW_GRENADE
+			# Ensure grenade hint is visible (may have already been added)
+			if not _tutorial_hints.has(TUTORIAL_HINT_GRENADE):
+				var canvas_layer := get_node_or_null("CanvasLayer")
+				if canvas_layer:
+					_add_tutorial_hint(TUTORIAL_HINT_GRENADE, "[G+ПКМ вправо] [G+ПКМ→отпусти G] [ПКМ бросок]", canvas_layer)
+
+
+## Called when player throws a grenade — dismisses grenade hint (Issue #808).
+func _on_tutorial_grenade_thrown() -> void:
+	if _tutorial_step != TutorialStep.THROW_GRENADE and _tutorial_step != TutorialStep.RELOAD:
+		return
+	if not _tutorial_has_thrown_grenade:
+		_tutorial_has_thrown_grenade = true
+		_dismiss_tutorial_hint(TUTORIAL_HINT_GRENADE)
+		if _tutorial_step == TutorialStep.THROW_GRENADE:
+			_tutorial_step = TutorialStep.COMPLETED
+			_dismiss_all_tutorial_hints()
+
+
+## Dismiss all remaining tutorial hints.
+func _dismiss_all_tutorial_hints() -> void:
+	for key in _tutorial_hints.keys():
+		_dismiss_tutorial_hint(key)
 
 
 ## Create and register a tutorial hint label.

--- a/scripts/levels/tutorial_level.gd
+++ b/scripts/levels/tutorial_level.gd
@@ -462,6 +462,11 @@ func _connect_player_signals() -> void:
 		elif _player.has_signal("reload_completed"):
 			_player.reload_completed.connect(_on_player_reload_completed)
 
+		# Connect to hammer cocked signal to dismiss hammer hint (Issue #808)
+		if revolver.has_signal("HammerCocked"):
+			revolver.HammerCocked.connect(_on_revolver_hammer_cocked)
+			print("Tutorial: Connected to HammerCocked signal")
+
 		# Connect to revolver ammo signal
 		if revolver.has_signal("AmmoChanged"):
 			revolver.AmmoChanged.connect(_on_weapon_ammo_changed)
@@ -718,6 +723,12 @@ func _on_player_reload_completed() -> void:
 			_advance_to_step(TutorialStep.COMPLETED)
 		else:
 			_advance_to_step(TutorialStep.THROW_GRENADE)
+
+
+## Called when the revolver hammer is cocked (RMB press or LMB fire).
+## Dismisses the hammer cock hint the first time the hammer is cocked (Issue #808).
+func _on_revolver_hammer_cocked() -> void:
+	_dismiss_hint(HINT_HAMMER_COCK)
 
 
 ## Called when player throws a grenade.

--- a/tests/unit/test_level_scripts.gd
+++ b/tests/unit/test_level_scripts.gd
@@ -389,39 +389,85 @@ class MockBeachLevel extends MockLevelBase:
 
 
 class MockLabyrinthLevel extends MockLevelBase:
-	## Laboratory / starting level (Issue #808: tutorial hints).
+	## Laboratory / starting level (Issue #808: weapon-dependent tutorial hints).
 	var level_name: String = "LabyrinthLevel"
 
 	## Default enemy count for labyrinth (5 enemies).
 	var default_enemy_count: int = 5
 
-	## Tutorial hint tracking (Issue #808).
+	## Tutorial hint tracking (Issue #808): weapon-dependent, mirrors tutorial_level.gd.
 	var _tutorial_hints: Dictionary = {}
-	var _tutorial_shot_fired: bool = false
-	var _tutorial_reloaded: bool = false
 
-	## Setup tutorial hints at level start.
+	## Tutorial state machine (mirrors labyrinth_level.gd TutorialStep).
+	enum TutorialStep { RELOAD, THROW_GRENADE, COMPLETED }
+	var _tutorial_step: int = TutorialStep.RELOAD
+
+	## Weapon type flags.
+	var _tutorial_has_shotgun: bool = false
+	var _tutorial_has_sniper_rifle: bool = false
+	var _tutorial_has_revolver: bool = false
+	var _tutorial_has_makarov_pm: bool = false
+
+	## State tracking.
+	var _tutorial_has_reloaded: bool = false
+	var _tutorial_has_thrown_grenade: bool = false
+
+	## Hint keys.
+	const HINT_RELOAD := "reload"
+	const HINT_GRENADE := "grenade"
+	const HINT_HAMMER_COCK := "hammer_cock"
+	const HINT_BOLT_CYCLE := "bolt_cycle"
+
+	## Setup weapon-dependent tutorial hints at level start (Issue #808).
 	func setup_tutorial_hints() -> void:
-		_tutorial_hints["move"] = "[WASD] Двигайся"
-		_tutorial_hints["shoot"] = "[ЛКМ] Стреляй"
-		_tutorial_hints["reload"] = "[R] Перезаряжайся"
+		_tutorial_step = TutorialStep.RELOAD
+		_add_reload_hints()
 
-	## Dismiss a tutorial hint by key.
-	func dismiss_tutorial_hint(hint_key: String) -> void:
-		_tutorial_hints.erase(hint_key)
+	## Add weapon-dependent reload hints plus grenade hint.
+	func _add_reload_hints() -> void:
+		if _tutorial_has_shotgun:
+			_tutorial_hints[HINT_RELOAD] = "[ПКМ↑ открыть] [СКМ+ПКМ↓ x8] [ПКМ↓ закрыть]"
+		elif _tutorial_has_sniper_rifle:
+			_tutorial_hints[HINT_RELOAD] = "[R] [F] [R] Перезарядись"
+			_tutorial_hints[HINT_BOLT_CYCLE] = "[←↓↑→] Передёрни затвор"
+		elif _tutorial_has_revolver:
+			_tutorial_hints[HINT_RELOAD] = "[R открыть] [ПКМ↑ патрон] [скролл] [R закрыть]"
+			_tutorial_hints[HINT_HAMMER_COCK] = "[ПКМ] Взведи курок"
+		elif _tutorial_has_makarov_pm:
+			_tutorial_hints[HINT_RELOAD] = "[R] [R] Перезарядись"
+		else:
+			_tutorial_hints[HINT_RELOAD] = "[R] [F] [R] Перезарядись"
+		if not _tutorial_hints.has(HINT_GRENADE):
+			_tutorial_hints[HINT_GRENADE] = "[G+ПКМ вправо] [G+ПКМ→отпусти G] [ПКМ бросок]"
 
-	## Called when shot is fired.
-	func on_shot_fired() -> void:
-		register_shot()
-		if not _tutorial_shot_fired:
-			_tutorial_shot_fired = true
-			dismiss_tutorial_hint("shoot")
+	## Called when hammer is cocked — dismisses hammer hint.
+	func on_hammer_cocked() -> void:
+		_tutorial_hints.erase(HINT_HAMMER_COCK)
 
 	## Called when reload completes.
 	func on_reload_completed() -> void:
-		if not _tutorial_reloaded:
-			_tutorial_reloaded = true
-			dismiss_tutorial_hint("reload")
+		if _tutorial_step != TutorialStep.RELOAD:
+			return
+		if not _tutorial_has_reloaded:
+			_tutorial_has_reloaded = true
+			_tutorial_hints.erase(HINT_RELOAD)
+			_tutorial_hints.erase(HINT_HAMMER_COCK)
+			if _tutorial_has_thrown_grenade:
+				_tutorial_step = TutorialStep.COMPLETED
+				_tutorial_hints.clear()
+			else:
+				_tutorial_step = TutorialStep.THROW_GRENADE
+
+	## Called when grenade is thrown.
+	func on_grenade_thrown() -> void:
+		if _tutorial_step != TutorialStep.THROW_GRENADE and _tutorial_step != TutorialStep.RELOAD:
+			return
+		if not _tutorial_has_thrown_grenade:
+			_tutorial_has_thrown_grenade = true
+			_tutorial_hints.erase(HINT_GRENADE)
+			if _tutorial_step == TutorialStep.THROW_GRENADE:
+				_tutorial_step = TutorialStep.COMPLETED
+				_tutorial_hints.clear()
 
 	## Check if a tutorial hint is currently active.
 	func is_tutorial_hint_active(hint_key: String) -> bool:
@@ -430,6 +476,10 @@ class MockLabyrinthLevel extends MockLevelBase:
 	## Check if all tutorial hints are dismissed.
 	func are_all_hints_dismissed() -> bool:
 		return _tutorial_hints.is_empty()
+
+	## Check if tutorial is complete.
+	func is_tutorial_complete() -> bool:
+		return _tutorial_step == TutorialStep.COMPLETED
 
 	## Initialize with default enemy configuration.
 	func initialize() -> void:
@@ -1677,68 +1727,8 @@ func test_beach_level_complete_with_accuracy_tracking() -> void:
 
 # ============================================================================
 # LabyrinthLevel Tutorial Hints Tests (Issue #808)
+# Weapon-dependent hints, same as Tutorial level — no walk/shoot hints.
 # ============================================================================
-
-
-func test_labyrinth_tutorial_hints_shown_at_start() -> void:
-	labyrinth_level.initialize()
-
-	assert_true(labyrinth_level.is_tutorial_hint_active("move"),
-		"Movement hint should be shown at start")
-	assert_true(labyrinth_level.is_tutorial_hint_active("shoot"),
-		"Shoot hint should be shown at start")
-	assert_true(labyrinth_level.is_tutorial_hint_active("reload"),
-		"Reload hint should be shown at start")
-
-
-func test_labyrinth_shoot_hint_dismissed_on_first_shot() -> void:
-	labyrinth_level.initialize()
-
-	labyrinth_level.on_shot_fired()
-
-	assert_false(labyrinth_level.is_tutorial_hint_active("shoot"),
-		"Shoot hint should be dismissed after first shot")
-	assert_true(labyrinth_level.is_tutorial_hint_active("move"),
-		"Move hint should still be visible")
-	assert_true(labyrinth_level.is_tutorial_hint_active("reload"),
-		"Reload hint should still be visible after shooting")
-
-
-func test_labyrinth_reload_hint_dismissed_on_first_reload() -> void:
-	labyrinth_level.initialize()
-
-	labyrinth_level.on_reload_completed()
-
-	assert_false(labyrinth_level.is_tutorial_hint_active("reload"),
-		"Reload hint should be dismissed after first reload")
-	assert_true(labyrinth_level.is_tutorial_hint_active("move"),
-		"Move hint should still be visible")
-	assert_true(labyrinth_level.is_tutorial_hint_active("shoot"),
-		"Shoot hint should still be visible after reloading")
-
-
-func test_labyrinth_shoot_not_dismissed_twice() -> void:
-	labyrinth_level.initialize()
-
-	labyrinth_level.on_shot_fired()
-	labyrinth_level.on_shot_fired()  # Second shot should be ignored for hint
-
-	assert_false(labyrinth_level.is_tutorial_hint_active("shoot"),
-		"Shoot hint should remain dismissed after second shot")
-
-
-func test_labyrinth_hints_independent_dismissal() -> void:
-	labyrinth_level.initialize()
-
-	labyrinth_level.on_shot_fired()
-	labyrinth_level.on_reload_completed()
-
-	assert_false(labyrinth_level.is_tutorial_hint_active("shoot"),
-		"Shoot hint dismissed")
-	assert_false(labyrinth_level.is_tutorial_hint_active("reload"),
-		"Reload hint dismissed")
-	assert_true(labyrinth_level.is_tutorial_hint_active("move"),
-		"Move hint still shown (no signal for movement)")
 
 
 func test_labyrinth_five_default_enemies() -> void:
@@ -1746,3 +1736,101 @@ func test_labyrinth_five_default_enemies() -> void:
 
 	assert_eq(labyrinth_level._initial_enemy_count, 5,
 		"Labyrinth should have 5 enemies by default")
+
+
+func test_labyrinth_tutorial_shows_reload_and_grenade_at_start() -> void:
+	labyrinth_level.initialize()
+
+	assert_true(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_RELOAD),
+		"Reload hint should be shown at start")
+	assert_true(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_GRENADE),
+		"Grenade hint should be shown at start alongside reload (Issue #808)")
+
+
+func test_labyrinth_tutorial_no_walk_or_shoot_hints() -> void:
+	labyrinth_level.initialize()
+
+	assert_false(labyrinth_level.is_tutorial_hint_active("move"),
+		"No movement hint in Lab tutorial (owner request)")
+	assert_false(labyrinth_level.is_tutorial_hint_active("shoot"),
+		"No shoot hint in Lab tutorial (owner request)")
+
+
+func test_labyrinth_reload_dismisses_reload_hint_grenade_remains() -> void:
+	labyrinth_level.initialize()
+
+	labyrinth_level.on_reload_completed()
+
+	assert_false(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_RELOAD),
+		"Reload hint should be dismissed after reload")
+	assert_true(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_GRENADE),
+		"Grenade hint should remain after reload (Issue #808)")
+
+
+func test_labyrinth_grenade_thrown_completes_after_reload() -> void:
+	labyrinth_level.initialize()
+
+	labyrinth_level.on_reload_completed()
+	labyrinth_level.on_grenade_thrown()
+
+	assert_true(labyrinth_level.is_tutorial_complete(),
+		"Tutorial should complete after reload then grenade")
+	assert_true(labyrinth_level.are_all_hints_dismissed(),
+		"All hints dismissed after tutorial complete")
+
+
+func test_labyrinth_grenade_before_reload_dismisses_grenade_hint() -> void:
+	labyrinth_level.initialize()
+
+	labyrinth_level.on_grenade_thrown()
+
+	assert_false(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_GRENADE),
+		"Grenade hint dismissed even when thrown before reload")
+	assert_true(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_RELOAD),
+		"Reload hint still visible when grenade thrown early")
+
+
+func test_labyrinth_reload_after_early_grenade_completes_tutorial() -> void:
+	labyrinth_level.initialize()
+
+	labyrinth_level.on_grenade_thrown()  # Grenade first
+	labyrinth_level.on_reload_completed()  # Then reload
+
+	assert_true(labyrinth_level.is_tutorial_complete(),
+		"Tutorial completes when reload done after early grenade")
+	assert_true(labyrinth_level.are_all_hints_dismissed(),
+		"No hints remain after tutorial completes")
+
+
+func test_labyrinth_revolver_shows_hammer_cock_hint() -> void:
+	labyrinth_level._tutorial_has_revolver = true
+	labyrinth_level.initialize()
+
+	assert_true(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_HAMMER_COCK),
+		"Revolver should show hammer cock hint (Issue #808)")
+	assert_true(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_RELOAD),
+		"Revolver should show reload hint")
+	assert_true(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_GRENADE),
+		"Revolver should show grenade hint simultaneously")
+
+
+func test_labyrinth_hammer_cocked_dismisses_hammer_hint() -> void:
+	labyrinth_level._tutorial_has_revolver = true
+	labyrinth_level.initialize()
+
+	labyrinth_level.on_hammer_cocked()
+
+	assert_false(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_HAMMER_COCK),
+		"Hammer hint dismissed when hammer is cocked (Issue #808)")
+	assert_true(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_RELOAD),
+		"Reload hint still visible after hammer cocked")
+
+
+func test_labyrinth_shotgun_no_hammer_hint() -> void:
+	labyrinth_level._tutorial_has_shotgun = true
+	labyrinth_level.initialize()
+
+	assert_false(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_HAMMER_COCK),
+		"Shotgun should not show hammer hint")
+	assert_true(labyrinth_level.is_tutorial_hint_active(MockLabyrinthLevel.HINT_RELOAD),
+		"Shotgun should show reload hint")

--- a/tests/unit/test_tutorial_level.gd
+++ b/tests/unit/test_tutorial_level.gd
@@ -124,6 +124,10 @@ class MockTutorialLevel:
 			_dismiss_hint(HINT_SCOPE)
 			advance_to_step(TutorialStep.THROW_GRENADE)
 
+	func on_hammer_cocked() -> void:
+		## Dismiss hammer cock hint when hammer is cocked (RMB or LMB fire) (Issue #808).
+		_dismiss_hint(HINT_HAMMER_COCK)
+
 	func on_reload_completed() -> void:
 		if _current_step != TutorialStep.RELOAD:
 			return
@@ -495,6 +499,65 @@ func test_non_revolver_no_hammer_cock_hint() -> void:
 
 	assert_false(tutorial.is_hint_active(MockTutorialLevel.HINT_HAMMER_COCK),
 		"Default weapon should not have hammer cock hint")
+
+
+func test_revolver_hammer_cocked_dismisses_hammer_hint() -> void:
+	## When revolver hammer is cocked (RMB), hammer cock hint should disappear (Issue #808)
+	tutorial._has_revolver = true
+	tutorial.set_initial_step_based_on_weapon(false)
+
+	tutorial.on_hammer_cocked()
+
+	assert_false(tutorial.is_hint_active(MockTutorialLevel.HINT_HAMMER_COCK),
+		"Hammer cock hint dismissed when hammer is cocked (Issue #808)")
+	assert_true(tutorial.is_hint_active(MockTutorialLevel.HINT_RELOAD),
+		"Reload hint remains after hammer cocked")
+	assert_true(tutorial.is_hint_active(MockTutorialLevel.HINT_GRENADE),
+		"Grenade hint remains after hammer cocked")
+
+
+func test_revolver_hammer_cocked_twice_is_safe() -> void:
+	## Cocking hammer twice should not cause errors (idempotent)
+	tutorial._has_revolver = true
+	tutorial.set_initial_step_based_on_weapon(false)
+
+	tutorial.on_hammer_cocked()
+	tutorial.on_hammer_cocked()  # Second call should be ignored
+
+	assert_false(tutorial.is_hint_active(MockTutorialLevel.HINT_HAMMER_COCK),
+		"Hammer hint still gone after double cock")
+
+
+func test_revolver_complete_flow_with_hammer_cock() -> void:
+	## Full revolver flow: cock hammer first, then reload, then grenade
+	tutorial._has_revolver = true
+	tutorial.set_initial_step_based_on_weapon(false)
+
+	# Cock hammer — only hammer hint disappears
+	tutorial.on_hammer_cocked()
+
+	assert_false(tutorial.is_hint_active(MockTutorialLevel.HINT_HAMMER_COCK),
+		"Hammer hint dismissed after cock")
+	assert_true(tutorial.is_hint_active(MockTutorialLevel.HINT_RELOAD),
+		"Reload hint remains")
+	assert_true(tutorial.is_hint_active(MockTutorialLevel.HINT_GRENADE),
+		"Grenade hint remains")
+
+	# Complete reload — only reload hint disappears
+	tutorial.on_reload_completed()
+
+	assert_false(tutorial.is_hint_active(MockTutorialLevel.HINT_RELOAD),
+		"Reload hint dismissed after reload")
+	assert_true(tutorial.is_hint_active(MockTutorialLevel.HINT_GRENADE),
+		"Grenade hint still visible")
+
+	# Throw grenade — complete tutorial
+	tutorial.on_grenade_thrown()
+
+	assert_true(tutorial.is_tutorial_complete(),
+		"Tutorial completes after all actions")
+	assert_false(tutorial.is_any_hint_active(),
+		"No hints remain after completion")
 
 
 # ============================================================================


### PR DESCRIPTION
Fixes #808 — addresses all feedback from owner comments.

## Changes

### 1. Bug fix: Grenade hint disappears when thrown before reload
**Reported:** \"if you throw the grenade first, the grenade throw hint does not disappear\"

Previously `_on_player_grenade_thrown()` only handled the `THROW_GRENADE` step. If the player threw the grenade during the `RELOAD` step, the handler returned early and the hint remained.

**Fix:** The grenade handler now accepts both `RELOAD` and `THROW_GRENADE` steps. When grenade is thrown early (during RELOAD), the grenade hint dismisses immediately and the level waits for reload completion. When reload completes after the grenade was already thrown, the tutorial goes straight to COMPLETED.

### 2. Revolver hammer cock hint
**Requested:** \"Add the line 'to cock the hammer press RMB' when the revolver is picked up\"
**Fix:** Added `HINT_HAMMER_COCK` constant with text `[ПКМ] Взведи курок` shown as a separate line alongside the reload hint for the revolver. The hammer cock hint is now **dismissed when the player actually cocks the hammer** (via `HammerCocked` signal from the Revolver weapon). Reload completion also dismisses it as a fallback.

### 3. Tutorial lines on Laboratory map (starting level)
**Requested:** \"Fix: Lab tutorial should be the same as Tutorial — weapon-dependent, teach grenade throwing, no walk/shoot hints\"

Completely reworked the Laboratory tutorial to mirror `tutorial_level.gd`:
- **Removed** walk (`[WASD]`) and shoot (`[ЛКМ]`) hints (owner request)
- **Added** weapon-dependent reload hints (same text as Tutorial level per weapon type)
- **Added** grenade throw hint shown simultaneously with reload hint
- **Added** hammer cock hint for revolver — dismissed on `HammerCocked` signal
- **Added** bolt cycle hint for sniper rifle — dismissed on `BoltStepChanged` signal
- **Added** full state machine: RELOAD → THROW_GRENADE → COMPLETED
- Connected to `GrenadeThrown`, `HammerCocked`, `BoltStepChanged` signals

## Files Changed

`scripts/levels/tutorial_level.gd`
- Connect to `HammerCocked` signal in `_connect_player_signals()` for revolver
- Add `_on_revolver_hammer_cocked()` handler that dismisses `HINT_HAMMER_COCK`

`scripts/levels/labyrinth_level.gd`
- Replace simple move/shoot/reload hints with full weapon-dependent tutorial system
- Add `TutorialStep` enum, weapon type flags, hint constants mirroring tutorial_level.gd
- Add `_setup_tutorial_hints()` using weapon-aware hint system
- Add `_on_tutorial_reload_completed()`, `_on_tutorial_grenade_thrown()`, `_on_tutorial_hammer_cocked()`, `_on_tutorial_sniper_bolt_step_changed()`
- Connect to `GrenadeThrown`, `HammerCocked`, `BoltStepChanged` signals in `_setup_player_tracking()`
- Add Revolver detection to weapon setup

`tests/unit/test_tutorial_level.gd`
- Add `on_hammer_cocked()` to `MockTutorialLevel`
- Add tests: hammer cocked dismisses hint, full flow with cock+reload+grenade

`tests/unit/test_level_scripts.gd`
- Update `MockLabyrinthLevel` to weapon-dependent tutorial system
- Add tests: no walk/shoot hints, reload+grenade flow, revolver hammer hint, grenade-first flow

## Test plan
- [ ] Grenade thrown before reload: grenade hint disappears immediately; reload hint stays; tutorial completes after reload
- [ ] Revolver tutorial: reload + hammer cock + grenade hints shown simultaneously; cocking hammer (RMB) dismisses hammer hint; reload dismisses reload hint; grenade hint remains until thrown
- [ ] Laboratory level: shows weapon-specific reload + grenade hints (no walk/shoot hints); hammer hint for revolver dismissed on RMB; tutorial completes after reload + grenade
- [ ] All existing tutorial flows (assault rifle, sniper, shotgun, default) continue to work
- [ ] Unit tests in `tests/unit/test_tutorial_level.gd` and `tests/unit/test_level_scripts.gd` pass