### PR TITLE
Fix CranePlatform room on Docks map (issue #859)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/859
-Your prepared branch: issue-859-adafaa3c179e
-Your prepared working directory: /tmp/gh-issue-solver-1771531358700
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary

Fixes two bugs with the **CranePlatform** room on the Docks map (issue #859):

1. **Missing entrance**: The CranePlatform was a fully enclosed room with enemies inside but no way for the player to enter. Fixed by splitting the bottom wall (`WallBottom`) into two halves (`WallBottomL` and `WallBottomR`) with a **100 px gap** in the center, creating an entrance.

2. **Invisible corner collision squares**: The vertical side walls (`WallLeft`, `WallRight`) had a collision shape height of **400 px**, while the visible `ColorRect` was only **340 px** tall (±170). This caused 30 px of invisible collision sticking out at each corner, blocking the player when walking along the wall. Fixed by resizing `RectangleShape2D_warehouse_wall_v` from `24×400` to `24×340` to match the visual.

## Changes

- `scenes/levels/DocksLevel.tscn`
  - Updated `load_steps` from 21 → 22 (one new sub-resource added)
  - `RectangleShape2D_warehouse_wall_v`: size `Vector2(24, 400)` → `Vector2(24, 340)`
  - Added `RectangleShape2D_crane_entrance_wall`: size `Vector2(150, 24)` (new shape for entrance wall halves)
  - Replaced single `WallBottom` node with `WallBottomL` (x=-125) and `WallBottomR` (x=+125), each 150 px wide, leaving a 100 px entrance gap

## Test plan

- [ ] Open DocksLevel in Godot editor and verify CranePlatform shows a visible opening at the bottom wall
- [ ] Run the game, navigate to CranePlatform area (top-left of map, around coordinates 400, 500), and confirm the player can enter the room through the bottom entrance
- [ ] Walk along the inner corners of the CranePlatform walls and confirm no invisible blocking squares

Issue Reference: Fixes Jhon-Crow/godot-topdown-MVP#859

🤖 Generated with [Claude Code](https://claude.com/claude-code)