### PR TITLE
fix: prevent enemy suppression through walls (Issue #928)

### DIFF
--- a/scripts/objects/enemy.gd
+++ b/scripts/objects/enemy.gd
@@ -4114,32 +4114,11 @@ func _initialize_idle_scan_targets() -> void:
 
 ## Called when a bullet enters the threat sphere.
 func _on_threat_area_entered(area: Area2D) -> void:
-	if "shooter_id" in area and area.shooter_id == get_instance_id():
-		return
-	# Check if a wall blocks line of sight between the bullet and the enemy.
-	# Enemies should not be suppressed by bullets they cannot "feel" due to a wall.
-	# However, if a bullet flies nearby (even past cover), it should still cause suppression
-	# as long as there is no wall directly between the bullet and the enemy.
-	if _is_wall_between_self_and(area.global_position):
-		_log_debug("Bullet in threat sphere blocked by wall — not suppressed")
-		return
+	if ("shooter_id" in area and area.shooter_id == get_instance_id()) or not _is_position_visible_to_enemy(area.global_position):
+		return  # Own bullet or wall blocking line of sight — no suppression
 	_bullets_in_threat_sphere.append(area)
 	_threat_memory_timer = THREAT_MEMORY_DURATION
 	_log_debug("Bullet entered threat sphere, starting reaction delay...")
-
-
-## Checks whether a wall (obstacle) lies between this enemy and the given world position.
-## Uses a raycast on collision layer 3 (mask 4), matching all other LOS checks in this file.
-## Returns true if a wall is found, false if the path is clear.
-func _is_wall_between_self_and(target_pos: Vector2) -> bool:
-	var space_state := get_world_2d().direct_space_state
-	var query := PhysicsRayQueryParameters2D.new()
-	query.from = global_position
-	query.to = target_pos
-	query.collision_mask = 4  # Only check obstacles (layer 3)
-	query.exclude = [self]
-	var result := space_state.intersect_ray(query)
-	return not result.is_empty()
 
 ## Called when a bullet exits the threat sphere.
 func _on_threat_area_exited(area: Area2D) -> void:


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/godot-topdown-MVP#928

### Problem

Enemies were being suppressed whenever a bullet entered their threat sphere (radius ~100px), **even when a wall separated the bullet from the enemy**. This produced unrealistic behaviour: an enemy completely shielded by a solid wall would still react to gunfire on the other side.

The issue required two conditions to hold simultaneously:
- An enemy behind a wall should **not** be suppressed if a wall blocks the line between the bullet and the enemy.
- An enemy in cover should still be suppressed by a near-miss (bullet flying past their threat zone) **as long as there is no wall between the enemy and the bullet**.

### Root Cause

`_on_threat_area_entered` in `scripts/objects/enemy.gd` appended every bullet that entered the threat sphere to `_bullets_in_threat_sphere` without checking for wall obstruction. There was no line-of-sight check against obstacles.

### Fix

Inlined a wall line-of-sight check into the existing guard condition at the top of `_on_threat_area_entered`, reusing the existing `_is_position_visible_to_enemy` helper (which already performs the same obstacle-layer raycast used everywhere else in the file):

```gdscript
func _on_threat_area_entered(area: Area2D) -> void:
    if ("shooter_id" in area and area.shooter_id == get_instance_id()) or not _is_position_visible_to_enemy(area.global_position):
        return  # Own bullet or wall blocking line of sight — no suppression
    _bullets_in_threat_sphere.append(area)
    _threat_memory_timer = THREAT_MEMORY_DURATION
    _log_debug("Bullet entered threat sphere, starting reaction delay...")
```

This reuses the existing `_is_position_visible_to_enemy` function (collision mask 4, obstacle layer only) instead of adding a new helper, keeping `enemy.gd` within the 5000-line CI architecture limit.

### Behaviour after the fix

| Scenario | Before | After |
|---|---|---|
| Enemy behind a wall, bullet on the other side | Suppressed ❌ | Not suppressed ✅ |
| Enemy in cover, bullet flies past (no wall between) | Suppressed ✅ | Suppressed ✅ |
| Direct shot at enemy (no wall) | Suppressed ✅ | Suppressed ✅ |

---
*This PR was created automatically by the AI issue solver*