### PR TITLE
на карте доки должно быть в 2 раза больше патронов

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/866
-Your prepared branch: issue-866-359750e09d0e
-Your prepared working directory: /tmp/gh-issue-solver-1771941907993
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary

Fixes #866

На карте «Доки» теперь в 2 раза больше патронов для всех оружий, **кроме пистолета с глушителем**.

## What changed

Added `_configure_docks_weapon_ammo()` function to `scripts/levels/docks_level.gd` that doubles the starting magazine count for the player's weapon when playing the Docks level.

### Affected weapons (2x ammo):
- Shotgun
- Mini UZI
- Sniper Rifle (ASVK)
- M16 Assault Rifle
- AK + GL
- Makarov PM (retains existing 2.5x bonus from Issue #636, which exceeds 2x)

### Unchanged weapons:
- **Silenced Pistol** — uses enemy-count-based ammo (`ConfigureAmmoForEnemyCount`) and is excluded as per the issue requirement

## Implementation details

The solution follows the same pattern used in `castle_level.gd` for its 2x ammo requirement. The `_configure_docks_weapon_ammo()` function:
1. Gets the weapon's `StartingMagazineCount` (default: 4)
2. Doubles it
3. Calls `ReinitializeMagazines()` with the doubled count
4. Updates the UI ammo labels

The function is called:
- When a new weapon is instantiated in `_setup_selected_weapon()`
- When the C# Player already has the correct weapon equipped (early-return path)

## Test plan
- [ ] Play Docks level with Shotgun — verify doubled ammo
- [ ] Play Docks level with Mini UZI — verify doubled ammo
- [ ] Play Docks level with Sniper Rifle — verify doubled ammo
- [ ] Play Docks level with M16 — verify doubled ammo
- [ ] Play Docks level with AK+GL — verify doubled ammo
- [ ] Play Docks level with Makarov PM — verify at least 2x ammo (2.5x expected)
- [ ] Play Docks level with Silenced Pistol — verify ammo is enemy-count-based (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)