### PR TITLE
fix: laser sight now stops at enemies instead of passing through them

### DIFF
--- a/Scripts/Weapons/AKGL.cs
+++ b/Scripts/Weapons/AKGL.cs
@@ -607,8 +607,9 @@ public partial class AKGL : BaseWeapon
             var result = spaceState.IntersectRay(query);
             if (result.Count > 0)
             {
+                // Extend 4px into the hit body so the laser visually penetrates the surface
                 Vector2 hitPosition = (Vector2)result["position"];
-                endPoint = hitPosition - GlobalPosition;
+                endPoint = hitPosition - GlobalPosition + laserDirection * 4.0f;
             }
         }
 

--- a/Scripts/Weapons/AssaultRifle.cs
+++ b/Scripts/Weapons/AssaultRifle.cs
@@ -387,9 +387,10 @@ public partial class AssaultRifle : BaseWeapon
 
         if (result.Count > 0)
         {
-            // Hit an obstacle, shorten the laser
+            // Hit an obstacle or enemy, shorten the laser
+            // Extend 4px into the hit body so the laser visually penetrates the surface
             Vector2 hitPosition = (Vector2)result["position"];
-            endPoint = hitPosition - GlobalPosition;
+            endPoint = hitPosition - GlobalPosition + laserDirection * 4.0f;
         }
 
         // Update the laser sight line points (in local coordinates)

--- a/Scripts/Weapons/MakarovPM.cs
+++ b/Scripts/Weapons/MakarovPM.cs
@@ -577,8 +577,9 @@ public partial class MakarovPM : BaseWeapon
             var result = spaceState.IntersectRay(query);
             if (result.Count > 0)
             {
+                // Extend 4px into the hit body so the laser visually penetrates the surface
                 Vector2 hitPosition = (Vector2)result["position"];
-                endPoint = hitPosition - GlobalPosition;
+                endPoint = hitPosition - GlobalPosition + laserDirection * 4.0f;
             }
         }
 

--- a/Scripts/Weapons/MiniUzi.cs
+++ b/Scripts/Weapons/MiniUzi.cs
@@ -536,8 +536,9 @@ public partial class MiniUzi : BaseWeapon
             var result = spaceState.IntersectRay(query);
             if (result.Count > 0)
             {
+                // Extend 4px into the hit body so the laser visually penetrates the surface
                 Vector2 hitPosition = (Vector2)result["position"];
-                endPoint = hitPosition - GlobalPosition;
+                endPoint = hitPosition - GlobalPosition + laserDirection * 4.0f;
             }
         }
 

--- a/Scripts/Weapons/SilencedPistol.cs
+++ b/Scripts/Weapons/SilencedPistol.cs
@@ -348,9 +348,10 @@ public partial class SilencedPistol : BaseWeapon
 
         if (result.Count > 0)
         {
-            // Hit an obstacle, shorten the laser
+            // Hit an obstacle or enemy, shorten the laser
+            // Extend 4px into the hit body so the laser visually penetrates the surface
             Vector2 hitPosition = (Vector2)result["position"];
-            endPoint = hitPosition - GlobalPosition;
+            endPoint = hitPosition - GlobalPosition + laserDirection * 4.0f;
         }
 
         // Update the laser sight line points (in local coordinates)

--- a/Scripts/Weapons/SniperRifle.cs
+++ b/Scripts/Weapons/SniperRifle.cs
@@ -571,8 +571,9 @@ public partial class SniperRifle : BaseWeapon
             var result = spaceState.IntersectRay(query);
             if (result.Count > 0)
             {
+                // Extend 4px into the hit body so the laser visually penetrates the surface
                 Vector2 hitPosition = (Vector2)result["position"];
-                endPoint = hitPosition - GlobalPosition;
+                endPoint = hitPosition - GlobalPosition + laserDirection * 4.0f;
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #857: laser sights passed through enemies instead of stopping at them.

**Root cause:** All `UpdateLaserSight()` methods in the 6 weapon files used collision mask `4` (obstacles/layer 3 only) for their raycasts. Enemies reside on physics layer 2 (value `2`), so the raycast never detected them and the laser beam rendered past enemy bodies.

**Fix (commit 1):** Updated collision mask to `6` (`4 | 2`) — obstacles + enemies — in all affected weapon files.

**Fix (commit 2):** Per owner feedback, extended the laser endpoint 4px past the raycast hit point (in the aim direction) so the laser visually penetrates the enemy surface slightly for a more natural look, rather than stopping exactly at the collision boundary edge.

**Affected files:**

- `Scripts/Weapons/AssaultRifle.cs`
- `Scripts/Weapons/SilencedPistol.cs`
- `Scripts/Weapons/SniperRifle.cs` (laser sight only; hitscan was already correct)
- `Scripts/Weapons/MakarovPM.cs`
- `Scripts/Weapons/AKGL.cs`
- `Scripts/Weapons/MiniUzi.cs`

This matches the existing pattern used by `SniperRifle.FireHitscan()` which already uses `combinedMask = wallMask | enemyBodyMask = 4 | 2 = 6`.

**Collision layer reference (project.godot):**
- Layer 1 = player → value 1
- Layer 2 = enemies → value 2
- Layer 3 = obstacles → value 4

Fixes Jhon-Crow/godot-topdown-MVP#857