### PR TITLE
fix: cursor stays visible after clicking Restart on score screen

### DIFF
--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -152,8 +152,11 @@ func on_player_death() -> void:
 
 
 ## Restarts the current scene.
+## Resets mouse mode to hidden before reloading so the cursor does not persist
+## from the score screen (Issue #905).
 func restart_scene() -> void:
 	_reset_stats()
+	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED_HIDDEN)
 	get_tree().reload_current_scene()
 
 

--- a/tests/unit/test_game_manager.gd
+++ b/tests/unit/test_game_manager.gd
@@ -62,11 +62,22 @@ class MockGameManager:
 			return WEAPON_SCENES[selected_weapon]
 		return WEAPON_SCENES["m16"]
 
+	## Tracks last mouse mode set (simulates Input.set_mouse_mode).
+	var last_mouse_mode: int = -1
+
+	## Tracks whether scene reload was requested.
+	var scene_reload_requested: bool = false
+
 	func _reset_stats() -> void:
 		kills = 0
 		shots_fired = 0
 		hits_landed = 0
 		player_alive = true
+
+	func restart_scene() -> void:
+		_reset_stats()
+		last_mouse_mode = Input.MOUSE_MODE_CONFINED_HIDDEN
+		scene_reload_requested = true
 
 
 var manager: MockGameManager
@@ -341,3 +352,38 @@ func test_unknown_weapon_returns_default_scene_path() -> void:
 	var path := manager.get_selected_weapon_scene_path()
 
 	assert_eq(path, "res://scenes/weapons/csharp/AssaultRifle.tscn", "Should return M16 path as fallback")
+
+
+# ============================================================================
+# Restart Scene Cursor Reset Tests (Issue #905)
+# ============================================================================
+
+
+func test_restart_scene_resets_mouse_mode_to_confined_hidden() -> void:
+	## Issue #905: After clicking restart on score screen, cursor must disappear.
+	## The score screen sets MOUSE_MODE_CONFINED (visible cursor for button interaction).
+	## restart_scene() must restore MOUSE_MODE_CONFINED_HIDDEN before reloading.
+	manager.restart_scene()
+
+	assert_eq(manager.last_mouse_mode, Input.MOUSE_MODE_CONFINED_HIDDEN,
+		"restart_scene() must set mouse mode to MOUSE_MODE_CONFINED_HIDDEN so cursor disappears on restart")
+
+
+func test_restart_scene_resets_stats() -> void:
+	manager.kills = 10
+	manager.shots_fired = 50
+	manager.hits_landed = 30
+	manager.player_alive = false
+
+	manager.restart_scene()
+
+	assert_eq(manager.kills, 0, "kills should be reset to 0 on restart")
+	assert_eq(manager.shots_fired, 0, "shots_fired should be reset to 0 on restart")
+	assert_eq(manager.hits_landed, 0, "hits_landed should be reset to 0 on restart")
+	assert_true(manager.player_alive, "player_alive should be reset to true on restart")
+
+
+func test_restart_scene_triggers_scene_reload() -> void:
+	manager.restart_scene()
+
+	assert_true(manager.scene_reload_requested, "restart_scene() must trigger scene reload")


### PR DESCRIPTION
## Root Cause

After the score screen is shown, the cursor is set to `MOUSE_MODE_CONFINED` (visible) so the player can click the navigation buttons. When the Restart button is pressed, `GameManager.restart_scene()` calls `get_tree().reload_current_scene()`.

Because `GameManager` is an **autoload singleton**, its `_ready()` method (which sets `Input.MOUSE_MODE_CONFINED_HIDDEN`) is **not re-executed on scene reload** — it only runs once at game startup. So the mouse mode stays as `MOUSE_MODE_CONFINED` (visible cursor) throughout the restarted level.

## Fix

Added `Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED_HIDDEN)` to `GameManager.restart_scene()` before `reload_current_scene()`, explicitly restoring the hidden cursor state that gameplay requires.

**Changed file:** `scripts/autoload/game_manager.gd`

```gdscript
func restart_scene() -> void:
    _reset_stats()
    Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED_HIDDEN)  # Issue #905: hide cursor on restart
    get_tree().reload_current_scene()
```

This fix also covers restarts triggered by:
- The Q key shortcut (handled in `GameManager._input()`)
- Player death (`GameManager.on_player_death()`)
- All level scripts calling `GameManager.restart_scene()`

## Tests

Added 3 regression tests to `tests/unit/test_game_manager.gd`:

- `test_restart_scene_resets_mouse_mode_to_confined_hidden` — verifies the cursor mode is reset to hidden
- `test_restart_scene_resets_stats` — verifies stats are cleared on restart
- `test_restart_scene_triggers_scene_reload` — verifies scene reload is requested

## Issue Reference

Fixes Jhon-Crow/godot-topdown-MVP#905

---
*This PR was created automatically by the AI issue solver*