### PR TITLE
perf: optimize FPS drops after grenade explosion - case study and fixes (Issue #966)

### DIFF
--- a/docs/case-studies/issue-966/README.md
+++ b/docs/case-studies/issue-966/README.md
@@ -1,0 +1,168 @@
+# Case Study: Issue #966 - FPS Drops After Grenade Explosion
+
+## Summary
+
+This case study analyzes FPS drops (10-29 fps) that occur after defensive grenade explosions in the game. Initial investigation focused on blood decal spawning, but further analysis revealed multiple root causes that contribute to the performance degradation.
+
+## Timeline of Events
+
+### Initial Report (game_log_20260305_222912.txt)
+- **22:29:14** - First FPS drop (10 fps) occurs right after particle shader warmup completes
+- **22:29:23** - Player throws defensive grenade, explosion occurs
+- **22:29:23-22:29:24** - Multiple FPS drops (24 fps, 22 fps) following grenade explosion
+- Pattern repeats throughout gameplay with each grenade explosion
+
+### After Attempted Fix (game_log_20260305_230043.txt)
+- Blood decal pooling implemented but broken (all decals at position 0,0)
+- **23:01:40** - FPS still drops to 7 fps despite "optimized" blood spawning
+- Confirms blood spawning is NOT the primary cause
+
+### Second Test Run (game_log_20260305_230201.txt)
+- **23:02:03** - FPS drop (18 fps) occurs right after particle shader warmup
+- Pattern confirms shader warmup is a consistent source of FPS drops
+
+## Root Cause Analysis
+
+### Identified Causes (Ranked by Impact)
+
+#### 1. Ragdoll Physics Activation (PRIMARY CAUSE)
+**Evidence:** Lines 839-854 in log 2 show:
+```
+[23:01:39] Enemy2, Enemy3, Enemy4 - Ragdoll activated
+[23:01:40] FPS Drop detected: 7 fps
+```
+
+**Technical Details:**
+- Each dying enemy creates 4 RigidBody2D nodes (body, head, left_arm, right_arm)
+- Each dying enemy creates 3 PinJoint2D connections
+- When 3 enemies die simultaneously: 12 RigidBody2D + 9 PinJoint2D created at once
+- RigidBody2D creation is expensive due to physics engine setup
+- Physics engine must recalculate collision pairs for all new bodies
+
+**Source:** `scripts/components/death_animation_component.gd` lines 310-367
+
+#### 2. Particle Shader Warmup (~1300ms)
+**Evidence:** Log lines show consistent pattern:
+```
+[22:29:13] Particle shader warmup complete: 7 effects warmed up in 1290 ms
+[22:29:14] FPS Drop detected: 10 fps
+```
+
+**Technical Details:**
+- GPU shader compilation happens during warmup
+- Takes 1290-1298ms across all test runs
+- Causes 10-18 fps drops at level start
+- Already implemented (Issue #343) but still impacts performance
+
+**Source:** `scripts/autoload/impact_effects_manager.gd` lines 871-1041
+
+#### 3. Shrapnel Spawning (40 projectiles at once)
+**Evidence:** Log shows synchronous spawning:
+```
+[23:01:38] Spawned shrapnel #1 at angle 3.4 degrees
+[23:01:38] Spawned shrapnel #2 at angle 21.7 degrees
+... (40 total)
+```
+
+**Technical Details:**
+- Defensive grenade spawns 40 shrapnel pieces synchronously
+- Each shrapnel is an Area2D with collision detection
+- Object pooling exists but not always used (falls back to instantiation)
+- Even with pooling, activating 40 physics objects at once is expensive
+
+**Source:** `scripts/projectiles/defensive_grenade.gd` lines 200-246
+
+#### 4. Blood Decal Timer Creation (SECONDARY CAUSE)
+**Technical Details:**
+- Each blood effect schedules 10-20 delayed decal spawns
+- Uses `await tree.create_timer(delay).timeout` for each decal
+- With multiple enemies hit, creates 100+ individual SceneTreeTimer objects
+- Timer objects add memory and processing overhead
+
+**Source:** `scripts/autoload/impact_effects_manager.gd` lines 540-596
+
+## Why Blood Decal Optimization Alone Failed
+
+The initial optimization attempt focused on blood decal spawning:
+1. Implemented object pooling for blood decals
+2. Implemented batch processing (5 decals per frame)
+
+However, FPS still dropped to 7 fps because:
+- Ragdoll activation (12 RigidBody2D at once) was the primary cause
+- Shrapnel spawning (40 Area2D at once) added significant load
+- Blood optimization only addressed a secondary contributing factor
+
+## Recommended Solutions
+
+### Option A: Ragdoll Optimization (Highest Impact)
+1. **Stagger ragdoll creation across frames**
+   - Instead of creating all body parts at once, spread across 3-4 frames
+   - Use a queue-based approach similar to blood decal batching
+
+2. **Simplify ragdoll physics**
+   - Reduce from 4 body parts to 2 (body + head)
+   - Or use a single RigidBody2D with animated sprite
+
+3. **Ragdoll pooling**
+   - Pre-create ragdoll bodies and reuse them
+   - Return to pool after death animation completes
+
+### Option B: Shrapnel Spawning Optimization (Medium Impact)
+1. **Stagger shrapnel spawning**
+   - Spawn 10 shrapnel per frame instead of 40 at once
+   - Spread across 4 frames (40/10 = 4 frames)
+
+2. **Ensure pooling is always used**
+   - Verify ProjectilePoolManager is available
+   - Fall back to staggered instantiation only if pool exhausted
+
+### Option C: Blood Decal Timer Optimization (Lower Impact)
+1. **Replace individual timers with queue-based processing**
+   - Single _process() function manages all pending decals
+   - Similar to existing batch processing but without timers
+
+2. **Limit concurrent blood effects**
+   - Cap maximum blood particles during explosions
+   - Reduce from 20 decals per kill to 10
+
+## Performance Optimization Research
+
+According to [Godot performance documentation](https://docs.godotengine.org/en/stable/tutorials/performance/general_optimization.html):
+- Deeply nested scene hierarchies increase processing overhead
+- Improperly configured collision layers cause unexpected physics interactions
+- Free unused resources explicitly and use object pooling for frequently instantiated objects
+
+From [Godot object pooling guide](https://uhiyama-lab.com/en/notes/godot/godot-object-pooling-basics/):
+- Object Pooling eliminates costly "creation" and "destruction" processes
+- Most useful for high-frequency, short-lived objects
+- Replaces instantiation spikes with light state-reset processing
+
+From [Godot FPS management guide](https://uhiyama-lab.com/en/notes/godot/godot-fps-management-vsync-settings/):
+- Physics interpolation (native in Godot 4.3) helps smooth movement
+- The asynchronicity between physics ticks and render frames causes jitter
+- Spreading object creation across frames prevents concentration of load
+
+## Files Analyzed
+
+- `docs/case-studies/issue-966/game_log_20260305_222912.txt` - Original report (4111 lines)
+- `docs/case-studies/issue-966/game_log_20260305_230043.txt` - After attempted fix (1647 lines)
+- `docs/case-studies/issue-966/game_log_20260305_230201.txt` - Second test run (2011 lines)
+
+## Related Code
+
+- `scripts/autoload/impact_effects_manager.gd` - Blood effects and shader warmup
+- `scripts/projectiles/defensive_grenade.gd` - Grenade explosion and shrapnel
+- `scripts/components/death_animation_component.gd` - Ragdoll physics
+- `scripts/projectiles/shrapnel.gd` - Shrapnel projectile
+- `scripts/autoload/projectile_pool_manager.gd` - Object pooling system
+
+## Conclusion
+
+The FPS drops after grenade explosions are caused by multiple factors working together:
+
+1. **Ragdoll activation** is the primary cause (creates 12+ physics bodies at once)
+2. **Shrapnel spawning** adds additional load (40 Area2D at once)
+3. **Blood decal timers** contribute but are secondary
+4. **Shader warmup** causes initial FPS drop at level start (separate issue)
+
+The most impactful fix would be to stagger ragdoll creation across multiple frames, similar to how blood decal batching was intended to work.

--- a/docs/case-studies/issue-966/game_log_20260305_222912.txt
+++ b/docs/case-studies/issue-966/game_log_20260305_222912.txt
@@ -1,0 +1,4111 @@
+[22:29:12] [INFO] ============================================================
+[22:29:12] [INFO] GAME LOG STARTED
+[22:29:12] [INFO] ============================================================
+[22:29:12] [INFO] Timestamp: 2026-03-05T22:29:12
+[22:29:12] [INFO] Log file: I:/Загрузки/godot exe/оптимизация/game_log_20260305_222912.txt
+[22:29:12] [INFO] Executable: I:/Загрузки/godot exe/оптимизация/Godot-Top-Down-Template.exe
+[22:29:12] [INFO] OS: Windows
+[22:29:12] [INFO] Debug build: false
+[22:29:12] [INFO] Engine version: 4.3-stable (official)
+[22:29:12] [INFO] Project: Godot Top-Down Template
+[22:29:12] [INFO] ------------------------------------------------------------
+[22:29:12] [INFO] [GameManager] GameManager ready
+[22:29:12] [INFO] [ScoreManager] ScoreManager ready
+[22:29:12] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[22:29:12] [INFO] [DifficultyManager] Loaded difficulty: Hard (value: 2)
+[22:29:12] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[22:29:12] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[22:29:12] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[22:29:12] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[22:29:12] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:29:12] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[22:29:12] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[22:29:12] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[22:29:12] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[22:29:12] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[22:29:12] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[22:29:12] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[22:29:12] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:29:12] [INFO] [LastChance] Last chance shader loaded successfully
+[22:29:12] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[22:29:12] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[22:29:12] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[22:29:12] [INFO] [LastChance]   Sepia intensity: 0.70
+[22:29:12] [INFO] [LastChance]   Brightness: 0.60
+[22:29:12] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[22:29:12] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[22:29:12] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[22:29:12] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[22:29:12] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: true, Invincibility: false, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: true, FPS drop logging: true
+[22:29:12] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.29, music: 1.00
+[22:29:12] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[22:29:12] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[22:29:12] [INFO] [CinemaEffects] Created effects layer at layer 99
+[22:29:12] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[22:29:12] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[22:29:12] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[22:29:12] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[22:29:12] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[22:29:12] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[22:29:12] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[22:29:12] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[22:29:12] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[22:29:12] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[22:29:12] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[22:29:12] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[22:29:12] [INFO] [GrenadeTimerHelper] Autoload ready
+[22:29:12] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[22:29:12] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[22:29:12] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[22:29:12] [INFO] [PowerFantasy]   Kill effect duration: 300ms
+[22:29:12] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[22:29:12] [INFO] [ProgressManager] ProgressManager ready, loaded 5 entries
+[22:29:12] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[22:29:12] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[22:29:12] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[22:29:12] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[22:29:12] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[22:29:12] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[22:29:12] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[22:29:12] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[22:29:12] [INFO] [PersistManager] Restored unlocked weapon: m16
+[22:29:12] [INFO] [PersistManager] Restored unlocked weapon: shotgun
+[22:29:12] [INFO] [PersistManager] Restored unlocked weapon: mini_uzi
+[22:29:12] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[22:29:12] [INFO] [PersistManager] Restored unlocked weapon: sniper
+[22:29:12] [INFO] [PersistManager] Restored unlocked weapon: revolver
+[22:29:12] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[22:29:12] [INFO] [GameManager] Weapon selected: silenced_pistol
+[22:29:12] [INFO] [PersistManager] Restored selected weapon: silenced_pistol
+[22:29:12] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[22:29:12] [INFO] [PersistManager] Restored unlocked grenade type: 1
+[22:29:12] [INFO] [PersistManager] Restored unlocked grenade type: 2
+[22:29:12] [INFO] [PersistManager] Restored unlocked grenade type: 3
+[22:29:12] [INFO] [GrenadeManager] Grenade type changed from Flashbang to F-1 Grenade
+[22:29:12] [INFO] [PersistManager] Restored selected grenade type: 2
+[22:29:12] [INFO] [PersistManager] Restored unlocked active item type: 0
+[22:29:12] [INFO] [PersistManager] Restored unlocked active item type: 1
+[22:29:12] [INFO] [PersistManager] Restored unlocked active item type: 2
+[22:29:12] [INFO] [PersistManager] Restored unlocked active item type: 3
+[22:29:12] [INFO] [PersistManager] Restored unlocked active item type: 4
+[22:29:12] [INFO] [PersistManager] Restored unlocked active item type: 5
+[22:29:12] [INFO] [PersistManager] Restored unlocked active item type: 6
+[22:29:12] [INFO] [PersistManager] Restored unlocked active item type: 7
+[22:29:12] [INFO] [PersistManager] Restored unlocked active item type: 8
+[22:29:12] [INFO] [ActiveItemManager] Active item changed from None to Homing Bullets
+[22:29:12] [INFO] [PersistManager] Restored selected active item type: 2
+[22:29:12] [INFO] [PersistManager] State loaded successfully
+[22:29:12] [INFO] [PersistManager] PersistManager ready
+[22:29:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:12] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:29:12] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:29:12] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:29:12] [ENEMY] [Enemy1] Death animation component initialized
+[22:29:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:12] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:29:12] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:29:12] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:29:12] [ENEMY] [Enemy2] Death animation component initialized
+[22:29:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:12] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:29:12] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:29:12] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:29:12] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:12] [ENEMY] [Enemy3] Death animation component initialized
+[22:29:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:12] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:29:12] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:29:12] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:29:12] [ENEMY] [Enemy4] Death animation component initialized
+[22:29:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:12] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[22:29:12] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[22:29:12] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[22:29:12] [ENEMY] [Enemy5] Death animation component initialized
+[22:29:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:12] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:29:12] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:29:12] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:29:12] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[22:29:12] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:29:12] [INFO] [Player.Weapon] GameManager weapon selection: silenced_pistol (SilencedPistol)
+[22:29:12] [INFO] [Player.Weapon] Removed default MakarovPM
+[22:29:12] [INFO] [Player.Weapon] Equipped SilencedPistol (ammo: 13/13)
+[22:29:12] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:29:12] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:29:12] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:29:12] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:29:12] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:29:12] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:29:12] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[22:29:12] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[22:29:12] [INFO] [Player.Homing] Homing activation sound loaded
+[22:29:12] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[22:29:12] [INFO] [Player.Homing] Homing bullets equipped, charges: 6/6
+[22:29:12] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[22:29:12] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[22:29:12] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[22:29:12] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[22:29:12] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[22:29:12] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[22:29:12] [INFO] [Player] Ready! Ammo: 13/13, Grenades: 1/3, Health: 3/4
+[22:29:12] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:29:12] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[22:29:12] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[22:29:12] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:29:12] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:29:12] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:29:12] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:29:12] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[22:29:12] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[22:29:12] [INFO] [LabyrinthLevel] Setting up weapon: silenced_pistol
+[22:29:12] [INFO] [LabyrinthLevel] SilencedPistol already equipped by C# Player - skipping GDScript weapon swap
+[22:29:12] [INFO] [ScoreManager] Level started with 5 enemies
+[22:29:12] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[22:29:12] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[22:29:12] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[22:29:12] [INFO] [ReplayManager] Replay data cleared
+[22:29:12] [INFO] [LabyrinthLevel] Previous replay data cleared
+[22:29:12] [INFO] [ReplayManager] Detected player weapon: Silenced Pistol
+[22:29:12] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[22:29:12] [INFO] [ReplayManager] Level: LabyrinthLevel
+[22:29:12] [INFO] [ReplayManager] Player: Player (valid: True)
+[22:29:12] [INFO] [ReplayManager] Enemies count: 5
+[22:29:12] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/silenced_pistol_topdown.png
+[22:29:12] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[22:29:12] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[22:29:12] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[22:29:12] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[22:29:12] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[22:29:12] [INFO] [LabyrinthLevel] Replay recording started successfully
+[22:29:12] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[22:29:12] [INFO] [EnemyGrenade] Target (600, 1000) not in enemy FOV - skipping throw
+[22:29:12] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (600, 1000) - skipping throw
+[22:29:13] [INFO] [LastChance] Issue #937: Cached 28 StaticBody2D nodes for fast freeze traversal
+[22:29:13] [INFO] [CinemaEffects] Found player node: Player
+[22:29:13] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[22:29:13] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/BuildingLevel.tscn
+[22:29:13] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:13] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:29:13] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:29:13] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:29:13] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:29:13] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[22:29:13] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:29:13] [INFO] [PenultimateHit] Shader warmup complete in 711 ms
+[22:29:13] [INFO] [LastChance] Shader warmup complete in 710 ms
+[22:29:13] [INFO] [CinemaEffects] Cinema shader warmup complete in 627 ms
+[22:29:13] [INFO] [FlashbangPlayer] Shader warmup complete in 618 ms
+[22:29:13] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:29:13] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:13] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:29:13] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:29:13] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[22:29:13] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[22:29:13] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[22:29:13] [ENEMY] [Enemy1] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:29:13] [ENEMY] [Enemy2] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:29:13] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:13] [ENEMY] [Enemy3] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:29:13] [ENEMY] [Enemy4] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[22:29:13] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[22:29:13] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[22:29:13] [ENEMY] [Grenadier] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:29:13] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:13] [ENEMY] [Enemy6] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:29:13] [ENEMY] [Enemy7] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:29:13] [ENEMY] [Enemy8] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:29:13] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:13] [ENEMY] [Enemy9] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:29:13] [ENEMY] [Enemy10] Death animation component initialized
+[22:29:13] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:13] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:29:13] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:29:13] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:29:13] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[22:29:13] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:29:13] [INFO] [Player.Weapon] GameManager weapon selection: silenced_pistol (SilencedPistol)
+[22:29:13] [INFO] [Player.Weapon] Removed default MakarovPM
+[22:29:13] [INFO] [Player.Weapon] Equipped SilencedPistol (ammo: 13/13)
+[22:29:13] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:29:13] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:29:13] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:29:13] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:29:13] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:29:13] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:29:13] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[22:29:13] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[22:29:13] [INFO] [Player.Homing] Homing activation sound loaded
+[22:29:13] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[22:29:13] [INFO] [Player.Homing] Homing bullets equipped, charges: 6/6
+[22:29:13] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[22:29:13] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[22:29:13] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[22:29:13] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[22:29:13] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[22:29:13] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[22:29:13] [INFO] [Player] Ready! Ammo: 13/13, Grenades: 1/3, Health: 2/4
+[22:29:13] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:29:13] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:29:13] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:29:13] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:29:13] [INFO] [BuildingLevel] Setting up weapon: silenced_pistol
+[22:29:13] [INFO] [BuildingLevel] SilencedPistol already equipped by C# Player - skipping GDScript weapon swap
+[22:29:13] [INFO] [ScoreManager] Level started with 10 enemies
+[22:29:13] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[22:29:13] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[22:29:13] [INFO] [ReplayManager] Replay data cleared
+[22:29:13] [INFO] [BuildingLevel] Previous replay data cleared
+[22:29:13] [INFO] [ReplayManager] Detected player weapon: Silenced Pistol
+[22:29:13] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[22:29:13] [INFO] [ReplayManager] Level: BuildingLevel
+[22:29:13] [INFO] [ReplayManager] Player: Player (valid: True)
+[22:29:13] [INFO] [ReplayManager] Enemies count: 10
+[22:29:13] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/silenced_pistol_topdown.png
+[22:29:13] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[22:29:13] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[22:29:13] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[22:29:13] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[22:29:13] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[22:29:13] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[22:29:13] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[22:29:13] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[22:29:13] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[22:29:13] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[22:29:13] [INFO] [BuildingLevel] Replay recording started successfully
+[22:29:13] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:29:13] [INFO] [LastChance] Issue #937: Cached 44 StaticBody2D nodes for fast freeze traversal
+[22:29:13] [INFO] [CinemaEffects] Found player node: Player
+[22:29:13] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[22:29:13] [ENEMY] [Enemy1] Registered as sound listener
+[22:29:13] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[22:29:13] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[22:29:13] [ENEMY] [Enemy2] Registered as sound listener
+[22:29:13] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:29:13] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[22:29:13] [ENEMY] [Enemy3] Registered as sound listener
+[22:29:13] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[22:29:13] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[22:29:13] [ENEMY] [Enemy4] Registered as sound listener
+[22:29:13] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[22:29:13] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[22:29:13] [ENEMY] [Grenadier] Registered as sound listener
+[22:29:13] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:29:13] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[22:29:13] [ENEMY] [Enemy6] Registered as sound listener
+[22:29:13] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:29:13] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[22:29:13] [ENEMY] [Enemy7] Registered as sound listener
+[22:29:13] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[22:29:13] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[22:29:13] [ENEMY] [Enemy8] Registered as sound listener
+[22:29:13] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[22:29:13] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[22:29:13] [ENEMY] [Enemy9] Registered as sound listener
+[22:29:13] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[22:29:13] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:29:13] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[22:29:13] [ENEMY] [Enemy10] Registered as sound listener
+[22:29:13] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:29:13] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:29:13] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[22:29:13] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:13] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:13] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:13] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:13] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:13] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:13] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:13] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:13] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:29:13] [INFO] [Player] Detected weapon: Silenced Pistol (Pistol pose)
+[22:29:13] [INFO] [Player] Applied Pistol arm pose: Left=(16, 6), Right=(4, 6)
+[22:29:13] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:29:13] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:29:13] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:29:13] [INFO] [LastChance] Found player: Player
+[22:29:13] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:29:13] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:29:13] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:29:13] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[22:29:13] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 1290 ms
+[22:29:14] [WARN] [FPS] Drop detected: 10 fps (threshold: 30)
+[22:29:14] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[22:29:15] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:15] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:29:15] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1250), corner_timer=0.30
+[22:29:15] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1250), corner_timer=0.30
+[22:29:15] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1250), corner_timer=-0.02
+[22:29:15] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:15] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1250), corner_timer=-0.02
+[22:29:15] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:29:15] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1250), corner_timer=0.30
+[22:29:15] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1250), corner_timer=0.30
+[22:29:15] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[22:29:16] [INFO] [PauseMenu] Armory button pressed
+[22:29:16] [INFO] [PauseMenu] Creating new armory menu instance
+[22:29:16] [INFO] [PauseMenu] armory_menu_scene resource path: res://scenes/ui/ArmoryMenu.tscn
+[22:29:16] [INFO] [PauseMenu] Instance created, class: CanvasLayer, name: ArmoryMenu
+[22:29:16] [INFO] [PauseMenu] Script attached: res://scripts/ui/armory_menu.gd
+[22:29:16] [INFO] [PauseMenu] back_pressed signal exists on instance
+[22:29:16] [INFO] [PauseMenu] back_pressed signal connected
+[22:29:16] [INFO] [PauseMenu] Armory menu instance added as child, is_inside_tree: true
+[22:29:16] [INFO] [PauseMenu] _populate_weapon_grid method exists
+[22:29:16] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[22:29:17] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[22:29:17] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,1250), corner_timer=-0.02
+[22:29:17] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:29:17] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,1250), corner_timer=0.30
+[22:29:18] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(450,1250), corner_timer=-0.02
+[22:29:18] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[22:29:18] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(450,1250), corner_timer=0.30
+[22:29:18] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(450,1250), corner_timer=-0.02
+[22:29:18] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[22:29:18] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[22:29:18] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(450,1250), corner_timer=0.30
+[22:29:18] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:18] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[22:29:18] [INFO] [Player.Grenade] G pressed - starting grab animation
+[22:29:18] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(450,1250), corner_timer=-0.02
+[22:29:18] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[22:29:18] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(450,1250), corner_timer=0.30
+[22:29:19] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:19] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (692.77625, 1105.065)
+[22:29:19] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:19] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[22:29:19] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[22:29:19] [INFO] [DefensiveGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[22:29:19] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 700
+[22:29:19] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[22:29:19] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[22:29:19] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[22:29:19] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[22:29:19] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[22:29:19] [INFO] [Player.Grenade] Step 1 complete! Drag: (283.25677, 39.40625)
+[22:29:19] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[22:29:19] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - starting trajectory aiming
+[22:29:19] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(450,1250), corner_timer=-0.02
+[22:29:19] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[22:29:19] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(450,1250), corner_timer=0.30
+[22:29:19] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:19] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[22:29:19] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(450,1250), corner_timer=-0.02
+[22:29:19] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[22:29:19] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(450,1250), corner_timer=0.30
+[22:29:19] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(450,1238), corner_timer=-0.02
+[22:29:20] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[22:29:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(450,1235), corner_timer=0.30
+[22:29:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(450,1138), corner_timer=-0.02
+[22:29:20] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[22:29:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(450,1133), corner_timer=0.30
+[22:29:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:20] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[22:29:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(450,1028), corner_timer=-0.02
+[22:29:20] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(450,1023), corner_timer=0.30
+[22:29:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:21] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(450,947), corner_timer=-0.02
+[22:29:21] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:21] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(450,946), corner_timer=0.30
+[22:29:21] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:21] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(389,935), corner_timer=-0.02
+[22:29:21] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:21] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(383,935), corner_timer=0.30
+[22:29:21] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:21] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=10
+[22:29:21] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(308,935), corner_timer=-0.02
+[22:29:21] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:21] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(307,935), corner_timer=0.30
+[22:29:21] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:22] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(304,935), corner_timer=-0.02
+[22:29:22] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:22] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(304,935), corner_timer=0.30
+[22:29:22] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:22] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(304,935), corner_timer=-0.02
+[22:29:22] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:22] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(304,935), corner_timer=0.30
+[22:29:22] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:22] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=10
+[22:29:22] [INFO] [Player.Grenade.Simple] Throwing! Target: (677.4109, 624.62854), Distance: 425,5, Speed: 505,3, Friction: 300,0
+[22:29:22] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,6957562
+[22:29:22] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[22:29:22] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.76756924, -0.64096606), speed=505,3, spawn=(350.77472, 897.3892)
+[22:29:22] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.767569, -0.640966), Speed: 505.3 (clamped from 505.3, max: 1000.0)
+[22:29:22] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[22:29:22] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[22:29:22] [INFO] [Player.Grenade] State reset to IDLE
+[22:29:22] [INFO] [Player.Grenade] State reset to IDLE
+[22:29:22] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[22:29:22] [INFO] [Player.Grenade] Player rotation restored to 0
+[22:29:22] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(304,942), corner_timer=-0.02
+[22:29:22] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:22] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(304,945), corner_timer=0.30
+[22:29:22] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:22] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[22:29:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(313,1032), corner_timer=-0.02
+[22:29:23] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(315,1037), corner_timer=0.30
+[22:29:23] [ENEMY] [Enemy3] GRENADE DANGER: Entering EVADING_GRENADE state from IDLE
+[22:29:23] [ENEMY] [Enemy3] EVADING_GRENADE started: escaping to (831.3046, 1435.931)
+[22:29:23] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:23] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P4:velocity, state=EVADING_GRENADE, target=79.2°, current=-110.6°, player=(349,1070), corner_timer=0.00
+[22:29:23] [INFO] [GrenadeBase] EXPLODED at (560.7339, 722.0607)!
+[22:29:23] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(560.7339, 722.0607), source=NEUTRAL (DefensiveGrenade), range=2937, listeners=10
+[22:29:23] [ENEMY] [Enemy1] Heard EXPLOSION at (560.7339, 722.0607), intensity=0.01, distance=454
+[22:29:23] [ENEMY] [Enemy2] Heard EXPLOSION at (560.7339, 722.0607), intensity=0.05, distance=235
+[22:29:23] [ENEMY] [Enemy4] Heard EXPLOSION at (560.7339, 722.0607), intensity=0.03, distance=298
+[22:29:23] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=0, self=0, below_threshold=6
+[22:29:23] [ENEMY] [Enemy1] Hit: dmg=1, hp=2/2->1/2
+[22:29:23] [INFO] [ImpactEffects] spawn_blood_effect called at (300, 350), dir=(-0.573893, -0.81893), lethal=false
+[22:29:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:23] [INFO] [ImpactEffects] Wall found for blood splatter at (246.7405, 274) (dist=92 px)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (246.7405, 275) (added to group)
+[22:29:23] [INFO] [ImpactEffects] Blood effect spawned at (300, 350) (scale=1)
+[22:29:23] [ENEMY] [Enemy1] Hit: dmg=1, hp=1/2->0/2
+[22:29:23] [INFO] [ImpactEffects] spawn_blood_effect called at (300, 350), dir=(-0.573893, -0.81893), lethal=true
+[22:29:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:23] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:29:23] [INFO] [ImpactEffects] Wall found for blood splatter at (246.7405, 274) (dist=92 px)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (246.7405, 275) (added to group)
+[22:29:23] [INFO] [ImpactEffects] Blood effect spawned at (300, 350) (scale=1.5)
+[22:29:23] [ENEMY] [Enemy1] Enemy died (ricochet: false, penetration: false)
+[22:29:23] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:29:23] [ENEMY] [Enemy1] [AllyDeath] Notified 1 enemies
+[22:29:23] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 9)
+[22:29:23] [INFO] [DeathAnim] Started - Angle: -125.0 deg, Index: 3
+[22:29:23] [ENEMY] [Enemy1] Death animation started with hit direction: (-0.573893, -0.81893)
+[22:29:23] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 454.3
+[22:29:23] [ENEMY] [Enemy2] Hit: dmg=1, hp=4/4->3/4
+[22:29:23] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.682645, -0.73075), lethal=false
+[22:29:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:23] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:29:23] [ENEMY] [Enemy2] Hit: dmg=1, hp=3/4->2/4
+[22:29:23] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.682645, -0.73075), lethal=false
+[22:29:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:23] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:29:23] [ENEMY] [Enemy2] Hit: dmg=1, hp=2/4->1/4
+[22:29:23] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.682645, -0.73075), lethal=false
+[22:29:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:23] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:29:23] [ENEMY] [Enemy2] Hit: dmg=1, hp=1/4->0/4
+[22:29:23] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.682645, -0.73075), lethal=true
+[22:29:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:23] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:29:23] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1.5)
+[22:29:23] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[22:29:23] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[22:29:23] [ENEMY] [Enemy3] [AllyDeath] Witnessed at (400, 550), entering SEARCHING
+[22:29:23] [ENEMY] [Enemy3] SEARCHING started: center=(400, 550), radius=100, waypoints=5
+[22:29:23] [ENEMY] [Enemy2] [AllyDeath] Notified 1 enemies
+[22:29:23] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 8)
+[22:29:23] [INFO] [DeathAnim] Started - Angle: -133.1 deg, Index: 3
+[22:29:23] [ENEMY] [Enemy2] Death animation started with hit direction: (-0.682645, -0.73075)
+[22:29:23] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 235.5
+[22:29:23] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/2->1/2
+[22:29:23] [INFO] [ImpactEffects] spawn_blood_effect called at (706.0165, 781.4293), dir=(0.925692, 0.378277), lethal=false
+[22:29:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:23] [INFO] [ImpactEffects] Blood effect spawned at (706.0165, 781.4293) (scale=1)
+[22:29:23] [ENEMY] [Enemy3] Hit: dmg=1, hp=1/2->0/2
+[22:29:23] [INFO] [ImpactEffects] spawn_blood_effect called at (706.0165, 781.4293), dir=(0.925692, 0.378277), lethal=true
+[22:29:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:23] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:29:23] [INFO] [ImpactEffects] Blood effect spawned at (706.0165, 781.4293) (scale=1.5)
+[22:29:23] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[22:29:23] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[22:29:23] [ENEMY] [Enemy3] [AllyDeath] Notified 1 enemies
+[22:29:23] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 7)
+[22:29:23] [INFO] [DeathAnim] Started - Angle: 22.2 deg, Index: 13
+[22:29:23] [ENEMY] [Enemy3] Death animation started with hit direction: (0.925692, 0.378277)
+[22:29:23] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 156.9
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #1 at angle 14.3 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #2 at angle 1.7 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #3 at angle 8.0 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #4 at angle 24.1 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #5 at angle 48.7 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #6 at angle 32.2 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #7 at angle 62.0 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #8 at angle 71.9 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #9 at angle 60.1 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #10 at angle 73.3 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #11 at angle 99.5 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #12 at angle 92.5 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #13 at angle 99.8 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #14 at angle 121.4 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #15 at angle 135.7 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #16 at angle 127.5 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #17 at angle 148.3 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #18 at angle 146.5 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #19 at angle 154.1 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #20 at angle 163.8 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #21 at angle 176.4 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #22 at angle 187.2 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #23 at angle 184.0 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #24 at angle 196.7 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #25 at angle 209.4 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #26 at angle 212.6 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #27 at angle 229.4 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #28 at angle 244.0 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #29 at angle 245.3 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #30 at angle 268.2 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #31 at angle 276.2 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #32 at angle 282.2 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #33 at angle 296.9 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #34 at angle 296.1 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #35 at angle 295.0 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #36 at angle 305.7 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #37 at angle 332.9 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #38 at angle 337.2 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #39 at angle 346.1 degrees
+[22:29:23] [INFO] [DefensiveGrenade] Spawned shrapnel #40 at angle 347.3 degrees
+[22:29:23] [INFO] [GrenadeTimer] Timer expired for Flashbang grenade!
+[22:29:23] [INFO] [GrenadeTimer] Flashbang grenade activated at (560.73395, 722.06067)!
+[22:29:23] [INFO] [GrenadeTimer] Applying flashbang effects (radius: 700, blindness: 12s, stun: 6s)
+[22:29:23] [INFO] [FlashbangStatus] Flashbang: blind=4.2s, stun=2.1s
+[22:29:23] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:29:23] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:29:23] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 454,3 (intensity: 0,35)
+[22:29:23] [INFO] [FlashbangStatus] Flashbang: blind=8.0s, stun=4.0s
+[22:29:23] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:29:23] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:29:23] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 235,5 (intensity: 0,66)
+[22:29:23] [INFO] [FlashbangStatus] Flashbang: blind=9.3s, stun=4.7s
+[22:29:23] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:29:23] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:29:23] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 156,9 (intensity: 0,78)
+[22:29:23] [INFO] [GrenadeTimer] Player behind wall - flashbang blocked (distance: 406,3)
+[22:29:23] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(560.7339, 722.0607), source=NEUTRAL (DefensiveGrenade), range=2938, listeners=7
+[22:29:23] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=6
+[22:29:23] [INFO] [GrenadeTimer] Spawned flashbang effect at (560.73395, 722.06067) (radius: 700)
+[22:29:23] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=158.4°, current=-101.3°, player=(358,1074), corner_timer=0.00
+[22:29:23] [ENEMY] [Enemy4] Hit: dmg=1, hp=3/3->2/3
+[22:29:23] [INFO] [ImpactEffects] spawn_blood_effect called at (771.6901, 911.1735), dir=(0.24729, -0.968942), lethal=false
+[22:29:23] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:23] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:23] [INFO] [ImpactEffects] Blood effect spawned at (771.6901, 911.1735) (scale=1)
+[22:29:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(400,1080), corner_timer=-0.02
+[22:29:23] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(405,1080), corner_timer=0.30
+[22:29:23] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[22:29:23] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=180.0°, current=127.3°, player=(444,1080), corner_timer=0.00
+[22:29:23] [ENEMY] [Enemy4] State: RETREATING -> IN_COVER
+[22:29:23] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:23] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=10
+[22:29:23] [ENEMY] [Enemy4] State: IN_COVER -> SUPPRESSED
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (231.5667, 318.1205) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (264.3811, 332.6194) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (283.4041, 312.1327) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (253.3053, 308.6531) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (257.8871, 297.0927) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (344.1681, 532.9742) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (369.623, 535.677) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (354.1364, 501.9682) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (374.5448, 482.9976) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (381.3645, 521.0963) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (338.2061, 502.7652) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (365.5416, 526.6519) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (754.2641, 793.5129) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (800.1741, 889.4989) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (213.9529, 337.7997) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (218.4586, 328.4323) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (244.1793, 336.1512) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (240.5181, 312.9608) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (238.1993, 316.2184) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (271.9781, 321.4352) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (218.1477, 322.1612) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (281.611, 311.3826) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (318.4376, 520.4483) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (336.565, 550.9941) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (308.6559, 516.7506) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (362.0985, 516.3597) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (284.2662, 531.29) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (338.033, 561.285) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (320.8056, 548.954) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (345.2556, 475.2442) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (291.4949, 523.4269) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (334.5411, 509.6882) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (366.187, 494.4944) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (340.3584, 521.399) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (357.9897, 465.4269) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (765.2089, 858.3626) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (784.5146, 820.8796) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (816.1436, 856.854) (added to group)
+[22:29:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(510,1080), corner_timer=-0.02
+[22:29:23] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(515,1080), corner_timer=0.30
+[22:29:23] [ENEMY] [Enemy1] Ragdoll activated
+[22:29:23] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:29:23] [ENEMY] [Enemy2] Ragdoll activated
+[22:29:23] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:29:23] [ENEMY] [Enemy3] Ragdoll activated
+[22:29:23] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (200.8321, 269.5867) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (183.5109, 345.7592) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (205.431, 304.0584) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (236.4649, 283.8616) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (283.2545, 317.8879) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (360.9309, 532.5261) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (292.9204, 474.7311) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (231.3864, 558.2328) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (269.2007, 533.216) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (332.1893, 509.2185) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (363.7816, 526.0182) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (300.6184, 522.2643) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (330.5452, 562.6205) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (247.0283, 544.9174) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (325.6295, 562.415) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (798.3928, 882.5699) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (760.4017, 828.0325) (added to group)
+[22:29:23] [INFO] [BloodDecal] Blood puddle created at (795.6947, 811.808) (added to group)
+[22:29:24] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (278.07, 274.4644) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (259.353, 275.8329) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (151.8804, 326.5478) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (253.3777, 276.74) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (304.2061, 594.7572) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (308.9775, 539.2028) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (341.1621, 560.1616) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (339.3415, 475.3289) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (317.6928, 494.2167) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (353.443, 515.9476) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (209.5414, 557.982) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (259.7433, 555.6478) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (347.9689, 479.0817) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (276.9835, 587.0688) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (229.2631, 550.1215) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (278.9968, 502.2771) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (327.5562, 531.0035) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (322.3543, 575.5816) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (238.7943, 506.6085) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (901.0419, 869.8329) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (782.4818, 885.5093) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (249.8176, 325.0095) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (274.4046, 340.9992) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (331.6412, 577.2651) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (283.803, 543.8963) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (827.2979, 890.5199) (added to group)
+[22:29:24] [INFO] [BloodDecal] Blood puddle created at (789.922, 912.6013) (added to group)
+[22:29:24] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(620,1080), corner_timer=-0.02
+[22:29:24] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:24] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(625,1080), corner_timer=0.30
+[22:29:24] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:24] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(677,1080), corner_timer=-0.02
+[22:29:24] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:24] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(677,1080), corner_timer=0.30
+[22:29:24] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:24] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=10
+[22:29:24] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:24] [WARN] [FPS] Drop detected: 24 fps (threshold: 30)
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:29:24] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:24] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:29:24] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:29:24] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[22:29:24] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[22:29:24] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[22:29:24] [ENEMY] [Enemy1] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:29:24] [ENEMY] [Enemy2] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:29:24] [ENEMY] [Enemy3] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:29:24] [ENEMY] [Enemy4] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[22:29:24] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[22:29:24] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[22:29:24] [ENEMY] [Grenadier] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:29:24] [ENEMY] [Enemy6] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:29:24] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:24] [ENEMY] [Enemy7] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:29:24] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:24] [ENEMY] [Enemy8] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:29:24] [ENEMY] [Enemy9] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:29:24] [ENEMY] [Enemy10] Death animation component initialized
+[22:29:24] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:24] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:29:24] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:29:24] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:29:24] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[22:29:24] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:29:24] [INFO] [Player.Weapon] GameManager weapon selection: silenced_pistol (SilencedPistol)
+[22:29:24] [INFO] [Player.Weapon] Removed default MakarovPM
+[22:29:24] [INFO] [Player.Weapon] Equipped SilencedPistol (ammo: 13/13)
+[22:29:24] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:29:24] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:29:24] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:29:24] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:29:24] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:29:24] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:29:24] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[22:29:24] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[22:29:24] [INFO] [Player.Homing] Homing activation sound loaded
+[22:29:24] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[22:29:24] [INFO] [Player.Homing] Homing bullets equipped, charges: 6/6
+[22:29:24] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[22:29:24] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[22:29:24] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[22:29:24] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[22:29:24] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[22:29:24] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[22:29:24] [INFO] [Player] Ready! Ammo: 13/13, Grenades: 1/3, Health: 3/4
+[22:29:24] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:29:24] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:29:24] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:29:24] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:29:24] [INFO] [BuildingLevel] Setting up weapon: silenced_pistol
+[22:29:24] [INFO] [BuildingLevel] SilencedPistol already equipped by C# Player - skipping GDScript weapon swap
+[22:29:24] [INFO] [ScoreManager] Level started with 10 enemies
+[22:29:24] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[22:29:24] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[22:29:24] [INFO] [ReplayManager] Replay data cleared
+[22:29:24] [INFO] [BuildingLevel] Previous replay data cleared
+[22:29:24] [INFO] [ReplayManager] Detected player weapon: Silenced Pistol
+[22:29:24] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[22:29:24] [INFO] [ReplayManager] Level: BuildingLevel
+[22:29:24] [INFO] [ReplayManager] Player: Player (valid: True)
+[22:29:24] [INFO] [ReplayManager] Enemies count: 10
+[22:29:24] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/silenced_pistol_topdown.png
+[22:29:24] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[22:29:24] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[22:29:24] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[22:29:24] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[22:29:24] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[22:29:24] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[22:29:24] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[22:29:24] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[22:29:24] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[22:29:24] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[22:29:24] [INFO] [BuildingLevel] Replay recording started successfully
+[22:29:24] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:29:24] [INFO] [LastChance] Issue #937: Cached 44 StaticBody2D nodes for fast freeze traversal
+[22:29:24] [INFO] [CinemaEffects] Found player node: Player
+[22:29:24] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 8)
+[22:29:24] [ENEMY] [Enemy1] Registered as sound listener
+[22:29:24] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[22:29:24] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 9)
+[22:29:24] [ENEMY] [Enemy2] Registered as sound listener
+[22:29:24] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:29:24] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 10)
+[22:29:24] [ENEMY] [Enemy3] Registered as sound listener
+[22:29:24] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[22:29:24] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 11)
+[22:29:24] [ENEMY] [Enemy4] Registered as sound listener
+[22:29:24] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[22:29:24] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 12)
+[22:29:24] [ENEMY] [Grenadier] Registered as sound listener
+[22:29:24] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:29:24] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 13)
+[22:29:24] [ENEMY] [Enemy6] Registered as sound listener
+[22:29:24] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:29:24] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 14)
+[22:29:24] [ENEMY] [Enemy7] Registered as sound listener
+[22:29:24] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[22:29:24] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 15)
+[22:29:24] [ENEMY] [Enemy8] Registered as sound listener
+[22:29:24] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[22:29:24] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 16)
+[22:29:24] [ENEMY] [Enemy9] Registered as sound listener
+[22:29:24] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[22:29:24] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:29:24] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 17)
+[22:29:24] [ENEMY] [Enemy10] Registered as sound listener
+[22:29:24] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:29:24] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:29:25] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[22:29:25] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:25] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:25] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:25] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:25] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:25] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:25] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:25] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:25] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:29:25] [INFO] [Player] Detected weapon: Silenced Pistol (Pistol pose)
+[22:29:25] [INFO] [Player] Applied Pistol arm pose: Left=(16, 6), Right=(4, 6)
+[22:29:25] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:29:25] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:29:25] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:29:25] [INFO] [LastChance] Found player: Player
+[22:29:25] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:29:25] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:29:25] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:29:25] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[22:29:25] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:25] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[22:29:25] [INFO] [Player.Grenade] G pressed - starting grab animation
+[22:29:25] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[22:29:26] [WARN] [FPS] Drop detected: 22 fps (threshold: 30)
+[22:29:26] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:26] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (664.3239, 940.7607)
+[22:29:26] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[22:29:26] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[22:29:26] [INFO] [DefensiveGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[22:29:26] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 700
+[22:29:26] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[22:29:26] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[22:29:26] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[22:29:26] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[22:29:26] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[22:29:26] [INFO] [Player.Grenade] Step 1 complete! Drag: (244.70703, 28.05194)
+[22:29:26] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[22:29:26] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - starting trajectory aiming
+[22:29:26] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:26] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:29:26] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1250), corner_timer=0.30
+[22:29:26] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1250), corner_timer=0.30
+[22:29:26] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1231), corner_timer=-0.02
+[22:29:26] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:26] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1231), corner_timer=-0.02
+[22:29:26] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:29:26] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1228), corner_timer=0.30
+[22:29:26] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1228), corner_timer=0.30
+[22:29:26] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[22:29:27] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,1127), corner_timer=-0.02
+[22:29:27] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:29:27] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,1122), corner_timer=0.30
+[22:29:27] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(450,1017), corner_timer=-0.02
+[22:29:27] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[22:29:27] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(450,1012), corner_timer=0.30
+[22:29:27] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(450,960), corner_timer=-0.02
+[22:29:27] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[22:29:27] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(450,960), corner_timer=0.30
+[22:29:27] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[22:29:28] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(428,960), corner_timer=-0.02
+[22:29:28] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[22:29:28] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(424,960), corner_timer=0.30
+[22:29:28] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:28] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(288,889), corner_timer=-0.02
+[22:29:28] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[22:29:28] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(285,886), corner_timer=0.30
+[22:29:28] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:28] [INFO] [Player.Grenade.Simple] Throwing! Target: (744.8848, 594.8301), Distance: 492,1, Speed: 543,4, Friction: 300,0
+[22:29:28] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,5192777
+[22:29:28] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[22:29:28] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.8681779, -0.4962532), speed=543,4, spawn=(317.65555, 839.03564)
+[22:29:28] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.868178, -0.496253), Speed: 543.4 (clamped from 543.4, max: 1000.0)
+[22:29:28] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[22:29:28] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[22:29:28] [INFO] [Player.Grenade] State reset to IDLE
+[22:29:28] [INFO] [Player.Grenade] State reset to IDLE
+[22:29:28] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[22:29:28] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[22:29:29] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(265,869), corner_timer=-0.02
+[22:29:29] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[22:29:29] [INFO] [Player.Grenade] Player rotation restored to 0
+[22:29:29] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(265,869), corner_timer=0.30
+[22:29:29] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:29] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[22:29:29] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(280,930), corner_timer=-0.02
+[22:29:29] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[22:29:29] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(283,934), corner_timer=0.30
+[22:29:29] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:29] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(357,1008), corner_timer=-0.02
+[22:29:29] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[22:29:29] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(361,1012), corner_timer=0.30
+[22:29:29] [ENEMY] [Enemy3] GRENADE DANGER: Entering EVADING_GRENADE state from IDLE
+[22:29:29] [ENEMY] [Enemy3] EVADING_GRENADE started: escaping to (521.3493, 1390.602)
+[22:29:29] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:29] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P4:velocity, state=EVADING_GRENADE, target=173.4°, current=-49.9°, player=(396,1047), corner_timer=0.00
+[22:29:29] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[22:29:30] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(435,1085), corner_timer=-0.02
+[22:29:30] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:30] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(439,1089), corner_timer=0.30
+[22:29:30] [ENEMY] [Enemy4] GRENADE DANGER: Entering EVADING_GRENADE state from IDLE
+[22:29:30] [ENEMY] [Enemy4] EVADING_GRENADE started: escaping to (896.0581, 1406.805)
+[22:29:30] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P4:velocity, state=EVADING_GRENADE, target=-98.0°, current=-117.6°, player=(451,1106), corner_timer=0.00
+[22:29:30] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:30] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P1:visible, state=EVADING_GRENADE, target=92.7°, current=120.6°, player=(461,1135), corner_timer=0.00
+[22:29:30] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[22:29:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(477.4318, 786.4932), source=ENEMY (Enemy3), range=1469, listeners=17
+[22:29:30] [INFO] [SoundPropagation] Cleaned up 7 invalid listeners
+[22:29:30] [ENEMY] [Enemy1] Heard gunshot at (477.4318, 786.4932), intensity=0.01, distance=471
+[22:29:30] [ENEMY] [Enemy2] Heard gunshot at (477.4318, 786.4932), intensity=0.04, distance=249
+[22:29:30] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=1, below_threshold=3
+[22:29:30] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=78.4°, current=168.8°, player=(461,1141), corner_timer=0.00
+[22:29:30] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=84.0°, current=-101.3°, player=(461,1141), corner_timer=0.00
+[22:29:30] [INFO] [LastChance] Threat detected: Bullet
+[22:29:30] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:29:30] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:29:30] [INFO] [GrenadeBase] EXPLODED at (714.2481, 612.342)!
+[22:29:30] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(714.2481, 612.342), source=NEUTRAL (DefensiveGrenade), range=2937, listeners=10
+[22:29:30] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=0, self=0, below_threshold=6
+[22:29:30] [ENEMY] [Enemy4] Hit: dmg=1, hp=3/3->2/3
+[22:29:30] [INFO] [ImpactEffects] spawn_blood_effect called at (762.3705, 783.0997), dir=(0.271251, 0.962509), lethal=false
+[22:29:30] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:30] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:30] [INFO] [ImpactEffects] Blood effect spawned at (762.3705, 783.0997) (scale=1)
+[22:29:30] [ENEMY] [Enemy4] Hit: dmg=1, hp=2/3->1/3
+[22:29:30] [INFO] [ImpactEffects] spawn_blood_effect called at (762.3705, 783.0997), dir=(0.271251, 0.962509), lethal=false
+[22:29:30] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:30] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:30] [INFO] [ImpactEffects] Blood effect spawned at (762.3705, 783.0997) (scale=1)
+[22:29:30] [ENEMY] [Enemy4] Hit: dmg=1, hp=1/3->0/3
+[22:29:30] [INFO] [ImpactEffects] spawn_blood_effect called at (762.3705, 783.0997), dir=(0.271251, 0.962509), lethal=true
+[22:29:30] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:30] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:29:30] [INFO] [ImpactEffects] Blood effect spawned at (762.3705, 783.0997) (scale=1.5)
+[22:29:30] [ENEMY] [Enemy4] Enemy died (ricochet: false, penetration: false)
+[22:29:30] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:29:30] [ENEMY] [Enemy4] [AllyDeath] Notified 2 enemies
+[22:29:30] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 9)
+[22:29:30] [INFO] [DeathAnim] Started - Angle: 74.3 deg, Index: 16
+[22:29:30] [ENEMY] [Enemy4] Death animation started with hit direction: (0.271251, 0.962509)
+[22:29:30] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 177.4
+[22:29:30] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(466.6972, 798.4316), source=NEUTRAL (null), range=900, listeners=9
+[22:29:30] [ENEMY] [Enemy1] Heard CASING_KICK at (466.6972, 798.4316), intensity=0.01, dist=453
+[22:29:30] [ENEMY] [Enemy2] Heard CASING_KICK at (466.6972, 798.4316), intensity=0.05, dist=231
+[22:29:30] [ENEMY] [Enemy3] Heard CASING_KICK at (466.6972, 798.4316), intensity=1.00, dist=47
+[22:29:30] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[22:29:30] [INFO] [GrenadeBase] Scattered 1 casings (lethal zone) + 0 casings (proximity) from explosion
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #1 at angle 0.5 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #2 at angle 23.5 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #3 at angle 11.9 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #4 at angle 21.8 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #5 at angle 41.7 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #6 at angle 51.5 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #7 at angle 54.2 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #8 at angle 66.1 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #9 at angle 64.6 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #10 at angle 87.2 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #11 at angle 100.8 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #12 at angle 85.7 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #13 at angle 111.0 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #14 at angle 125.5 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #15 at angle 128.7 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #16 at angle 144.0 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #17 at angle 153.8 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #18 at angle 148.5 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #19 at angle 174.6 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #20 at angle 156.6 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #21 at angle 188.4 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #22 at angle 180.4 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #23 at angle 184.2 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #24 at angle 202.0 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #25 at angle 219.0 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #26 at angle 233.8 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #27 at angle 247.4 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #28 at angle 252.1 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #29 at angle 239.5 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #30 at angle 273.1 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #31 at angle 266.5 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #32 at angle 268.1 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #33 at angle 300.2 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #34 at angle 283.9 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #35 at angle 316.0 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #36 at angle 307.4 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #37 at angle 329.5 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #38 at angle 333.8 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #39 at angle 342.6 degrees
+[22:29:30] [INFO] [DefensiveGrenade] Spawned shrapnel #40 at angle 337.7 degrees
+[22:29:30] [INFO] [GrenadeTimer] Timer expired for Flashbang grenade!
+[22:29:30] [INFO] [GrenadeTimer] Flashbang grenade activated at (714.2481, 612.34204)!
+[22:29:30] [INFO] [GrenadeTimer] Applying flashbang effects (radius: 700, blindness: 12s, stun: 6s)
+[22:29:30] [INFO] [FlashbangStatus] Flashbang: blind=9.0s, stun=4.5s
+[22:29:30] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:29:30] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:29:30] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 177,4 (intensity: 0,75)
+[22:29:30] [INFO] [GrenadeTimer] Player behind wall - flashbang blocked (distance: 609,5)
+[22:29:30] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(714.2481, 612.342), source=NEUTRAL (DefensiveGrenade), range=2938, listeners=9
+[22:29:30] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=0, self=0, below_threshold=6
+[22:29:30] [INFO] [GrenadeTimer] Spawned flashbang effect at (714.2481, 612.34204) (radius: 700)
+[22:29:30] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(466.6972, 798.4316), source=NEUTRAL (null), range=900, listeners=9
+[22:29:30] [ENEMY] [Enemy1] Heard CASING_KICK at (466.6972, 798.4316), intensity=0.01, dist=453
+[22:29:30] [ENEMY] [Enemy2] Heard CASING_KICK at (466.6972, 798.4316), intensity=0.05, dist=231
+[22:29:30] [ENEMY] [Enemy3] Heard CASING_KICK at (466.6972, 798.4316), intensity=1.00, dist=47
+[22:29:30] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[22:29:30] [INFO] [GrenadeTimer] Scattered 1 casings
+[22:29:30] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[22:29:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(475.7432, 855.2373), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:30] [INFO] [Player] Spawning blood effect at (454.26715, 1179.7412), dir=(1, 0), lethal=False (C#)
+[22:29:30] [INFO] [ImpactEffects] spawn_blood_effect called at (454.2672, 1179.741), dir=(1, 0), lethal=false
+[22:29:30] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:30] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:30] [INFO] [ImpactEffects] Blood effect spawned at (454.2672, 1179.741) (scale=1)
+[22:29:30] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[22:29:30] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[22:29:30] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(454,1179), corner_timer=-0.02
+[22:29:30] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:30] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/2->1/2
+[22:29:30] [INFO] [ImpactEffects] spawn_blood_effect called at (475.781, 881.9039), dir=(0.600163, 0.799878), lethal=false
+[22:29:30] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:30] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:30] [INFO] [ImpactEffects] Wall found for blood splatter at (500, 914.1821) (dist=40 px)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (499, 914.1821) (added to group)
+[22:29:30] [INFO] [ImpactEffects] Blood effect spawned at (475.781, 881.9039) (scale=1)
+[22:29:30] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(451,1184), corner_timer=0.30
+[22:29:30] [INFO] [LastChance] Threat detected: @Area2D@1209
+[22:29:30] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[22:29:30] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:29:30] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P4:velocity, state=EVADING_GRENADE, target=89.9°, current=-133.3°, player=(446,1192), corner_timer=0.00
+[22:29:30] [ENEMY] [Enemy3] EVADING_GRENADE: Escaped to safe distance
+[22:29:30] [ENEMY] [Enemy3] State: EVADING_GRENADE -> IDLE
+[22:29:30] [ENEMY] [Enemy3] Memory: high confidence (0.99) - transitioning to PURSUING
+[22:29:30] [ENEMY] [Enemy3] State: IDLE -> PURSUING
+[22:29:30] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P2:combat_state, state=PURSUING, target=97.3°, current=-139.0°, player=(439,1200), corner_timer=0.00
+[22:29:30] [ENEMY] [Enemy3] State: PURSUING -> RETREATING
+[22:29:30] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=89.9°, current=-141.9°, player=(435,1204), corner_timer=0.00
+[22:29:30] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:30] [ENEMY] [Enemy1] Hit: dmg=1, hp=3/3->2/3
+[22:29:30] [INFO] [ImpactEffects] spawn_blood_effect called at (332.2654, 401.9339), dir=(-0.481145, 0.876641), lethal=false
+[22:29:30] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:30] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:30] [INFO] [ImpactEffects] Wall found for blood splatter at (319.0566, 426) (dist=27 px)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (319.0566, 425) (added to group)
+[22:29:30] [INFO] [ImpactEffects] Blood effect spawned at (332.2654, 401.9339) (scale=1)
+[22:29:30] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[22:29:30] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=111.7°, current=41.7°, player=(408,1231), corner_timer=0.00
+[22:29:30] [ENEMY] [Enemy2] State: RETREATING -> IN_COVER
+[22:29:30] [ENEMY] [Enemy2] State: IN_COVER -> SUPPRESSED
+[22:29:30] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(479.7402, 923.16833), shooter_id=219395657938, bullet_pos=(439.25632, 1588.604)
+[22:29:30] [INFO] [Bullet] Using shooter_position, distance=666,666
+[22:29:30] [INFO] [Bullet] Distance to wall: 666,666 (45,394516% of viewport)
+[22:29:30] [INFO] [Bullet] Distance-based penetration chance: 93,7064%
+[22:29:30] [INFO] [Bullet] Starting wall penetration at (439.25632, 1588.604)
+[22:29:30] [ENEMY] [Enemy10] Hit: dmg=1, hp=3/3->2/3
+[22:29:30] [INFO] [ImpactEffects] spawn_blood_effect called at (1159.099, 1601.934), dir=(0.661377, 0.750053), lethal=false
+[22:29:30] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:30] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:30] [INFO] [ImpactEffects] Wall found for blood splatter at (1180.32, 1626) (dist=32 px)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (1180.32, 1625) (added to group)
+[22:29:30] [INFO] [ImpactEffects] Blood effect spawned at (1159.099, 1601.934) (scale=1)
+[22:29:30] [INFO] [Bullet] Raycast backward hit penetrating body at distance 23,227314
+[22:29:30] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:29:30] [INFO] [Bullet] Exiting penetration at (436.42245, 1635.1844) after traveling 41,666668 pixels through wall
+[22:29:30] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (797.2623, 871.18) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (797.0653, 860.9106) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (791.7374, 875.9677) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (775.5767, 887.3423) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (797.9945, 863.0585) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (830.1907, 892.9682) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (798.8119, 841.1337) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (505.705, 1221.342) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (505.6869, 1190.988) (added to group)
+[22:29:30] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(380,1258), corner_timer=-0.02
+[22:29:30] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:30] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[22:29:30] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(377,1262), corner_timer=0.30
+[22:29:30] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=180.0°, current=-25.0°, player=(373,1266), corner_timer=0.00
+[22:29:30] [ENEMY] [Enemy1] State: RETREATING -> IN_COVER
+[22:29:30] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[22:29:30] [ENEMY] [Enemy4] Ragdoll activated
+[22:29:30] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (817.0896, 897.6472) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (784.3096, 931.0441) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (804.4084, 952.4224) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (784.6137, 964.067) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (779.2968, 913.9583) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (844.4492, 947.9625) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (784.9047, 932.9296) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (779.1338, 898.2312) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (775.3139, 913.1505) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (773.8448, 891.3604) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (761.4433, 952.1216) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (837.2744, 941.8453) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (759.46, 932.6047) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (551.0258, 1185.531) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (534.3289, 1208.748) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (561.1332, 1242.397) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (530.5071, 1237.151) (added to group)
+[22:29:30] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (786.8793, 940.9329) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (781.3199, 947.4973) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (782.5109, 965.9966) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (809.7715, 997.0237) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (840.2356, 956.5052) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (770.2633, 949.8351) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (573.7214, 1194.191) (added to group)
+[22:29:30] [INFO] [BloodDecal] Blood puddle created at (570.7237, 1272.909) (added to group)
+[22:29:31] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[22:29:31] [INFO] [BloodDecal] Blood puddle created at (834.3198, 970.677) (added to group)
+[22:29:31] [INFO] [BloodDecal] Blood puddle created at (626.899, 1241.815) (added to group)
+[22:29:31] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(303,1336), corner_timer=-0.02
+[22:29:31] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:31] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(299,1340), corner_timer=0.30
+[22:29:31] [WARN] [FPS] Drop detected: 26 fps (threshold: 30)
+[22:29:31] [INFO] [BloodDecal] Blood puddle created at (614.9539, 1257.843) (added to group)
+[22:29:31] [INFO] [BloodDecal] Blood puddle created at (505.0712, 1065.924) (added to group)
+[22:29:31] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P1:visible, state=RETREATING, target=114.5°, current=158.2°, player=(283,1356), corner_timer=0.00
+[22:29:31] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(465.8479, 957.0417), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:31] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:31] [INFO] [LastChance] Threat detected: Bullet
+[22:29:31] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[22:29:31] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:29:31] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(463.6091, 963.4961), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(445.1261, 967.0085), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (445.1261, 967.0085), intensity=0.03, dist=307
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (445.1261, 967.0085), intensity=1.00, dist=26
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(443.0079, 966.7448), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (443.0079, 966.7448), intensity=0.03, dist=307
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (443.0079, 966.7448), intensity=1.00, dist=32
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(440.2948, 966.568), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (440.2948, 966.568), intensity=0.03, dist=306
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (440.2948, 966.568), intensity=1.00, dist=32
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(444.8853, 1021.781), shooter_id=219395657938, bullet_pos=(273.76105, 1401.6858)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=416,66672
+[22:29:31] [INFO] [Bullet] Distance to wall: 416,66672 (28,371605% of viewport)
+[22:29:31] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:31] [INFO] [Bullet] Starting wall penetration at (273.76105, 1401.6858)
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(437.0142, 966.4211), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (437.0142, 966.4211), intensity=0.03, dist=305
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (437.0142, 966.4211), intensity=1.00, dist=32
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [Bullet] Raycast backward hit penetrating body at distance 35,354374
+[22:29:31] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:29:31] [INFO] [Bullet] Exiting penetration at (254.59511, 1444.2351) after traveling 41,666668 pixels through wall
+[22:29:31] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(433.1956, 966.2502), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (433.1956, 966.2502), intensity=0.03, dist=305
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (433.1956, 966.2502), intensity=1.00, dist=33
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(428.871, 966.0062), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (428.871, 966.0062), intensity=0.03, dist=304
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (428.871, 966.0062), intensity=1.00, dist=34
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(462.7513, 972.2483), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(424.0735, 965.6465), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (424.0735, 965.6465), intensity=0.03, dist=303
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (424.0735, 965.6465), intensity=1.00, dist=37
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(445.7075, 966.0628), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (445.7075, 966.0628), intensity=0.03, dist=306
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (445.7075, 966.0628), intensity=1.00, dist=15
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(214,1371), corner_timer=-0.02
+[22:29:31] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(444.1113, 964.5158), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (444.1113, 964.5158), intensity=0.03, dist=305
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (444.1113, 964.5158), intensity=1.00, dist=17
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(208,1371), corner_timer=0.30
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(442.2037, 962.4603), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (442.2037, 962.4603), intensity=0.03, dist=302
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (442.2037, 962.4603), intensity=1.00, dist=23
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(439.9549, 1027.3011), shooter_id=219395657938, bullet_pos=(250.4319, 1398.3705)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=416,66705
+[22:29:31] [INFO] [Bullet] Distance to wall: 416,66705 (28,371626% of viewport)
+[22:29:31] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:31] [INFO] [Bullet] Starting wall penetration at (250.4319, 1398.3705)
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(439.9387, 959.9693), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (439.9387, 959.9693), intensity=0.03, dist=299
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (439.9387, 959.9693), intensity=1.00, dist=30
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [Bullet] Raycast backward hit penetrating body at distance 31,36242
+[22:29:31] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:29:31] [INFO] [Bullet] Exiting penetration at (229.20534, 1439.9303) after traveling 41,666668 pixels through wall
+[22:29:31] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(437.3014, 957.0952), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (437.3014, 957.0952), intensity=0.03, dist=296
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (437.3014, 957.0952), intensity=1.00, dist=37
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(467.5742, 984.3998), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(443.2663, 979.3984), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (443.2663, 979.3984), intensity=0.02, dist=319
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (443.2663, 979.3984), intensity=1.00, dist=32
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(441.437, 978.674), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (441.437, 978.674), intensity=0.02, dist=318
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (441.437, 978.674), intensity=1.00, dist=31
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(439.0284, 977.7691), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (439.0284, 977.7691), intensity=0.02, dist=317
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (439.0284, 977.7691), intensity=1.00, dist=31
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(434.27228, 1034.0508), shooter_id=219395657938, bullet_pos=(215.5351, 1388.6846)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=416,66663
+[22:29:31] [INFO] [Bullet] Distance to wall: 416,66663 (28,371597% of viewport)
+[22:29:31] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(436.0879, 976.6452), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (436.0879, 976.6452), intensity=0.03, dist=315
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (436.0879, 976.6452), intensity=1.00, dist=31
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(432.6642, 975.2665), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (432.6642, 975.2665), intensity=0.03, dist=314
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (432.6642, 975.2665), intensity=1.00, dist=32
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(428.8056, 973.6024), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (428.8056, 973.6024), intensity=0.03, dist=311
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (428.8056, 973.6024), intensity=1.00, dist=33
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [ENEMY] [Enemy3] Player distracted - priority attack triggered
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(456.5663, 992.3262), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(442.4638, 986.4646), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (442.4638, 986.4646), intensity=0.02, dist=326
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (442.4638, 986.4646), intensity=1.00, dist=15
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(440.2166, 985.2426), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (440.2166, 985.2426), intensity=0.02, dist=324
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (440.2166, 985.2426), intensity=1.00, dist=20
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(437.3957, 983.9233), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (437.3957, 983.9233), intensity=0.02, dist=323
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (437.3957, 983.9233), intensity=1.00, dist=26
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(434.27228, 1034.0508), shooter_id=219395657938, bullet_pos=(67.128494, 1183.8866)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=396,54172
+[22:29:31] [INFO] [Bullet] Distance to wall: 396,54172 (27,001255% of viewport)
+[22:29:31] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(434.0211, 982.5624), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (434.0211, 982.5624), intensity=0.02, dist=321
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (434.0211, 982.5624), intensity=1.00, dist=32
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(430.117, 981.1941), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (430.117, 981.1941), intensity=0.02, dist=319
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (430.117, 981.1941), intensity=1.00, dist=39
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(117,1340), corner_timer=-0.02
+[22:29:31] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(475.8116, 980.6456), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:31] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(113,1336), corner_timer=0.30
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(433.6726, 1043.4022), shooter_id=219395657938, bullet_pos=(64.12409, 1547.444)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=624,9993
+[22:29:31] [INFO] [Bullet] Distance to wall: 624,9993 (42,557354% of viewport)
+[22:29:31] [ENEMY] [Enemy4] Death animation completed
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(433.6726, 1043.4022), shooter_id=219395657938, bullet_pos=(116.8808, 1601.918)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=642,10345
+[22:29:31] [INFO] [Bullet] Distance to wall: 642,10345 (43,722008% of viewport)
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(428.9358, 994.7868), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (428.9358, 994.7868), intensity=0.02, dist=333
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (428.9358, 994.7868), intensity=1.00, dist=28
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(419.18146, 1049.1854), shooter_id=219395657938, bullet_pos=(48.91846, 1499.9437)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=583,3333
+[22:29:31] [INFO] [Bullet] Distance to wall: 583,3333 (39,72024% of viewport)
+[22:29:31] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(427.3881, 994.2789), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (427.3881, 994.2789), intensity=0.02, dist=332
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (427.3881, 994.2789), intensity=1.00, dist=27
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(453.5242, 1000.528), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(425.2316, 993.6326), source=NEUTRAL (null), range=900, listeners=9
+[22:29:31] [ENEMY] [Enemy2] Heard CASING_KICK at (425.2316, 993.6326), intensity=0.02, dist=331
+[22:29:31] [ENEMY] [Enemy3] Heard CASING_KICK at (425.2316, 993.6326), intensity=1.00, dist=33
+[22:29:31] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[22:29:31] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(419.18146, 1049.1854), shooter_id=219395657938, bullet_pos=(147.4351, 1608.597)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=621,92236
+[22:29:31] [INFO] [Bullet] Distance to wall: 621,92236 (42,34784% of viewport)
+[22:29:31] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:31] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(433.6726, 1043.4022), shooter_id=219395657938, bullet_pos=(351.58716, 1405.5146)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=371,29965
+[22:29:31] [INFO] [Bullet] Distance to wall: 371,29965 (25,282475% of viewport)
+[22:29:31] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:31] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:31] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:31] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(434.27228, 1034.0508), shooter_id=219395657938, bullet_pos=(350.19583, 715.9708)
+[22:29:31] [INFO] [Bullet] Using shooter_position, distance=329,00412
+[22:29:31] [INFO] [Bullet] Distance to wall: 329,00412 (22,402496% of viewport)
+[22:29:31] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [LastChance] Threat detected: @Area2D@1415
+[22:29:32] [INFO] [LastChance] Player health is 2.0 - effect requires exactly 1 HP or less but alive
+[22:29:32] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:29:32] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(432.57877, 1033.9805), shooter_id=219395657938, bullet_pos=(43.042805, 1522.7402)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=624,9995
+[22:29:32] [INFO] [Bullet] Distance to wall: 624,9995 (42,55737% of viewport)
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [Player] Spawning blood effect at (80.063156, 1251.4323), dir=(1, 0), lethal=False (C#)
+[22:29:32] [INFO] [ImpactEffects] spawn_blood_effect called at (80.06316, 1251.432), dir=(1, 0), lethal=false
+[22:29:32] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:32] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:32] [INFO] [ImpactEffects] Blood effect spawned at (80.06316, 1251.432) (scale=1)
+[22:29:32] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[22:29:32] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[22:29:32] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(432.57877, 1033.9805), shooter_id=219395657938, bullet_pos=(117.25137, 1605.6237)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=652,8455
+[22:29:32] [INFO] [Bullet] Distance to wall: 652,8455 (44,453453% of viewport)
+[22:29:32] [INFO] [Bullet] Distance-based penetration chance: 94,804306%
+[22:29:32] [INFO] [Bullet] Starting wall penetration at (117.25137, 1605.6237)
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(419.18146, 1049.1854), shooter_id=219395657938, bullet_pos=(293.84317, 1411.1166)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=383,01938
+[22:29:32] [INFO] [Bullet] Distance to wall: 383,01938 (26,080496% of viewport)
+[22:29:32] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(464.8106, 1011.789), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:32] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [Bullet] Raycast backward hit penetrating body at distance 31,85806
+[22:29:32] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:29:32] [INFO] [Bullet] Exiting penetration at (144.21103, 1635.7349) after traveling 35,416668 pixels through wall
+[22:29:32] [INFO] [Bullet] Damage multiplier after penetration: 0,45
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [WARN] [FPS] Drop detected: 20 fps (threshold: 30)
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(434.27228, 1034.0508), shooter_id=219395657938, bullet_pos=(498.7681, 930.4177)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=122,0636
+[22:29:32] [INFO] [Bullet] Distance to wall: 122,0636 (8,311536% of viewport)
+[22:29:32] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [Bullet] Starting wall penetration at (498.7681, 930.4177)
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:29:32] [INFO] [Bullet] Exiting penetration at (516.18805, 955.5614) after traveling 25,588543 pixels through wall
+[22:29:32] [INFO] [Bullet] Damage multiplier after penetration: 0,1125
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(475.5417, 987.9611), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:32] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(419.18146, 1049.1854), shooter_id=219395657938, bullet_pos=(393.3767, 1595.6991)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=547,12256
+[22:29:32] [INFO] [Bullet] Distance to wall: 547,12256 (37,25458% of viewport)
+[22:29:32] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(410.683, 1053.8416), shooter_id=219395657938, bullet_pos=(41.680145, 1325.6995)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=458,33377
+[22:29:32] [INFO] [Bullet] Distance to wall: 458,33377 (31,20879% of viewport)
+[22:29:32] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(456.672, 1006.041), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:32] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [BloodDecal] Blood puddle created at (147.417, 1245.96) (added to group)
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [BloodDecal] Blood puddle created at (145.8903, 1264.94) (added to group)
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(419.94223, 1027.7295), shooter_id=219395657938, bullet_pos=(36.00367, 1278.0507)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=458,3334
+[22:29:32] [INFO] [Bullet] Distance to wall: 458,3334 (31,208765% of viewport)
+[22:29:32] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[22:29:32] [INFO] [BloodDecal] Blood puddle created at (158.5851, 1281.047) (added to group)
+[22:29:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(475.9253, 988.9053), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:32] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(397.0049, 1040.3054), shooter_id=219395657938, bullet_pos=(57.088467, 1198.6777)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=374,99997
+[22:29:32] [INFO] [Bullet] Distance to wall: 374,99997 (25,53444% of viewport)
+[22:29:32] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(419.94223, 1027.7295), shooter_id=219395657938, bullet_pos=(261.8229, 1391.9478)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=397,06003
+[22:29:32] [INFO] [Bullet] Distance to wall: 397,06003 (27,036549% of viewport)
+[22:29:32] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(410.683, 1053.8416), shooter_id=219395657938, bullet_pos=(468.6848, 1587.4269)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=536,7285
+[22:29:32] [INFO] [Bullet] Distance to wall: 536,7285 (36,546833% of viewport)
+[22:29:32] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [BloodDecal] Blood puddle created at (149.2597, 1302.609) (added to group)
+[22:29:32] [INFO] [BloodDecal] Blood puddle created at (165.5246, 1305.253) (added to group)
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.7°, current=89.4°, player=(80,1097), corner_timer=-0.02
+[22:29:32] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=92.3°, player=(80,1091), corner_timer=0.30
+[22:29:32] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(459.7437, 1014.009), source=ENEMY (Enemy3), range=1469, listeners=9
+[22:29:32] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [BloodDecal] Blood puddle created at (234.4145, 1347.018) (added to group)
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(414.41525, 1019.1622), shooter_id=219395657938, bullet_pos=(32.6977, 1186.2032)
+[22:29:32] [INFO] [Bullet] Using shooter_position, distance=416,66656
+[22:29:32] [INFO] [Bullet] Distance to wall: 416,66656 (28,371593% of viewport)
+[22:29:32] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:32] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[22:29:32] [INFO] [BloodDecal] Blood puddle created at (211.1681, 1354.034) (added to group)
+[22:29:32] [INFO] [BloodDecal] Blood puddle created at (215.3357, 1325.667) (added to group)
+[22:29:32] [INFO] [BloodDecal] Blood puddle created at (202.1405, 1347.692) (added to group)
+[22:29:32] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:29:32] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:32] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:29:32] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:29:32] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[22:29:32] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[22:29:32] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[22:29:32] [ENEMY] [Enemy1] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:29:32] [ENEMY] [Enemy2] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:29:32] [ENEMY] [Enemy3] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:29:32] [ENEMY] [Enemy4] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[22:29:32] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[22:29:32] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[22:29:32] [ENEMY] [Grenadier] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:29:32] [ENEMY] [Enemy6] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:29:32] [ENEMY] [Enemy7] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:29:32] [ENEMY] [Enemy8] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:29:32] [ENEMY] [Enemy9] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:29:32] [ENEMY] [Enemy10] Death animation component initialized
+[22:29:32] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:32] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:29:32] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:29:32] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:29:32] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[22:29:32] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:29:32] [INFO] [Player.Weapon] GameManager weapon selection: silenced_pistol (SilencedPistol)
+[22:29:32] [INFO] [Player.Weapon] Removed default MakarovPM
+[22:29:32] [INFO] [Player.Weapon] Equipped SilencedPistol (ammo: 13/13)
+[22:29:32] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:29:32] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:29:32] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:29:32] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:29:32] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:29:32] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[22:29:32] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[22:29:32] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[22:29:32] [INFO] [Player.Homing] Homing activation sound loaded
+[22:29:32] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[22:29:32] [INFO] [Player.Homing] Homing bullets equipped, charges: 6/6
+[22:29:32] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[22:29:32] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[22:29:32] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[22:29:32] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[22:29:32] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[22:29:32] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[22:29:32] [INFO] [Player] Ready! Ammo: 13/13, Grenades: 1/3, Health: 2/4
+[22:29:32] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:29:32] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:29:32] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:29:32] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:29:32] [INFO] [BuildingLevel] Setting up weapon: silenced_pistol
+[22:29:32] [INFO] [BuildingLevel] SilencedPistol already equipped by C# Player - skipping GDScript weapon swap
+[22:29:32] [INFO] [ScoreManager] Level started with 10 enemies
+[22:29:32] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[22:29:32] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[22:29:32] [INFO] [ReplayManager] Replay data cleared
+[22:29:32] [INFO] [BuildingLevel] Previous replay data cleared
+[22:29:32] [INFO] [ReplayManager] Detected player weapon: Silenced Pistol
+[22:29:32] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[22:29:32] [INFO] [ReplayManager] Level: BuildingLevel
+[22:29:32] [INFO] [ReplayManager] Player: Player (valid: True)
+[22:29:32] [INFO] [ReplayManager] Enemies count: 10
+[22:29:32] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/silenced_pistol_topdown.png
+[22:29:32] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[22:29:32] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[22:29:32] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[22:29:32] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[22:29:32] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[22:29:32] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[22:29:32] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[22:29:32] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[22:29:32] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[22:29:32] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[22:29:32] [INFO] [BuildingLevel] Replay recording started successfully
+[22:29:32] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:29:32] [INFO] [LastChance] Issue #937: Cached 44 StaticBody2D nodes for fast freeze traversal
+[22:29:32] [INFO] [CinemaEffects] Found player node: Player
+[22:29:32] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 10)
+[22:29:32] [ENEMY] [Enemy1] Registered as sound listener
+[22:29:32] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[22:29:32] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 11)
+[22:29:32] [ENEMY] [Enemy2] Registered as sound listener
+[22:29:32] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:29:32] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 12)
+[22:29:32] [ENEMY] [Enemy3] Registered as sound listener
+[22:29:32] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:29:32] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 13)
+[22:29:32] [ENEMY] [Enemy4] Registered as sound listener
+[22:29:32] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[22:29:32] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 14)
+[22:29:32] [ENEMY] [Grenadier] Registered as sound listener
+[22:29:32] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:29:32] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 15)
+[22:29:32] [ENEMY] [Enemy6] Registered as sound listener
+[22:29:32] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:29:32] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 16)
+[22:29:32] [ENEMY] [Enemy7] Registered as sound listener
+[22:29:32] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[22:29:32] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 17)
+[22:29:32] [ENEMY] [Enemy8] Registered as sound listener
+[22:29:32] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:29:32] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 18)
+[22:29:32] [ENEMY] [Enemy9] Registered as sound listener
+[22:29:32] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[22:29:32] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:29:32] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 19)
+[22:29:32] [ENEMY] [Enemy10] Registered as sound listener
+[22:29:32] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:29:32] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:29:32] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[22:29:32] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:32] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:32] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:32] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:32] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:32] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:32] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=213.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:32] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:32] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:29:32] [INFO] [Player] Detected weapon: Silenced Pistol (Pistol pose)
+[22:29:32] [INFO] [Player] Applied Pistol arm pose: Left=(16, 6), Right=(4, 6)
+[22:29:33] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:29:33] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:29:33] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:29:33] [INFO] [LastChance] Found player: Player
+[22:29:33] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:29:33] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:29:33] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:29:33] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[22:29:33] [INFO] [BloodDecal] Blood puddle created at (216.0657, 1349.313) (added to group)
+[22:29:33] [WARN] [FPS] Drop detected: 14 fps (threshold: 30)
+[22:29:33] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[22:29:34] [INFO] [Player] Invincibility mode: ON
+[22:29:34] [INFO] [ExperimentalSettings] Invincibility mode enabled
+[22:29:34] [INFO] [GameManager] Invincibility mode toggled: ON
+[22:29:34] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:34] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:29:34] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1250), corner_timer=0.30
+[22:29:34] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1250), corner_timer=0.30
+[22:29:34] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1235), corner_timer=-0.02
+[22:29:34] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:34] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1235), corner_timer=-0.02
+[22:29:34] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:29:34] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1231), corner_timer=0.30
+[22:29:34] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1231), corner_timer=0.30
+[22:29:34] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[22:29:35] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,1133), corner_timer=-0.02
+[22:29:35] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:29:35] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,1127), corner_timer=0.30
+[22:29:35] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:35] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[22:29:35] [INFO] [Player.Grenade] G pressed - starting grab animation
+[22:29:35] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:35] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (706.1371, 843.0668)
+[22:29:35] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[22:29:35] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[22:29:35] [INFO] [DefensiveGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[22:29:35] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 700
+[22:29:35] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[22:29:35] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[22:29:35] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[22:29:35] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1041.9445)
+[22:29:35] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[22:29:35] [INFO] [Player.Grenade] Step 1 complete! Drag: (163.67462, 34.830933)
+[22:29:35] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(450,1035), corner_timer=-0.02
+[22:29:35] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[22:29:35] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(450,1032), corner_timer=0.30
+[22:29:35] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[22:29:35] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - starting trajectory aiming
+[22:29:35] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(450,1020), corner_timer=-0.02
+[22:29:35] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[22:29:35] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(450,1020), corner_timer=0.30
+[22:29:35] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[22:29:36] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(450,990), corner_timer=-0.02
+[22:29:36] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[22:29:36] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(450,985), corner_timer=0.30
+[22:29:36] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:36] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(343,916), corner_timer=-0.02
+[22:29:36] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[22:29:36] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(338,918), corner_timer=0.30
+[22:29:36] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:36] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[22:29:36] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(296,937), corner_timer=-0.02
+[22:29:36] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[22:29:36] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(296,937), corner_timer=0.30
+[22:29:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:37] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(296,937), corner_timer=-0.02
+[22:29:37] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[22:29:37] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(296,937), corner_timer=0.30
+[22:29:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:37] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(296,937), corner_timer=-0.02
+[22:29:37] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[22:29:37] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(296,937), corner_timer=0.30
+[22:29:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:37] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[22:29:37] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(296,937), corner_timer=-0.02
+[22:29:37] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:37] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(296,937), corner_timer=0.30
+[22:29:38] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:38] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(296,937), corner_timer=-0.02
+[22:29:38] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:38] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(296,937), corner_timer=0.30
+[22:29:38] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:38] [INFO] [Player.Grenade.Simple] Throwing! Target: (670.06226, 643.4322), Distance: 415,1, Speed: 499,1, Friction: 300,0
+[22:29:38] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,6669053
+[22:29:38] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[22:29:38] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.78573966, -0.6185573), speed=499,1, spawn=(343.8993, 900.1972)
+[22:29:38] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.78574, -0.618557), Speed: 499.1 (clamped from 499.1, max: 1000.0)
+[22:29:38] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[22:29:38] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[22:29:38] [INFO] [Player.Grenade] State reset to IDLE
+[22:29:38] [INFO] [Player.Grenade] State reset to IDLE
+[22:29:38] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[22:29:38] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(296,937), corner_timer=-0.02
+[22:29:38] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:38] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(296,937), corner_timer=0.30
+[22:29:38] [INFO] [Player.Grenade] Player rotation restored to 0
+[22:29:38] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:38] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[22:29:38] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[22:29:38] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(296,937), corner_timer=-0.02
+[22:29:38] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:38] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(296,937), corner_timer=0.30
+[22:29:39] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(342,937), corner_timer=-0.02
+[22:29:39] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(347,937), corner_timer=0.30
+[22:29:39] [INFO] [GrenadeBase] EXPLODED at (577.2097, 716.5283)!
+[22:29:39] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(577.2097, 716.5283), source=NEUTRAL (DefensiveGrenade), range=2937, listeners=19
+[22:29:39] [INFO] [SoundPropagation] Cleaned up 9 invalid listeners
+[22:29:39] [ENEMY] [Enemy1] Heard EXPLOSION at (577.2097, 716.5283), intensity=0.01, distance=460
+[22:29:39] [ENEMY] [Enemy2] Heard EXPLOSION at (577.2097, 716.5283), intensity=0.04, distance=243
+[22:29:39] [ENEMY] [Enemy3] Heard EXPLOSION at (577.2097, 716.5283), intensity=0.15, distance=127
+[22:29:39] [ENEMY] [Enemy4] Heard EXPLOSION at (577.2097, 716.5283), intensity=0.03, distance=289
+[22:29:39] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=0, self=0, below_threshold=6
+[22:29:39] [ENEMY] [Enemy1] Hit: dmg=1, hp=2/2->1/2
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (300, 350), dir=(-0.603217, -0.797577), lethal=false
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Wall found for blood splatter at (242.5203, 274) (dist=95 px)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (242.5203, 275) (added to group)
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (300, 350) (scale=1)
+[22:29:39] [ENEMY] [Enemy1] Hit: dmg=1, hp=1/2->0/2
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (300, 350), dir=(-0.603217, -0.797577), lethal=true
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Wall found for blood splatter at (242.5203, 274) (dist=95 px)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (242.5203, 275) (added to group)
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (300, 350) (scale=1.5)
+[22:29:39] [ENEMY] [Enemy1] Enemy died (ricochet: false, penetration: false)
+[22:29:39] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:29:39] [ENEMY] [Enemy1] [AllyDeath] Notified 1 enemies
+[22:29:39] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 9)
+[22:29:39] [INFO] [DeathAnim] Started - Angle: -127.1 deg, Index: 3
+[22:29:39] [ENEMY] [Enemy1] Death animation started with hit direction: (-0.603217, -0.797577)
+[22:29:39] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 459.6
+[22:29:39] [ENEMY] [Enemy2] Hit: dmg=1, hp=4/4->3/4
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.728728, -0.684803), lethal=false
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:29:39] [ENEMY] [Enemy2] Hit: dmg=1, hp=3/4->2/4
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.728728, -0.684803), lethal=false
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:29:39] [ENEMY] [Enemy2] Hit: dmg=1, hp=2/4->1/4
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.728728, -0.684803), lethal=false
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:29:39] [ENEMY] [Enemy2] Hit: dmg=1, hp=1/4->0/4
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.728728, -0.684803), lethal=true
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1.5)
+[22:29:39] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[22:29:39] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[22:29:39] [ENEMY] [Enemy2] [AllyDeath] Notified 1 enemies
+[22:29:39] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 8)
+[22:29:39] [INFO] [DeathAnim] Started - Angle: -136.8 deg, Index: 2
+[22:29:39] [ENEMY] [Enemy2] Death animation started with hit direction: (-0.728728, -0.684803)
+[22:29:39] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 243.2
+[22:29:39] [ENEMY] [Enemy3] Hit: dmg=1, hp=3/3->2/3
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.964797, 0.262996), lethal=false
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[22:29:39] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/3->1/3
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.964797, 0.262996), lethal=false
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[22:29:39] [ENEMY] [Enemy3] Hit: dmg=1, hp=1/3->0/3
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.964797, 0.262996), lethal=true
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1.5)
+[22:29:39] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[22:29:39] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[22:29:39] [ENEMY] [Enemy3] [AllyDeath] Notified 1 enemies
+[22:29:39] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 7)
+[22:29:39] [INFO] [DeathAnim] Started - Angle: 15.2 deg, Index: 13
+[22:29:39] [ENEMY] [Enemy3] Death animation started with hit direction: (0.964797, 0.262996)
+[22:29:39] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 127.3
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #1 at angle 0.5 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #2 at angle 23.2 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #3 at angle 7.8 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #4 at angle 23.1 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #5 at angle 36.1 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #6 at angle 48.8 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #7 at angle 45.4 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #8 at angle 65.7 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #9 at angle 74.4 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #10 at angle 87.2 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #11 at angle 76.6 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #12 at angle 102.5 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #13 at angle 94.6 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #14 at angle 104.2 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #15 at angle 121.0 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #16 at angle 135.9 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #17 at angle 129.1 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #18 at angle 139.1 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #19 at angle 152.5 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #20 at angle 156.5 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #21 at angle 170.4 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #22 at angle 191.7 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #23 at angle 212.6 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #24 at angle 206.0 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #25 at angle 209.9 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #26 at angle 217.9 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #27 at angle 233.6 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #28 at angle 253.6 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #29 at angle 244.1 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #30 at angle 252.9 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #31 at angle 283.9 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #32 at angle 278.1 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #33 at angle 284.9 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #34 at angle 303.1 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #35 at angle 312.8 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #36 at angle 308.0 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #37 at angle 325.0 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #38 at angle 340.8 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #39 at angle 352.0 degrees
+[22:29:39] [INFO] [DefensiveGrenade] Spawned shrapnel #40 at angle 356.9 degrees
+[22:29:39] [INFO] [GrenadeTimer] Timer expired for Flashbang grenade!
+[22:29:39] [INFO] [GrenadeTimer] Flashbang grenade activated at (577.20966, 716.52826)!
+[22:29:39] [INFO] [GrenadeTimer] Applying flashbang effects (radius: 700, blindness: 12s, stun: 6s)
+[22:29:39] [INFO] [FlashbangStatus] Flashbang: blind=4.1s, stun=2.1s
+[22:29:39] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:29:39] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:29:39] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 459,6 (intensity: 0,34)
+[22:29:39] [INFO] [FlashbangStatus] Flashbang: blind=7.8s, stun=3.9s
+[22:29:39] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:29:39] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:29:39] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 243,2 (intensity: 0,65)
+[22:29:39] [INFO] [FlashbangStatus] Flashbang: blind=9.8s, stun=4.9s
+[22:29:39] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:29:39] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:29:39] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 127,3 (intensity: 0,82)
+[22:29:39] [INFO] [GrenadeTimer] Player behind wall - flashbang blocked (distance: 295,6)
+[22:29:39] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(577.2097, 716.5283), source=NEUTRAL (DefensiveGrenade), range=2938, listeners=7
+[22:29:39] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=6
+[22:29:39] [INFO] [GrenadeTimer] Spawned flashbang effect at (577.20966, 716.52826) (radius: 700)
+[22:29:39] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=174.9°, current=-67.5°, player=(380,937), corner_timer=0.00
+[22:29:39] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(452,937), corner_timer=-0.02
+[22:29:39] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(457,937), corner_timer=0.30
+[22:29:39] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (273.3538, 312.1007) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (245.857, 298.9844) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (255.7566, 299.4625) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (280.7528, 282.5285) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (331.5035, 522.632) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (338.2089, 538.8192) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (384.3937, 527.9333) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (769.1254, 812.616) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (760.5881, 802.4706) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (743.0261, 788.3663) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (769.7366, 804.524) (added to group)
+[22:29:39] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=90.0°, current=147.6°, player=(468,937), corner_timer=0.00
+[22:29:39] [ENEMY] [Enemy4] State: RETREATING -> IN_COVER
+[22:29:39] [ENEMY] [Enemy4] State: IN_COVER -> SUPPRESSED
+[22:29:39] [ENEMY] [Enemy4] Hit: dmg=1, hp=3/3->2/3
+[22:29:39] [INFO] [ImpactEffects] spawn_blood_effect called at (770.2362, 913.0625), dir=(0.055432, 0.998463), lethal=false
+[22:29:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:39] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:39] [INFO] [ImpactEffects] Wall found for blood splatter at (775.0627, 1000) (dist=87 px)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (775.0627, 999) (added to group)
+[22:29:39] [INFO] [ImpactEffects] Blood effect spawned at (770.2362, 913.0625) (scale=1)
+[22:29:39] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (248.0539, 312.4968) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (280.5266, 327.7401) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (352.3986, 487.1158) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (298.0009, 512.3649) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (312.0137, 527.1153) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (346.3117, 518.0012) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (352.6679, 498.4373) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (329.2555, 539.0164) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (347.25, 530.7008) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (377.4337, 514.2507) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (291.0933, 511.6942) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (350.9027, 492.2026) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (337.2002, 511.0554) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (809.5468, 826.8218) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (800.1665, 764.7344) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (763.6459, 778.6931) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (754.0555, 799.9191) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (788.1102, 793.9213) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (750.2114, 789.96) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (764.5972, 777.5485) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (771.2118, 809.7452) (added to group)
+[22:29:39] [INFO] [BloodyFeet:Enemy1] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:29:39] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[22:29:39] [ENEMY] [Enemy1] Ragdoll activated
+[22:29:39] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:29:39] [ENEMY] [Enemy2] Ragdoll activated
+[22:29:39] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:29:39] [ENEMY] [Enemy3] Ragdoll activated
+[22:29:39] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (227.3053, 287.7521) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (253.7941, 298.7956) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (191.7222, 301.7816) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (188.8419, 316.6701) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (218.1035, 309.6589) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (198.0053, 281.4015) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (266.0337, 304.2748) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (225.6001, 319.9418) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (307.3341, 535.5199) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (346.1881, 532.3049) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (284.7052, 487.4614) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (352.6774, 488.4226) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (325.0331, 559.1387) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (289.7017, 571.2996) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (342.0553, 510.7379) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (264.9445, 498.2958) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (780.8671, 788.8286) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (812.212, 824.7532) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (843.6332, 769.7918) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (798.0638, 789.4254) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (772.2729, 810.9093) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (836.9695, 762.9172) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (782.5206, 789.3855) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (803.1263, 814.6359) (added to group)
+[22:29:39] [INFO] [BloodDecal] Blood puddle created at (851.1678, 831.011) (added to group)
+[22:29:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:39] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (162.2221, 340.4516) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (203.1057, 302.7662) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (170.8214, 339.9615) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (340.154, 524.2939) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (328.2658, 500.4366) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (342.23, 454.2218) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (315.2021, 494.3531) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (276.8297, 526.4888) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (339.654, 503.143) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (210.5112, 546.4171) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (278.6096, 559.0616) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (322.2147, 515.1168) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (264.4746, 576.2413) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (283.6124, 555.4457) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (268.6517, 519.5316) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (787.7974, 802.0339) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (823.7624, 865.9897) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (777.0309, 814.0292) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (797.1467, 807.4875) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (842.8669, 791.7413) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (865.0753, 870.4243) (added to group)
+[22:29:40] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (193.0099, 368.4247) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (243.6212, 323.7961) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (163.2286, 374.7135) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (233.4424, 366.1289) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (103.2662, 332.0311) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (254.8643, 593.7657) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (291.2808, 538.0624) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (269.1299, 521.1719) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (216.5114, 537.9961) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (331.4269, 556.2448) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (255.4382, 547.4514) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (333.694, 530.3148) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (324.9072, 553.5596) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (299.3715, 500.1797) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (261.056, 536.5483) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (273.9326, 479.1012) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (347.4215, 525.957) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (883.3915, 839.9991) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (823.9134, 820.8992) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (894.2612, 833.6867) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (878.4699, 918.0153) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (755.2675, 998.9984) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (138.9485, 377.2821) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (233.8708, 502.4045) (added to group)
+[22:29:40] [INFO] [BloodDecal] Blood puddle created at (192.2497, 594.9641) (added to group)
+[22:29:40] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:40] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:40] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:40] [WARN] [FPS] Drop detected: 28 fps (threshold: 30)
+[22:29:40] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:40] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:40] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:40] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:40] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:40] [ENEMY] [Enemy1] Death animation completed
+[22:29:40] [ENEMY] [Enemy2] Death animation completed
+[22:29:40] [ENEMY] [Enemy3] Death animation completed
+[22:29:40] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=10
+[22:29:40] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:40] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:40] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:41] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:41] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:41] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:41] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:41] [WARN] [FPS] Drop detected: 23 fps (threshold: 30)
+[22:29:41] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:41] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:41] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:41] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:41] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:41] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=10
+[22:29:41] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:41] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:41] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:42] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:42] [ENEMY] [Enemy4] State: SUPPRESSED -> IN_COVER
+[22:29:42] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:42] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:42] [ENEMY] [Enemy4] State: IN_COVER -> PURSUING
+[22:29:42] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:42] [ENEMY] [Enemy4] ROT_CHANGE: P4:velocity -> P2:combat_state, state=PURSUING, target=175.2°, current=-93.2°, player=(483,937), corner_timer=0.00
+[22:29:42] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:42] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:42] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:42] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:42] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:42] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=10
+[22:29:42] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:42] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:42] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:43] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:43] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:43] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:43] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:43] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:43] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,937), corner_timer=-0.02
+[22:29:43] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:43] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,937), corner_timer=0.30
+[22:29:43] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:43] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=10
+[22:29:43] [ENEMY] [Enemy4] PURSUING corner check: angle -76.1°
+[22:29:43] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,915), corner_timer=-0.02
+[22:29:43] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:43] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,911), corner_timer=0.30
+[22:29:44] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:44] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,809), corner_timer=-0.02
+[22:29:44] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:44] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,803), corner_timer=0.30
+[22:29:44] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-148.2°, current=-149.2°, player=(485,780), corner_timer=0.17
+[22:29:44] [INFO] [ScoreManager] Combo ended at 3. Max combo: 3
+[22:29:44] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[22:29:44] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:44] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(701.6085, 914.0663), source=ENEMY (Enemy4), range=1469, listeners=7
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=5
+[22:29:44] [INFO] [LastChance] Threat detected: Bullet
+[22:29:44] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:29:44] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:29:44] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(685.9245, 914.0658), source=ENEMY (Enemy4), range=1469, listeners=7
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=5
+[22:29:44] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(641.40466, 882.3474), shooter_id=353814711931, bullet_pos=(366.41785, 693.95044)
+[22:29:44] [INFO] [Bullet] Using shooter_position, distance=333,33344
+[22:29:44] [INFO] [Bullet] Distance to wall: 333,33344 (22,697289% of viewport)
+[22:29:44] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:44] [INFO] [LastChance] Threat detected: @Area2D@2039
+[22:29:44] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:29:44] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:29:44] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(521,743), corner_timer=-0.02
+[22:29:44] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:44] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(526,742), corner_timer=0.30
+[22:29:44] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[22:29:44] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(630.80237, 874.16406), shooter_id=353814711931, bullet_pos=(446.07275, 705.71545)
+[22:29:44] [INFO] [Bullet] Using shooter_position, distance=249,99992
+[22:29:44] [INFO] [Bullet] Distance to wall: 249,99992 (17,022955% of viewport)
+[22:29:44] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(704.8458, 893.7665), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (704.8458, 893.7665), intensity=1.00, dist=26
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(705.3636, 893.3757), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (705.3636, 893.3757), intensity=1.00, dist=26
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(688.5964, 893.9042), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (688.5964, 893.9042), intensity=1.00, dist=20
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(705.871, 892.9077), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (705.871, 892.9077), intensity=1.00, dist=25
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(689.6511, 892.9921), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (689.6511, 892.9921), intensity=1.00, dist=21
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(692.0998, 914.066), source=ENEMY (Enemy4), range=1469, listeners=7
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=5
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(706.3713, 892.3298), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (706.3713, 892.3298), intensity=1.00, dist=27
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(690.1896, 892.1541), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (690.1896, 892.1541), intensity=1.00, dist=24
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [LastChance] Threat detected: @Area2D@2045
+[22:29:44] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:29:44] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(706.8862, 891.5349), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (706.8862, 891.5349), intensity=1.00, dist=30
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(690.5231, 891.1685), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (690.5231, 891.1685), intensity=1.00, dist=28
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(641.40466, 882.3474), shooter_id=353814711931, bullet_pos=(59.777863, 880.95996)
+[22:29:44] [INFO] [Bullet] Using shooter_position, distance=581,6285
+[22:29:44] [INFO] [Bullet] Distance to wall: 581,6285 (39,604153% of viewport)
+[22:29:44] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(706.8862, 891.7448), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (706.8862, 891.7448), intensity=1.00, dist=31
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(690.5231, 891.6561), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (690.5231, 891.6561), intensity=1.00, dist=30
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(707.0552, 891.29), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (707.0552, 891.29), intensity=1.00, dist=33
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(690.3798, 891.2496), source=NEUTRAL (null), range=900, listeners=7
+[22:29:44] [ENEMY] [Enemy4] Heard CASING_KICK at (690.3798, 891.2496), intensity=1.00, dist=32
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(698.4185, 922.6377), source=ENEMY (Enemy4), range=1469, listeners=7
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=5
+[22:29:44] [INFO] [LastChance] Threat detected: @Area2D@2048
+[22:29:44] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:29:44] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:29:44] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(642.30316, 864.4402), shooter_id=353814711931, bullet_pos=(457.33362, 696.2549)
+[22:29:44] [INFO] [Bullet] Using shooter_position, distance=250,00006
+[22:29:44] [INFO] [Bullet] Distance to wall: 250,00006 (17,022964% of viewport)
+[22:29:44] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:44] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(707.0002, 928.9506), source=ENEMY (Enemy4), range=1469, listeners=7
+[22:29:44] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=1, below_threshold=5
+[22:29:44] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(680.4164, 870.8966), shooter_id=353814711931, bullet_pos=(680.4164, 870.8966)
+[22:29:44] [INFO] [Bullet] Using shooter_position, distance=0
+[22:29:44] [INFO] [Bullet] Distance to wall: 0 (0% of viewport)
+[22:29:44] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[22:29:44] [INFO] [Bullet] Starting wall penetration at (680.4164, 870.8966)
+[22:29:44] [INFO] [LastChance] Threat detected: @Area2D@2051
+[22:29:44] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[22:29:44] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[22:29:44] [INFO] [Bullet] Raycast backward hit penetrating body at distance 45,84005
+[22:29:44] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:29:44] [INFO] [Bullet] Exiting penetration at (656.91284, 830.5808) after traveling 41,66667 pixels through wall
+[22:29:44] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:29:44] [INFO] [ReplayManager] Recording frame 720 (12,0s): player_valid=True, enemies=10
+[22:29:44] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P3:corner, state=RETREATING, target=-76.1°, current=-12.6°, player=(607,741), corner_timer=0.17
+[22:29:44] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(552.2156, 741.4121), shooter_id=356817833460, bullet_pos=(643.7639, 1006.552)
+[22:29:44] [INFO] [Bullet] Using shooter_position, distance=280.499755859375
+[22:29:44] [INFO] [Bullet] Distance to wall: 280.499755859375 (19.0997441700344% of viewport)
+[22:29:44] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:44] [INFO] [Bullet] Caliber cannot penetrate walls
+[22:29:44] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(630.80237, 874.16406), shooter_id=353814711931, bullet_pos=(64.3717, 1082.3699)
+[22:29:44] [INFO] [Bullet] Using shooter_position, distance=603,4843
+[22:29:44] [INFO] [Bullet] Distance to wall: 603,4843 (41,092358% of viewport)
+[22:29:44] [ENEMY] [Enemy4] State: RETREATING -> IN_COVER
+[22:29:44] [ENEMY] [Enemy4] State: IN_COVER -> SUPPRESSED
+[22:29:44] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(629,741), corner_timer=-0.02
+[22:29:44] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:44] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(634,741), corner_timer=0.30
+[22:29:45] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(652.47925, 867.96716), shooter_id=353814711931, bullet_pos=(286.29803, 468.82574)
+[22:29:45] [INFO] [Bullet] Using shooter_position, distance=541,66644
+[22:29:45] [INFO] [Bullet] Distance to wall: 541,66644 (36,883064% of viewport)
+[22:29:45] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:45] [INFO] [Bullet] Starting wall penetration at (286.29803, 468.82574)
+[22:29:45] [INFO] [Bullet] No longer inside obstacle - raycasts found no collision with penetrating body
+[22:29:45] [INFO] [Bullet] Exiting penetration at (254.7501, 434.43817) after traveling 41,66667 pixels through wall
+[22:29:45] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[22:29:45] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:45] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(642.30316, 864.4402), shooter_id=353814711931, bullet_pos=(51.793945, 1194.5962)
+[22:29:45] [INFO] [Bullet] Using shooter_position, distance=676,5383
+[22:29:45] [INFO] [Bullet] Distance to wall: 676,5383 (46,066742% of viewport)
+[22:29:45] [INFO] [Bullet] Distance-based penetration chance: 92,92214%
+[22:29:45] [INFO] [Bullet] Starting wall penetration at (51.793945, 1194.5962)
+[22:29:45] [INFO] [Bullet] Raycast backward hit penetrating body at distance 9,056917
+[22:29:45] [INFO] [Bullet] Body exited signal received for penetrating body
+[22:29:45] [INFO] [Bullet] Exiting penetration at (26.283339, 1225.9446) after traveling 35,416668 pixels through wall
+[22:29:45] [INFO] [Bullet] Damage multiplier after penetration: 0,45
+[22:29:45] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(630.80237, 874.16406), shooter_id=353814711931, bullet_pos=(347.62177, 1401.1743)
+[22:29:45] [INFO] [Bullet] Using shooter_position, distance=598,2734
+[22:29:45] [INFO] [Bullet] Distance to wall: 598,2734 (40,737537% of viewport)
+[22:29:45] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(739,741), corner_timer=-0.02
+[22:29:45] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:45] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(744,741), corner_timer=0.30
+[22:29:45] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:45] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(630.80237, 874.16406), shooter_id=353814711931, bullet_pos=(653.832, 1017.1234)
+[22:29:45] [INFO] [Bullet] Using shooter_position, distance=144,80241
+[22:29:45] [INFO] [Bullet] Distance to wall: 144,80241 (9,859863% of viewport)
+[22:29:45] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[22:29:45] [ENEMY] [Enemy4] State: SUPPRESSED -> SEEKING_COVER
+[22:29:45] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[22:29:45] [ENEMY] [Enemy4] State: SEEKING_COVER -> IN_COVER
+[22:29:45] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(839,741), corner_timer=-0.02
+[22:29:45] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:45] [ENEMY] [Enemy4] State: IN_COVER -> SUPPRESSED
+[22:29:45] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(842,741), corner_timer=0.30
+[22:29:45] [INFO] [ReplayManager] Recording frame 780 (13,0s): player_valid=True, enemies=10
+[22:29:46] [INFO] [PauseMenu] Armory button pressed
+[22:29:46] [INFO] [PauseMenu] Creating new armory menu instance
+[22:29:46] [INFO] [PauseMenu] armory_menu_scene resource path: res://scenes/ui/ArmoryMenu.tscn
+[22:29:46] [INFO] [PauseMenu] Instance created, class: CanvasLayer, name: ArmoryMenu
+[22:29:46] [INFO] [PauseMenu] Script attached: res://scripts/ui/armory_menu.gd
+[22:29:46] [INFO] [PauseMenu] back_pressed signal exists on instance
+[22:29:46] [INFO] [PauseMenu] back_pressed signal connected
+[22:29:46] [INFO] [PauseMenu] Armory menu instance added as child, is_inside_tree: true
+[22:29:46] [INFO] [PauseMenu] _populate_weapon_grid method exists
+[22:29:46] [INFO] [ReplayManager] Recording frame 840 (14,0s): player_valid=True, enemies=10
+[22:29:47] [INFO] [PersistManager] State saved to user://game_state.cfg
+[22:29:47] [INFO] [GameManager] Weapon selected: m16
+[22:29:47] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:29:47] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:47] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:29:47] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:29:47] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[22:29:47] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[22:29:47] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[22:29:47] [ENEMY] [Enemy1] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:29:47] [ENEMY] [Enemy2] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:29:47] [ENEMY] [Enemy3] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:29:47] [ENEMY] [Enemy4] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[22:29:47] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[22:29:47] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[22:29:47] [ENEMY] [Grenadier] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:29:47] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:47] [ENEMY] [Enemy6] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:29:47] [ENEMY] [Enemy7] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:29:47] [ENEMY] [Enemy8] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:29:47] [ENEMY] [Enemy9] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:29:47] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:47] [ENEMY] [Enemy10] Death animation component initialized
+[22:29:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:47] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:29:47] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:29:47] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:29:47] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[22:29:47] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:29:47] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[22:29:47] [INFO] [Player.Weapon] Removed default MakarovPM
+[22:29:47] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[22:29:47] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:29:47] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:29:47] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:29:47] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:29:47] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:29:47] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[22:29:47] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[22:29:47] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[22:29:47] [INFO] [Player.Homing] Homing activation sound loaded
+[22:29:47] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[22:29:47] [INFO] [Player.Homing] Homing bullets equipped, charges: 6/6
+[22:29:47] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[22:29:47] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[22:29:47] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[22:29:47] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[22:29:47] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[22:29:47] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[22:29:47] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[22:29:47] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:29:47] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:29:47] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:29:47] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:29:47] [INFO] [BuildingLevel] Setting up weapon: m16
+[22:29:47] [INFO] [BuildingLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[22:29:47] [INFO] [ScoreManager] Level started with 10 enemies
+[22:29:47] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[22:29:47] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[22:29:47] [INFO] [ReplayManager] Replay data cleared
+[22:29:47] [INFO] [BuildingLevel] Previous replay data cleared
+[22:29:47] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[22:29:47] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[22:29:47] [INFO] [ReplayManager] Level: BuildingLevel
+[22:29:47] [INFO] [ReplayManager] Player: Player (valid: True)
+[22:29:47] [INFO] [ReplayManager] Enemies count: 10
+[22:29:47] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[22:29:47] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[22:29:47] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[22:29:47] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[22:29:47] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[22:29:47] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[22:29:47] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[22:29:47] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[22:29:47] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[22:29:47] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[22:29:47] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[22:29:47] [INFO] [BuildingLevel] Replay recording started successfully
+[22:29:47] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:29:47] [INFO] [LastChance] Issue #937: Cached 44 StaticBody2D nodes for fast freeze traversal
+[22:29:47] [INFO] [CinemaEffects] Found player node: Player
+[22:29:47] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 8)
+[22:29:47] [ENEMY] [Enemy1] Registered as sound listener
+[22:29:47] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[22:29:47] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 9)
+[22:29:47] [ENEMY] [Enemy2] Registered as sound listener
+[22:29:47] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:29:47] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 10)
+[22:29:47] [ENEMY] [Enemy3] Registered as sound listener
+[22:29:47] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:29:47] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 11)
+[22:29:47] [ENEMY] [Enemy4] Registered as sound listener
+[22:29:47] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[22:29:47] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 12)
+[22:29:47] [ENEMY] [Grenadier] Registered as sound listener
+[22:29:47] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:29:47] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 13)
+[22:29:47] [ENEMY] [Enemy6] Registered as sound listener
+[22:29:47] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[22:29:47] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 14)
+[22:29:47] [ENEMY] [Enemy7] Registered as sound listener
+[22:29:47] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[22:29:47] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 15)
+[22:29:47] [ENEMY] [Enemy8] Registered as sound listener
+[22:29:47] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[22:29:47] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 16)
+[22:29:47] [ENEMY] [Enemy9] Registered as sound listener
+[22:29:47] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:29:47] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:29:47] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 17)
+[22:29:47] [ENEMY] [Enemy10] Registered as sound listener
+[22:29:47] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[22:29:47] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:29:48] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[22:29:48] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:48] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:48] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:48] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:48] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:48] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:48] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:48] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:48] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:29:48] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:29:48] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:29:48] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:29:48] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:29:48] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:29:48] [INFO] [LastChance] Found player: Player
+[22:29:48] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:29:48] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:29:48] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:29:48] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[22:29:48] [WARN] [FPS] Drop detected: 26 fps (threshold: 30)
+[22:29:49] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[22:29:49] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:49] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:29:49] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(483,929), corner_timer=0.30
+[22:29:49] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(483,929), corner_timer=0.30
+[22:29:49] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:49] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[22:29:49] [INFO] [Player.Grenade] G pressed - starting grab animation
+[22:29:49] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:49] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (762.90955, 867.54205)
+[22:29:49] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(483,922), corner_timer=-0.02
+[22:29:49] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:49] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(483,922), corner_timer=-0.02
+[22:29:49] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:29:49] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(483,922), corner_timer=0.30
+[22:29:49] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(483,922), corner_timer=0.30
+[22:29:49] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[22:29:49] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[22:29:49] [INFO] [DefensiveGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[22:29:49] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 700
+[22:29:49] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[22:29:49] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[22:29:49] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[22:29:49] [INFO] [Player.Grenade] Timer started, grenade created at (483.9331, 922.4279)
+[22:29:49] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[22:29:49] [INFO] [Player.Grenade] Step 1 complete! Drag: (98.87732, 11.1622925)
+[22:29:49] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[22:29:49] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - starting trajectory aiming
+[22:29:50] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[22:29:50] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(483,922), corner_timer=-0.02
+[22:29:50] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:29:50] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(483,922), corner_timer=0.30
+[22:29:50] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(483,922), corner_timer=-0.02
+[22:29:50] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[22:29:50] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(483,922), corner_timer=0.30
+[22:29:50] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(483,922), corner_timer=-0.02
+[22:29:50] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[22:29:50] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(483,922), corner_timer=0.30
+[22:29:51] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[22:29:51] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(483,922), corner_timer=-0.02
+[22:29:51] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[22:29:51] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(483,922), corner_timer=0.30
+[22:29:51] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:51] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(483,922), corner_timer=-0.02
+[22:29:51] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[22:29:51] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(483,922), corner_timer=0.30
+[22:29:51] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:51] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[22:29:52] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(483,922), corner_timer=-0.02
+[22:29:52] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[22:29:52] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(483,922), corner_timer=0.30
+[22:29:52] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:52] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(468,922), corner_timer=-0.02
+[22:29:52] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[22:29:52] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(465,922), corner_timer=0.30
+[22:29:52] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:52] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(374,905), corner_timer=-0.02
+[22:29:52] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[22:29:52] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(370,902), corner_timer=0.30
+[22:29:52] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:52] [INFO] [Player.Grenade.Simple] Throwing! Target: (710.14575, 645.3824), Distance: 379,2, Speed: 477,0, Friction: 300,0
+[22:29:52] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,5411864
+[22:29:52] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[22:29:52] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.8570981, -0.5151532), speed=477,0, spawn=(385.12994, 840.731)
+[22:29:52] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.857098, -0.515153), Speed: 477.0 (clamped from 477.0, max: 1000.0)
+[22:29:52] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[22:29:52] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[22:29:52] [INFO] [Player.Grenade] State reset to IDLE
+[22:29:52] [INFO] [Player.Grenade] State reset to IDLE
+[22:29:52] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[22:29:52] [INFO] [Player.Grenade] Player rotation restored to 0
+[22:29:52] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[22:29:53] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(319,858), corner_timer=-0.02
+[22:29:53] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:53] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(319,858), corner_timer=0.30
+[22:29:53] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:53] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[22:29:53] [ENEMY] [Enemy1] GRENADE DANGER: Entering EVADING_GRENADE state from IDLE
+[22:29:53] [ENEMY] [Enemy1] EVADING_GRENADE started: escaping to (40.71295, 162.4871)
+[22:29:53] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P4:velocity, state=EVADING_GRENADE, target=-153.4°, current=8.2°, player=(349,889), corner_timer=0.00
+[22:29:53] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(357,896), corner_timer=-0.02
+[22:29:53] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:53] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(361,900), corner_timer=0.30
+[22:29:53] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:53] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(454,927), corner_timer=-0.02
+[22:29:53] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:29:53] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(460,927), corner_timer=0.30
+[22:29:53] [ENEMY] [Enemy1] EVADING_GRENADE: Escaped to safe distance
+[22:29:53] [ENEMY] [Enemy1] State: EVADING_GRENADE -> IDLE
+[22:29:53] [ENEMY] [Enemy1] ROT_CHANGE: P4:velocity -> P5:idle_scan, state=IDLE, target=168.8°, current=-128.4°, player=(482,927), corner_timer=0.00
+[22:29:53] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:53] [INFO] [GrenadeBase] EXPLODED at (668.0952, 670.6565)!
+[22:29:53] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(668.0952, 670.6565), source=NEUTRAL (DefensiveGrenade), range=2937, listeners=17
+[22:29:53] [INFO] [SoundPropagation] Cleaned up 7 invalid listeners
+[22:29:53] [ENEMY] [Enemy2] Heard EXPLOSION at (668.0952, 670.6565), intensity=0.03, distance=294
+[22:29:53] [ENEMY] [Enemy3] Heard EXPLOSION at (668.0952, 670.6565), intensity=0.34, distance=86
+[22:29:53] [ENEMY] [Enemy4] Heard EXPLOSION at (668.0952, 670.6565), intensity=0.04, distance=265
+[22:29:53] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=0, self=0, below_threshold=7
+[22:29:53] [ENEMY] [Enemy3] Hit: dmg=1, hp=3/3->2/3
+[22:29:53] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.373077, 0.9278), lethal=false
+[22:29:53] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:53] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:53] [INFO] [ImpactEffects] Wall found for blood splatter at (724.1266, 810) (dist=64 px)
+[22:29:53] [INFO] [BloodDecal] Blood puddle created at (724.1266, 809) (added to group)
+[22:29:53] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[22:29:53] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/3->1/3
+[22:29:53] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.373077, 0.9278), lethal=false
+[22:29:53] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:53] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:29:53] [INFO] [ImpactEffects] Wall found for blood splatter at (724.1266, 810) (dist=64 px)
+[22:29:53] [INFO] [BloodDecal] Blood puddle created at (724.1266, 809) (added to group)
+[22:29:53] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[22:29:53] [ENEMY] [Enemy3] Hit: dmg=1, hp=1/3->0/3
+[22:29:53] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.373077, 0.9278), lethal=true
+[22:29:53] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:29:53] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:29:53] [INFO] [ImpactEffects] Wall found for blood splatter at (724.1266, 810) (dist=64 px)
+[22:29:53] [INFO] [BloodDecal] Blood puddle created at (724.1266, 809) (added to group)
+[22:29:53] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1.5)
+[22:29:53] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[22:29:53] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:29:53] [ENEMY] [Enemy3] [AllyDeath] Notified 2 enemies
+[22:29:53] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 9)
+[22:29:53] [INFO] [DeathAnim] Started - Angle: 68.1 deg, Index: 16
+[22:29:53] [ENEMY] [Enemy3] Death animation started with hit direction: (0.373077, 0.9278)
+[22:29:53] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 85.5
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #1 at angle -0.8 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #2 at angle 23.2 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #3 at angle 15.1 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #4 at angle 28.8 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #5 at angle 35.0 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #6 at angle 41.4 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #7 at angle 41.5 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #8 at angle 73.6 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #9 at angle 58.6 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #10 at angle 72.1 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #11 at angle 90.5 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #12 at angle 88.7 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #13 at angle 97.1 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #14 at angle 121.5 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #15 at angle 129.7 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #16 at angle 128.0 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #17 at angle 152.4 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #18 at angle 164.8 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #19 at angle 177.0 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #20 at angle 166.8 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #21 at angle 177.1 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #22 at angle 195.2 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #23 at angle 206.0 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #24 at angle 207.6 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #25 at angle 221.7 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #26 at angle 230.6 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #27 at angle 244.7 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #28 at angle 234.0 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #29 at angle 240.0 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #30 at angle 269.4 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #31 at angle 285.0 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #32 at angle 293.6 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #33 at angle 275.3 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #34 at angle 304.6 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #35 at angle 316.3 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #36 at angle 306.6 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #37 at angle 326.7 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #38 at angle 337.1 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #39 at angle 352.4 degrees
+[22:29:53] [INFO] [DefensiveGrenade] Spawned shrapnel #40 at angle 347.7 degrees
+[22:29:53] [INFO] [GrenadeTimer] Timer expired for Flashbang grenade!
+[22:29:53] [INFO] [GrenadeTimer] Flashbang grenade activated at (668.0952, 670.6565)!
+[22:29:53] [INFO] [GrenadeTimer] Applying flashbang effects (radius: 700, blindness: 12s, stun: 6s)
+[22:29:53] [INFO] [FlashbangStatus] Flashbang: blind=10.5s, stun=5.3s
+[22:29:53] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:29:53] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:29:53] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 85,5 (intensity: 0,88)
+[22:29:53] [INFO] [GrenadeTimer] Player behind wall - flashbang blocked (distance: 315,8)
+[22:29:53] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(668.0952, 670.6565), source=NEUTRAL (DefensiveGrenade), range=2938, listeners=9
+[22:29:53] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=7
+[22:29:53] [INFO] [GrenadeTimer] Spawned flashbang effect at (668.0952, 670.6565) (radius: 700)
+[22:29:53] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=77.4°, current=-67.5°, player=(483,927), corner_timer=0.00
+[22:29:53] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=175.1°, current=-67.5°, player=(483,927), corner_timer=0.00
+[22:29:54] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[22:29:54] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(483,927), corner_timer=-0.02
+[22:29:54] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:54] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,927), corner_timer=0.30
+[22:29:54] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[22:29:54] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[22:29:54] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=171.9°, current=145.7°, player=(483,927), corner_timer=0.00
+[22:29:54] [ENEMY] [Enemy4] State: RETREATING -> IN_COVER
+[22:29:54] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:54] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=77.4°, current=55.8°, player=(483,927), corner_timer=0.00
+[22:29:54] [ENEMY] [Enemy2] State: RETREATING -> IN_COVER
+[22:29:54] [ENEMY] [Enemy4] State: IN_COVER -> SUPPRESSED
+[22:29:54] [ENEMY] [Enemy2] State: IN_COVER -> SUPPRESSED
+[22:29:54] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,927), corner_timer=-0.02
+[22:29:54] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:54] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,927), corner_timer=0.30
+[22:29:54] [ENEMY] [Enemy3] Ragdoll activated
+[22:29:54] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:29:54] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:54] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,927), corner_timer=-0.02
+[22:29:54] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:54] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,927), corner_timer=0.30
+[22:29:54] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:55] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[22:29:55] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,927), corner_timer=-0.02
+[22:29:55] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:55] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,927), corner_timer=0.30
+[22:29:55] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:55] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,927), corner_timer=-0.02
+[22:29:55] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:55] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,927), corner_timer=0.30
+[22:29:55] [ENEMY] [Enemy3] Death animation completed
+[22:29:55] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:55] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,927), corner_timer=-0.02
+[22:29:55] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:55] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,927), corner_timer=0.30
+[22:29:55] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:29:55] [WARN] [FPS] Drop detected: 18 fps (threshold: 30)
+[22:29:56] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=10
+[22:29:56] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,927), corner_timer=-0.02
+[22:29:56] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:29:56] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,927), corner_timer=0.30
+[22:29:56] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:29:56] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:29:56] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:29:56] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:29:56] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[22:29:56] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[22:29:56] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[22:29:56] [ENEMY] [Enemy1] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:29:56] [ENEMY] [Enemy2] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:29:56] [ENEMY] [Enemy3] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:29:56] [ENEMY] [Enemy4] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[22:29:56] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[22:29:56] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[22:29:56] [ENEMY] [Grenadier] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:29:56] [ENEMY] [Enemy6] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:29:56] [ENEMY] [Enemy7] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:29:56] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:56] [ENEMY] [Enemy8] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:29:56] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:29:56] [ENEMY] [Enemy9] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:29:56] [ENEMY] [Enemy10] Death animation component initialized
+[22:29:56] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:29:56] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:29:56] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:29:56] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:29:56] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[22:29:56] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:29:56] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[22:29:56] [INFO] [Player.Weapon] Removed default MakarovPM
+[22:29:56] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[22:29:56] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:29:56] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:29:56] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:29:56] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:29:56] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:29:56] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[22:29:56] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[22:29:56] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[22:29:56] [INFO] [Player.Homing] Homing activation sound loaded
+[22:29:56] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[22:29:56] [INFO] [Player.Homing] Homing bullets equipped, charges: 6/6
+[22:29:56] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[22:29:56] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[22:29:56] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[22:29:56] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[22:29:56] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[22:29:56] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[22:29:56] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[22:29:56] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:29:56] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:29:56] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:29:56] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:29:56] [INFO] [BuildingLevel] Setting up weapon: m16
+[22:29:56] [INFO] [BuildingLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[22:29:56] [INFO] [ScoreManager] Level started with 10 enemies
+[22:29:56] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[22:29:56] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[22:29:56] [INFO] [ReplayManager] Replay data cleared
+[22:29:56] [INFO] [BuildingLevel] Previous replay data cleared
+[22:29:56] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[22:29:56] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[22:29:56] [INFO] [ReplayManager] Level: BuildingLevel
+[22:29:56] [INFO] [ReplayManager] Player: Player (valid: True)
+[22:29:56] [INFO] [ReplayManager] Enemies count: 10
+[22:29:56] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[22:29:56] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[22:29:56] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[22:29:56] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[22:29:56] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[22:29:56] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[22:29:56] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[22:29:56] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[22:29:56] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[22:29:56] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[22:29:56] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[22:29:56] [INFO] [BuildingLevel] Replay recording started successfully
+[22:29:56] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:29:56] [INFO] [LastChance] Issue #937: Cached 44 StaticBody2D nodes for fast freeze traversal
+[22:29:56] [INFO] [CinemaEffects] Found player node: Player
+[22:29:56] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 10)
+[22:29:56] [ENEMY] [Enemy1] Registered as sound listener
+[22:29:56] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[22:29:56] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 11)
+[22:29:56] [ENEMY] [Enemy2] Registered as sound listener
+[22:29:56] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:29:56] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 12)
+[22:29:56] [ENEMY] [Enemy3] Registered as sound listener
+[22:29:56] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:29:56] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 13)
+[22:29:56] [ENEMY] [Enemy4] Registered as sound listener
+[22:29:56] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[22:29:56] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 14)
+[22:29:56] [ENEMY] [Grenadier] Registered as sound listener
+[22:29:56] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:29:56] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 15)
+[22:29:56] [ENEMY] [Enemy6] Registered as sound listener
+[22:29:56] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:29:56] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 16)
+[22:29:56] [ENEMY] [Enemy7] Registered as sound listener
+[22:29:56] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[22:29:56] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 17)
+[22:29:56] [ENEMY] [Enemy8] Registered as sound listener
+[22:29:56] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[22:29:56] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 18)
+[22:29:56] [ENEMY] [Enemy9] Registered as sound listener
+[22:29:56] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[22:29:56] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:29:56] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 19)
+[22:29:56] [ENEMY] [Enemy10] Registered as sound listener
+[22:29:56] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[22:29:56] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:29:56] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[22:29:56] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:56] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:56] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:56] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:56] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:56] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:56] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:56] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:29:56] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:29:56] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:29:56] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:29:56] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:29:56] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:29:56] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:29:56] [INFO] [LastChance] Found player: Player
+[22:29:56] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:29:56] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:29:56] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:29:56] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[22:29:56] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:56] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[22:29:56] [INFO] [Player.Grenade] G pressed - starting grab animation
+[22:29:56] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[22:29:56] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (664.4231, 1002.87573)
+[22:29:56] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[22:29:56] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[22:29:56] [INFO] [DefensiveGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[22:29:56] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 700
+[22:29:56] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[22:29:56] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[22:29:56] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[22:29:56] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[22:29:56] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[22:29:56] [INFO] [Player.Grenade] Step 1 complete! Drag: (73.1933, 34.730957)
+[22:29:56] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[22:29:56] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - starting trajectory aiming
+[22:29:57] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[22:29:57] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:57] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:29:57] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1231), corner_timer=0.30
+[22:29:57] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1231), corner_timer=0.30
+[22:29:58] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1133), corner_timer=-0.02
+[22:29:58] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:29:58] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1133), corner_timer=-0.02
+[22:29:58] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:29:58] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1127), corner_timer=0.30
+[22:29:58] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1127), corner_timer=0.30
+[22:29:58] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[22:29:58] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,1023), corner_timer=-0.02
+[22:29:58] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[22:29:58] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,1017), corner_timer=0.30
+[22:29:58] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(425,953), corner_timer=-0.02
+[22:29:58] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[22:29:58] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(421,952), corner_timer=0.30
+[22:29:59] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(389,943), corner_timer=-0.02
+[22:29:59] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[22:29:59] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(389,943), corner_timer=0.30
+[22:29:59] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[22:29:59] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(389,943), corner_timer=-0.02
+[22:29:59] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[22:29:59] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(389,943), corner_timer=0.30
+[22:29:59] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:00] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(389,943), corner_timer=-0.02
+[22:30:00] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[22:30:00] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(389,943), corner_timer=0.30
+[22:30:00] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:00] [INFO] [Player.Grenade.Simple] Throwing! Target: (590.5633, 627.43604), Distance: 314,2, Speed: 434,2, Friction: 300,0
+[22:30:00] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,0050431
+[22:30:00] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[22:30:00] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.53605175, -0.84418505), speed=434,2, spawn=(422.14975, 892.65704)
+[22:30:00] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.536052, -0.844185), Speed: 434.2 (clamped from 434.2, max: 1000.0)
+[22:30:00] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[22:30:00] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[22:30:00] [INFO] [Player.Grenade] State reset to IDLE
+[22:30:00] [INFO] [Player.Grenade] State reset to IDLE
+[22:30:00] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[22:30:00] [INFO] [Player.Grenade] Player rotation restored to 0
+[22:30:00] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[22:30:00] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(399,943), corner_timer=-0.02
+[22:30:00] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[22:30:00] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(401,943), corner_timer=0.30
+[22:30:00] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[22:30:00] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:00] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(483,943), corner_timer=-0.02
+[22:30:00] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[22:30:00] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(483,943), corner_timer=0.30
+[22:30:00] [ENEMY] [Enemy1] GRENADE DANGER: Entering EVADING_GRENADE state from IDLE
+[22:30:00] [ENEMY] [Enemy1] EVADING_GRENADE started: escaping to (-4.909912, 56.84479)
+[22:30:00] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P4:velocity, state=EVADING_GRENADE, target=-153.4°, current=8.2°, player=(483,943), corner_timer=0.00
+[22:30:00] [INFO] [GrenadeBase] EXPLODED at (532.0418, 719.5969)!
+[22:30:00] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(532.0418, 719.5969), source=NEUTRAL (DefensiveGrenade), range=2937, listeners=19
+[22:30:00] [INFO] [SoundPropagation] Cleaned up 9 invalid listeners
+[22:30:00] [ENEMY] [Enemy2] Heard EXPLOSION at (532.0418, 719.5969), intensity=0.05, distance=215
+[22:30:00] [ENEMY] [Enemy3] Heard EXPLOSION at (532.0418, 719.5969), intensity=0.09, distance=171
+[22:30:00] [ENEMY] [Enemy4] Heard EXPLOSION at (532.0418, 719.5969), intensity=0.02, distance=323
+[22:30:00] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=0, self=0, below_threshold=6
+[22:30:00] [ENEMY] [Enemy2] Hit: dmg=1, hp=4/4->3/4
+[22:30:00] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.614326, -0.789052), lethal=false
+[22:30:00] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:30:00] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:30:00] [INFO] [ImpactEffects] Wall found for blood splatter at (340, 472.9349) (dist=97 px)
+[22:30:00] [INFO] [BloodDecal] Blood puddle created at (341, 472.9349) (added to group)
+[22:30:00] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:30:00] [ENEMY] [Enemy2] Hit: dmg=1, hp=3/4->2/4
+[22:30:00] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.614326, -0.789052), lethal=false
+[22:30:00] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:30:00] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:30:00] [INFO] [ImpactEffects] Wall found for blood splatter at (340, 472.9349) (dist=97 px)
+[22:30:00] [INFO] [BloodDecal] Blood puddle created at (341, 472.9349) (added to group)
+[22:30:00] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:30:00] [ENEMY] [Enemy2] Hit: dmg=1, hp=2/4->1/4
+[22:30:00] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.614326, -0.789052), lethal=false
+[22:30:00] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:30:00] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:30:00] [INFO] [ImpactEffects] Wall found for blood splatter at (340, 472.9349) (dist=97 px)
+[22:30:00] [INFO] [BloodDecal] Blood puddle created at (341, 472.9349) (added to group)
+[22:30:00] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[22:30:00] [ENEMY] [Enemy2] Hit: dmg=1, hp=1/4->0/4
+[22:30:00] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.614326, -0.789052), lethal=true
+[22:30:00] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:30:00] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:30:00] [INFO] [ImpactEffects] Wall found for blood splatter at (340, 472.9349) (dist=97 px)
+[22:30:00] [INFO] [BloodDecal] Blood puddle created at (341, 472.9349) (added to group)
+[22:30:00] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1.5)
+[22:30:00] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[22:30:00] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[22:30:00] [ENEMY] [Enemy2] [AllyDeath] Notified 2 enemies
+[22:30:00] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 9)
+[22:30:00] [INFO] [DeathAnim] Started - Angle: -127.9 deg, Index: 3
+[22:30:00] [ENEMY] [Enemy2] Death animation started with hit direction: (-0.614326, -0.789052)
+[22:30:00] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 214.9
+[22:30:00] [ENEMY] [Enemy3] Hit: dmg=1, hp=3/3->2/3
+[22:30:00] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.984008, 0.178121), lethal=false
+[22:30:00] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:30:00] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:30:00] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[22:30:00] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/3->1/3
+[22:30:00] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.984008, 0.178121), lethal=false
+[22:30:00] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:30:00] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:30:00] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[22:30:00] [ENEMY] [Enemy3] Hit: dmg=1, hp=1/3->0/3
+[22:30:00] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.984008, 0.178121), lethal=true
+[22:30:00] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:30:00] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[22:30:00] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1.5)
+[22:30:00] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[22:30:00] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[22:30:00] [ENEMY] [Enemy3] [AllyDeath] Notified 1 enemies
+[22:30:00] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 8)
+[22:30:00] [INFO] [DeathAnim] Started - Angle: 10.3 deg, Index: 12
+[22:30:00] [ENEMY] [Enemy3] Death animation started with hit direction: (0.984008, 0.178121)
+[22:30:00] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 170.7
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #1 at angle -2.3 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #2 at angle 9.9 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #3 at angle 30.0 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #4 at angle 24.5 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #5 at angle 44.3 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #6 at angle 37.2 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #7 at angle 51.7 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #8 at angle 49.3 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #9 at angle 68.7 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #10 at angle 84.0 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #11 at angle 100.5 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #12 at angle 111.9 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #13 at angle 110.8 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #14 at angle 119.8 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #15 at angle 124.7 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #16 at angle 127.7 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #17 at angle 138.0 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #18 at angle 167.9 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #19 at angle 157.0 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #20 at angle 177.4 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #21 at angle 179.1 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #22 at angle 174.5 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #23 at angle 208.4 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #24 at angle 209.4 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #25 at angle 228.0 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #26 at angle 235.1 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #27 at angle 248.6 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #28 at angle 229.4 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #29 at angle 238.1 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #30 at angle 260.2 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #31 at angle 270.6 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #32 at angle 280.3 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #33 at angle 295.4 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #34 at angle 288.2 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #35 at angle 303.8 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #36 at angle 312.2 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #37 at angle 328.4 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #38 at angle 341.8 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #39 at angle 354.2 degrees
+[22:30:00] [INFO] [DefensiveGrenade] Spawned shrapnel #40 at angle 338.8 degrees
+[22:30:00] [INFO] [GrenadeTimer] Timer expired for Flashbang grenade!
+[22:30:00] [INFO] [GrenadeTimer] Flashbang grenade activated at (532.0418, 719.59686)!
+[22:30:00] [INFO] [GrenadeTimer] Applying flashbang effects (radius: 700, blindness: 12s, stun: 6s)
+[22:30:00] [INFO] [FlashbangStatus] Flashbang: blind=8.3s, stun=4.2s
+[22:30:00] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:30:00] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:30:00] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 214,9 (intensity: 0,69)
+[22:30:00] [INFO] [FlashbangStatus] Flashbang: blind=9.1s, stun=4.5s
+[22:30:00] [INFO] [FlashbangStatus] Status: BLINDED applied
+[22:30:00] [INFO] [FlashbangStatus] Status: STUNNED applied
+[22:30:00] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 170,7 (intensity: 0,76)
+[22:30:00] [INFO] [GrenadeTimer] Player behind wall - flashbang blocked (distance: 228,8)
+[22:30:00] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(532.0418, 719.5969), source=NEUTRAL (DefensiveGrenade), range=2938, listeners=8
+[22:30:00] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=6
+[22:30:00] [INFO] [GrenadeTimer] Spawned flashbang effect at (532.0418, 719.59686) (radius: 700)
+[22:30:00] [ENEMY] [Enemy1] EVADING_GRENADE: Escaped to safe distance
+[22:30:00] [ENEMY] [Enemy1] State: EVADING_GRENADE -> IDLE
+[22:30:00] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=172.2°, current=-101.3°, player=(483,943), corner_timer=0.00
+[22:30:00] [ENEMY] [Enemy1] ROT_CHANGE: P4:velocity -> P5:idle_scan, state=IDLE, target=146.3°, current=-21.7°, player=(483,943), corner_timer=0.00
+[22:30:00] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:01] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(483,943), corner_timer=-0.02
+[22:30:01] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[22:30:01] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[22:30:01] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(483,943), corner_timer=0.30
+[22:30:01] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=180.0°, current=112.9°, player=(483,943), corner_timer=0.00
+[22:30:01] [ENEMY] [Enemy4] State: RETREATING -> IN_COVER
+[22:30:01] [ENEMY] [Enemy4] State: IN_COVER -> SUPPRESSED
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (359.8688, 476.5761) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (365.9837, 486.7539) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (382.1079, 527.0008) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (342.9967, 539.4039) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (348.487, 534.8556) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (747.3516, 764.9492) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (775.1693, 747.7885) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (740.1965, 785.1517) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (742.8052, 774.5577) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (755.5007, 751.2092) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (763.9, 783.0707) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (769.4813, 774.708) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (792.1293, 778.0664) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (782.3602, 812.9703) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (783.4678, 767.8224) (added to group)
+[22:30:01] [ENEMY] [Grenadier] Hit: dmg=1, hp=2/2->1/2
+[22:30:01] [INFO] [ImpactEffects] spawn_blood_effect called at (1700, 350), dir=(-0.926306, 0.376771), lethal=false
+[22:30:01] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[22:30:01] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[22:30:01] [INFO] [ImpactEffects] Blood effect spawned at (1700, 350) (scale=1)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (309.5327, 527.5091) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (353.0518, 545.4566) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (370.9036, 483.9516) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (299.1316, 535.3647) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (362.7008, 533.3983) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (348.6871, 481.3069) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (332.638, 544.364) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (326.6719, 509.9179) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (372.7663, 457.6671) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (341.045, 526.1085) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (362.8997, 532.9066) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (274.1245, 525.1249) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (365.0136, 513.3776) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (341.0641, 506.856) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (788.5891, 766.6661) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (761.5312, 807.7059) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (825.8682, 777.4627) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (805.5574, 773.1395) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (799.88, 818.2778) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (828.2531, 758.0601) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (774.4117, 804.4448) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (778.6229, 802.4521) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (828.861, 775.0427) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (796.9783, 800.073) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [ENEMY] [Enemy2] Ragdoll activated
+[22:30:01] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:30:01] [ENEMY] [Enemy3] Ragdoll activated
+[22:30:01] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (370.808, 503.1685) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (348.1343, 534.4865) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (276.4034, 546.35) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (337.7685, 534.0715) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (310.5261, 509.4396) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (322.7563, 502.8496) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (316.5788, 569.996) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (330.584, 541.4453) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (840.3617, 814.1793) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (818.7482, 791.3655) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (792.2571, 840.5062) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(483,943), corner_timer=-0.02
+[22:30:01] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(483,943), corner_timer=0.30
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (360.6983, 525.2412) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (356.8362, 496.5618) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (275.5189, 556.5701) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (354.0887, 533.3322) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (369.3225, 452.6187) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (304.2787, 543.9599) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (334.2385, 483.3533) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (367.452, 523.3157) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (247.8039, 544.1746) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (326.1717, 509.7163) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (361.02, 445.5653) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (324.5868, 504.4416) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (297.6782, 515.791) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (838.3001, 811.7527) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (857.6961, 851.9591) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (896.4068, 815.0216) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (882.05, 866.8279) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (876.2444, 829.5806) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (290.3133, 498.8965) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (273.1453, 580.1009) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (226.0503, 534.9965) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (283.8401, 521.3851) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (860.9557, 882.0205) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1637.923, 431.6892) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (335.3123, 540.5261) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (344.9605, 569.4052) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (264.7775, 525.2694) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1629.056, 395.6622) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1569.642, 433.138) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1626.505, 405.8265) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(483,943), corner_timer=-0.02
+[22:30:01] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1535.363, 427.7432) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(483,943), corner_timer=0.30
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1617.205, 524.0229) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1489.868, 560.7892) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1569.622, 496.2819) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1605.505, 537.906) (added to group)
+[22:30:01] [INFO] [BloodDecal] Blood puddle created at (1499.647, 520.5712) (added to group)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:01] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(483,943), corner_timer=-0.02
+[22:30:02] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [WARN] [FPS] Drop detected: 16 fps (threshold: 30)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy2] Death animation completed
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy3] Death animation completed
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(483,943), corner_timer=-0.02
+[22:30:02] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:02] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:02] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:03] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:03] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy4] State: SUPPRESSED -> IN_COVER
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy4] State: IN_COVER -> PURSUING
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy4] ROT_CHANGE: P4:velocity -> P2:combat_state, state=PURSUING, target=173.5°, current=118.6°, player=(483,943), corner_timer=0.00
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:03] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:03] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:04] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [WARN] [FPS] Drop detected: 29 fps (threshold: 30)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=10
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:04] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:04] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:04] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:05] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=10
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy4] PURSUING corner check: angle -86.4°
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:05] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy4] PURSUING corner check: angle -63.8°
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:05] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [ScoreManager] Combo ended at 2. Max combo: 2
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:05] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:06] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=10
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:06] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:06] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:06] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:07] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=10
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:07] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:07] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:07] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:08] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [ReplayManager] Recording frame 720 (12,0s): player_valid=True, enemies=10
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:08] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:08] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:08] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:09] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [ENEMY] [Enemy4] PURSUING corner check: angle -64.4°
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [ReplayManager] Recording frame 780 (13,0s): player_valid=True, enemies=10
+[22:30:09] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=92.8°, current=140.3°, player=(483,943), corner_timer=0.13
+[22:30:09] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:09] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,943), corner_timer=0.30
+[22:30:09] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=92.7°, current=39.0°, player=(483,943), corner_timer=0.13
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [INFO] [EnemyGrenade] Throw path blocked for Offensive to (1160.763, 613.1033)
+[22:30:09] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,943), corner_timer=-0.02
+[22:30:09] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[22:30:09] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[22:30:09] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[22:30:09] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[22:30:09] [INFO] [LastChance] Resetting all effects (scene change detected)
+[22:30:09] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[22:30:09] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[22:30:09] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[22:30:09] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:30:09] [ENEMY] [Enemy1] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[22:30:09] [ENEMY] [Enemy2] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[22:30:09] [ENEMY] [Enemy3] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[22:30:09] [ENEMY] [Enemy4] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[22:30:09] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[22:30:09] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[22:30:09] [ENEMY] [Grenadier] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[22:30:09] [ENEMY] [Enemy6] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[22:30:09] [ENEMY] [Enemy7] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[22:30:09] [ENEMY] [Enemy8] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[22:30:09] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[22:30:09] [ENEMY] [Enemy9] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[22:30:09] [ENEMY] [Enemy10] Death animation component initialized
+[22:30:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[22:30:09] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[22:30:09] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[22:30:09] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[22:30:09] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[22:30:09] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[22:30:09] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[22:30:09] [INFO] [Player.Weapon] Removed default MakarovPM
+[22:30:09] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[22:30:09] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[22:30:09] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[22:30:09] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[22:30:09] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[22:30:09] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[22:30:09] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[22:30:09] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[22:30:09] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[22:30:09] [INFO] [Player.Homing] Homing activation sound loaded
+[22:30:09] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[22:30:09] [INFO] [Player.Homing] Homing bullets equipped, charges: 6/6
+[22:30:09] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[22:30:09] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[22:30:09] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[22:30:09] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[22:30:09] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[22:30:09] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[22:30:09] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[22:30:09] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[22:30:09] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[22:30:09] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[22:30:09] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[22:30:09] [INFO] [BuildingLevel] Setting up weapon: m16
+[22:30:09] [INFO] [BuildingLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[22:30:09] [INFO] [ScoreManager] Level started with 10 enemies
+[22:30:09] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[22:30:09] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[22:30:09] [INFO] [ReplayManager] Replay data cleared
+[22:30:09] [INFO] [BuildingLevel] Previous replay data cleared
+[22:30:09] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[22:30:09] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[22:30:09] [INFO] [ReplayManager] Level: BuildingLevel
+[22:30:09] [INFO] [ReplayManager] Player: Player (valid: True)
+[22:30:09] [INFO] [ReplayManager] Enemies count: 10
+[22:30:09] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[22:30:09] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[22:30:09] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[22:30:09] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[22:30:09] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[22:30:09] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[22:30:09] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[22:30:09] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[22:30:09] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[22:30:09] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[22:30:09] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[22:30:09] [INFO] [BuildingLevel] Replay recording started successfully
+[22:30:09] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[22:30:09] [INFO] [LastChance] Issue #937: Cached 44 StaticBody2D nodes for fast freeze traversal
+[22:30:09] [INFO] [CinemaEffects] Found player node: Player
+[22:30:09] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 9)
+[22:30:09] [ENEMY] [Enemy1] Registered as sound listener
+[22:30:09] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[22:30:09] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 10)
+[22:30:09] [ENEMY] [Enemy2] Registered as sound listener
+[22:30:09] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[22:30:09] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 11)
+[22:30:09] [ENEMY] [Enemy3] Registered as sound listener
+[22:30:09] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[22:30:09] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 12)
+[22:30:09] [ENEMY] [Enemy4] Registered as sound listener
+[22:30:09] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[22:30:09] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 13)
+[22:30:09] [ENEMY] [Grenadier] Registered as sound listener
+[22:30:09] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[22:30:09] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 14)
+[22:30:09] [ENEMY] [Enemy6] Registered as sound listener
+[22:30:09] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[22:30:09] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 15)
+[22:30:09] [ENEMY] [Enemy7] Registered as sound listener
+[22:30:09] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[22:30:09] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 16)
+[22:30:09] [ENEMY] [Enemy8] Registered as sound listener
+[22:30:09] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[22:30:09] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 17)
+[22:30:09] [ENEMY] [Enemy9] Registered as sound listener
+[22:30:09] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[22:30:09] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[22:30:09] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 18)
+[22:30:09] [ENEMY] [Enemy10] Registered as sound listener
+[22:30:09] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[22:30:09] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[22:30:10] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[22:30:10] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:30:10] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:30:10] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:30:10] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:30:10] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:30:10] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:30:10] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:30:10] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[22:30:10] [INFO] [Player] Detecting weapon pose (frame 3)...
+[22:30:10] [INFO] [Player] Detected weapon: Rifle (default pose)
+[22:30:10] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[22:30:10] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[22:30:10] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[22:30:10] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[22:30:10] [INFO] [LastChance] Found player: Player
+[22:30:10] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[22:30:10] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[22:30:10] [INFO] [LastChance] Connected to player Died signal (C#)
+[22:30:10] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[22:30:10] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[22:30:11] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:30:11] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[22:30:11] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1250), corner_timer=0.30
+[22:30:11] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1250), corner_timer=0.30
+[22:30:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1250), corner_timer=-0.02
+[22:30:11] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[22:30:11] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1250), corner_timer=-0.02
+[22:30:11] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[22:30:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1250), corner_timer=0.30
+[22:30:11] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1250), corner_timer=0.30
+[22:30:11] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[22:30:12] [INFO] ------------------------------------------------------------
+[22:30:12] [INFO] GAME LOG ENDED: 2026-03-05T22:30:12
+[22:30:12] [INFO] ============================================================

--- a/docs/case-studies/issue-966/game_log_20260305_230043.txt
+++ b/docs/case-studies/issue-966/game_log_20260305_230043.txt
@@ -1,0 +1,1647 @@
+[23:00:43] [INFO] ============================================================
+[23:00:43] [INFO] GAME LOG STARTED
+[23:00:43] [INFO] ============================================================
+[23:00:43] [INFO] Timestamp: 2026-03-05T23:00:43
+[23:00:43] [INFO] Log file: I:/Загрузки/godot exe/оптимизация/game_log_20260305_230043.txt
+[23:00:43] [INFO] Executable: I:/Загрузки/godot exe/оптимизация/Godot-Top-Down-Template.exe
+[23:00:43] [INFO] OS: Windows
+[23:00:43] [INFO] Debug build: false
+[23:00:43] [INFO] Engine version: 4.3-stable (official)
+[23:00:43] [INFO] Project: Godot Top-Down Template
+[23:00:43] [INFO] ------------------------------------------------------------
+[23:00:43] [INFO] [GameManager] GameManager ready
+[23:00:43] [INFO] [ScoreManager] ScoreManager ready
+[23:00:43] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[23:00:43] [INFO] [DifficultyManager] Loaded difficulty: Hard (value: 2)
+[23:00:43] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[23:00:43] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[23:00:43] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:00:43] [INFO] [ImpactEffects] Blood decal pool initialized: 150 decals pre-created
+[23:00:43] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[23:00:43] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[23:00:43] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[23:00:43] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[23:00:43] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[23:00:43] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[23:00:43] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[23:00:43] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[23:00:43] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[23:00:43] [INFO] [LastChance] Resetting all effects (scene change detected)
+[23:00:43] [INFO] [LastChance] Last chance shader loaded successfully
+[23:00:43] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[23:00:43] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[23:00:43] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[23:00:43] [INFO] [LastChance]   Sepia intensity: 0.70
+[23:00:43] [INFO] [LastChance]   Brightness: 0.60
+[23:00:43] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[23:00:43] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[23:00:43] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[23:00:43] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[23:00:43] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: true, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: true, FPS drop logging: true
+[23:00:43] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.29, music: 1.00
+[23:00:43] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[23:00:43] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[23:00:43] [INFO] [CinemaEffects] Created effects layer at layer 99
+[23:00:43] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[23:00:43] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[23:00:43] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[23:00:43] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[23:00:43] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[23:00:43] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[23:00:43] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[23:00:43] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[23:00:43] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[23:00:43] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[23:00:43] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[23:00:43] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[23:00:43] [INFO] [GrenadeTimerHelper] Autoload ready
+[23:00:43] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[23:00:43] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[23:00:43] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[23:00:43] [INFO] [PowerFantasy]   Kill effect duration: 300ms
+[23:00:43] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[23:00:43] [INFO] [ProgressManager] ProgressManager ready, loaded 5 entries
+[23:00:43] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[23:00:43] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[23:00:43] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[23:00:43] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[23:00:43] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[23:00:43] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[23:00:43] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[23:00:43] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[23:00:43] [INFO] [PersistManager] Restored unlocked weapon: m16
+[23:00:43] [INFO] [PersistManager] Restored unlocked weapon: shotgun
+[23:00:43] [INFO] [PersistManager] Restored unlocked weapon: mini_uzi
+[23:00:43] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[23:00:43] [INFO] [PersistManager] Restored unlocked weapon: sniper
+[23:00:43] [INFO] [PersistManager] Restored unlocked weapon: revolver
+[23:00:43] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[23:00:43] [INFO] [GameManager] Weapon selected: m16
+[23:00:43] [INFO] [PersistManager] Restored selected weapon: m16
+[23:00:43] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[23:00:43] [INFO] [PersistManager] Restored unlocked grenade type: 1
+[23:00:43] [INFO] [PersistManager] Restored unlocked grenade type: 2
+[23:00:43] [INFO] [PersistManager] Restored unlocked grenade type: 3
+[23:00:43] [INFO] [GrenadeManager] Grenade type changed from Flashbang to F-1 Grenade
+[23:00:43] [INFO] [PersistManager] Restored selected grenade type: 2
+[23:00:43] [INFO] [PersistManager] Restored unlocked active item type: 0
+[23:00:43] [INFO] [PersistManager] Restored unlocked active item type: 1
+[23:00:43] [INFO] [PersistManager] Restored unlocked active item type: 2
+[23:00:43] [INFO] [PersistManager] Restored unlocked active item type: 3
+[23:00:43] [INFO] [PersistManager] Restored unlocked active item type: 4
+[23:00:43] [INFO] [PersistManager] Restored unlocked active item type: 5
+[23:00:43] [INFO] [PersistManager] Restored unlocked active item type: 6
+[23:00:43] [INFO] [PersistManager] Restored unlocked active item type: 7
+[23:00:43] [INFO] [PersistManager] Restored unlocked active item type: 8
+[23:00:43] [INFO] [ActiveItemManager] Active item changed from None to BFF Pendant
+[23:00:43] [INFO] [PersistManager] Restored selected active item type: 4
+[23:00:43] [INFO] [PersistManager] State loaded successfully
+[23:00:43] [INFO] [PersistManager] PersistManager ready
+[23:00:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:43] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[23:00:43] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[23:00:43] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[23:00:43] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:00:43] [ENEMY] [Enemy1] Death animation component initialized
+[23:00:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:43] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[23:00:43] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[23:00:43] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[23:00:43] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:00:43] [ENEMY] [Enemy2] Death animation component initialized
+[23:00:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:43] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[23:00:43] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[23:00:43] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[23:00:43] [ENEMY] [Enemy3] Death animation component initialized
+[23:00:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:43] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[23:00:43] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[23:00:43] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[23:00:43] [ENEMY] [Enemy4] Death animation component initialized
+[23:00:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:43] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[23:00:43] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[23:00:43] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[23:00:43] [ENEMY] [Enemy5] Death animation component initialized
+[23:00:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:43] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[23:00:43] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[23:00:43] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[23:00:43] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[23:00:43] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[23:00:43] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[23:00:43] [INFO] [Player.Weapon] Removed default MakarovPM
+[23:00:43] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[23:00:43] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[23:00:43] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[23:00:43] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[23:00:43] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[23:00:43] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[23:00:43] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[23:00:43] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[23:00:43] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[23:00:43] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[23:00:43] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[23:00:43] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[23:00:43] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[23:00:43] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[23:00:43] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[23:00:43] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[23:00:43] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[23:00:43] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[23:00:43] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[23:00:43] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[23:00:43] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[23:00:43] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[23:00:43] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[23:00:43] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[23:00:43] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[23:00:43] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[23:00:43] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[23:00:43] [INFO] [LabyrinthLevel] Setting up weapon: m16
+[23:00:43] [INFO] [LabyrinthLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[23:00:43] [INFO] [ScoreManager] Level started with 5 enemies
+[23:00:43] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[23:00:43] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[23:00:43] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[23:00:43] [INFO] [ReplayManager] Replay data cleared
+[23:00:43] [INFO] [LabyrinthLevel] Previous replay data cleared
+[23:00:43] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[23:00:43] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[23:00:43] [INFO] [ReplayManager] Level: LabyrinthLevel
+[23:00:43] [INFO] [ReplayManager] Player: Player (valid: True)
+[23:00:43] [INFO] [ReplayManager] Enemies count: 5
+[23:00:43] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[23:00:43] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[23:00:43] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[23:00:43] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[23:00:43] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[23:00:43] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[23:00:43] [INFO] [LabyrinthLevel] Replay recording started successfully
+[23:00:44] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[23:00:44] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (301.3289, 989.9114) - skipping throw
+[23:00:44] [INFO] [CinemaEffects] Found player node: Player
+[23:00:44] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[23:00:44] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/BuildingLevel.tscn
+[23:00:44] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[23:00:44] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[23:00:44] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[23:00:44] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[23:00:44] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[23:00:44] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[23:00:44] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[23:00:44] [INFO] [PenultimateHit] Shader warmup complete in 713 ms
+[23:00:44] [INFO] [LastChance] Shader warmup complete in 712 ms
+[23:00:44] [INFO] [CinemaEffects] Cinema shader warmup complete in 627 ms
+[23:00:44] [INFO] [FlashbangPlayer] Shader warmup complete in 617 ms
+[23:00:44] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[23:00:44] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[23:00:44] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[23:00:44] [INFO] [LastChance] Resetting all effects (scene change detected)
+[23:00:44] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[23:00:44] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[23:00:44] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[23:00:44] [ENEMY] [Enemy1] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[23:00:44] [ENEMY] [Enemy2] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[23:00:44] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:00:44] [ENEMY] [Enemy3] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[23:00:44] [ENEMY] [Enemy4] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[23:00:44] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[23:00:44] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[23:00:44] [ENEMY] [Grenadier] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[23:00:44] [ENEMY] [Enemy6] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[23:00:44] [ENEMY] [Enemy7] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[23:00:44] [ENEMY] [Enemy8] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[23:00:44] [ENEMY] [Enemy9] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[23:00:44] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:00:44] [ENEMY] [Enemy10] Death animation component initialized
+[23:00:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:00:44] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[23:00:44] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[23:00:44] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[23:00:44] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[23:00:44] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[23:00:44] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[23:00:44] [INFO] [Player.Weapon] Removed default MakarovPM
+[23:00:44] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[23:00:44] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[23:00:44] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[23:00:44] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[23:00:44] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[23:00:44] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[23:00:44] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[23:00:44] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[23:00:44] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[23:00:44] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[23:00:44] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[23:00:44] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[23:00:44] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[23:00:44] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[23:00:44] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[23:00:44] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[23:00:44] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[23:00:44] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[23:00:44] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[23:00:44] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[23:00:44] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[23:00:44] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[23:00:44] [INFO] [BuildingLevel] Setting up weapon: m16
+[23:00:44] [INFO] [BuildingLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[23:00:44] [INFO] [ScoreManager] Level started with 10 enemies
+[23:00:44] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[23:00:44] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[23:00:44] [INFO] [ReplayManager] Replay data cleared
+[23:00:44] [INFO] [BuildingLevel] Previous replay data cleared
+[23:00:44] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[23:00:44] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[23:00:44] [INFO] [ReplayManager] Level: BuildingLevel
+[23:00:44] [INFO] [ReplayManager] Player: Player (valid: True)
+[23:00:44] [INFO] [ReplayManager] Enemies count: 10
+[23:00:44] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[23:00:44] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[23:00:44] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[23:00:44] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[23:00:44] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[23:00:44] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[23:00:44] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[23:00:44] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[23:00:44] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[23:00:44] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[23:00:44] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[23:00:44] [INFO] [BuildingLevel] Replay recording started successfully
+[23:00:44] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[23:00:44] [INFO] [CinemaEffects] Found player node: Player
+[23:00:44] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[23:00:44] [ENEMY] [Enemy1] Registered as sound listener
+[23:00:44] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[23:00:44] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[23:00:44] [ENEMY] [Enemy2] Registered as sound listener
+[23:00:44] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[23:00:44] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[23:00:44] [ENEMY] [Enemy3] Registered as sound listener
+[23:00:44] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[23:00:44] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[23:00:44] [ENEMY] [Enemy4] Registered as sound listener
+[23:00:44] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[23:00:44] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[23:00:44] [ENEMY] [Grenadier] Registered as sound listener
+[23:00:44] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[23:00:44] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[23:00:44] [ENEMY] [Enemy6] Registered as sound listener
+[23:00:44] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[23:00:44] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[23:00:44] [ENEMY] [Enemy7] Registered as sound listener
+[23:00:44] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[23:00:44] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[23:00:44] [ENEMY] [Enemy8] Registered as sound listener
+[23:00:44] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[23:00:44] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[23:00:44] [ENEMY] [Enemy9] Registered as sound listener
+[23:00:44] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[23:00:44] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[23:00:44] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[23:00:44] [ENEMY] [Enemy10] Registered as sound listener
+[23:00:44] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[23:00:44] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[23:00:44] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[23:00:44] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:00:44] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:00:44] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:00:44] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:00:44] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:00:44] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:00:44] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:00:44] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:00:44] [INFO] [Player] Detecting weapon pose (frame 3)...
+[23:00:44] [INFO] [Player] Detected weapon: Rifle (default pose)
+[23:00:44] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[23:00:44] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[23:00:44] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[23:00:44] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[23:00:44] [INFO] [LastChance] Found player: Player
+[23:00:44] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[23:00:44] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[23:00:44] [INFO] [LastChance] Connected to player Died signal (C#)
+[23:00:44] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[23:00:44] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 1295 ms
+[23:00:45] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[23:00:46] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[23:00:47] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[23:00:48] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[23:00:49] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[23:00:50] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[23:00:51] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[23:00:52] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=10
+[23:00:53] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=10
+[23:00:54] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=10
+[23:00:55] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=10
+[23:00:56] [INFO] [ReplayManager] Recording frame 720 (12,0s): player_valid=True, enemies=10
+[23:00:57] [INFO] [ReplayManager] Recording frame 780 (13,0s): player_valid=True, enemies=10
+[23:00:58] [INFO] [ReplayManager] Recording frame 840 (14,0s): player_valid=True, enemies=10
+[23:00:59] [INFO] [ReplayManager] Recording frame 900 (15,0s): player_valid=True, enemies=10
+[23:01:00] [INFO] [ReplayManager] Recording frame 960 (16,0s): player_valid=True, enemies=10
+[23:01:01] [INFO] [ReplayManager] Recording frame 1020 (17,0s): player_valid=True, enemies=10
+[23:01:02] [INFO] [ReplayManager] Recording frame 1080 (18,0s): player_valid=True, enemies=10
+[23:01:03] [INFO] [ReplayManager] Recording frame 1140 (19,0s): player_valid=True, enemies=10
+[23:01:04] [INFO] [ReplayManager] Recording frame 1200 (20,0s): player_valid=True, enemies=10
+[23:01:05] [INFO] [ReplayManager] Recording frame 1260 (21,0s): player_valid=True, enemies=10
+[23:01:06] [INFO] [ReplayManager] Recording frame 1320 (22,0s): player_valid=True, enemies=10
+[23:01:07] [INFO] [ReplayManager] Recording frame 1380 (23,0s): player_valid=True, enemies=10
+[23:01:08] [INFO] [ReplayManager] Recording frame 1440 (24,0s): player_valid=True, enemies=10
+[23:01:09] [INFO] [ReplayManager] Recording frame 1500 (25,0s): player_valid=True, enemies=10
+[23:01:10] [INFO] [ReplayManager] Recording frame 1560 (26,0s): player_valid=True, enemies=10
+[23:01:11] [INFO] [ReplayManager] Recording frame 1620 (27,0s): player_valid=True, enemies=10
+[23:01:12] [INFO] [ReplayManager] Recording frame 1680 (28,0s): player_valid=True, enemies=10
+[23:01:13] [INFO] [ReplayManager] Recording frame 1740 (29,0s): player_valid=True, enemies=10
+[23:01:14] [INFO] [ReplayManager] Recording frame 1800 (30,0s): player_valid=True, enemies=10
+[23:01:15] [INFO] [ReplayManager] Recording frame 1860 (31,0s): player_valid=True, enemies=10
+[23:01:16] [INFO] [ReplayManager] Recording frame 1920 (32,0s): player_valid=True, enemies=10
+[23:01:17] [INFO] [ReplayManager] Recording frame 1980 (33,0s): player_valid=True, enemies=10
+[23:01:18] [INFO] [ReplayManager] Recording frame 2040 (34,0s): player_valid=True, enemies=10
+[23:01:19] [INFO] [ReplayManager] Recording frame 2100 (35,0s): player_valid=True, enemies=10
+[23:01:20] [INFO] [ReplayManager] Recording frame 2160 (36,0s): player_valid=True, enemies=10
+[23:01:21] [INFO] [ReplayManager] Recording frame 2220 (37,0s): player_valid=True, enemies=10
+[23:01:22] [INFO] [ReplayManager] Recording frame 2280 (38,0s): player_valid=True, enemies=10
+[23:01:23] [INFO] [ReplayManager] Recording frame 2340 (39,0s): player_valid=True, enemies=10
+[23:01:24] [INFO] [ReplayManager] Recording frame 2400 (40,0s): player_valid=True, enemies=10
+[23:01:25] [INFO] [ReplayManager] Recording frame 2460 (41,0s): player_valid=True, enemies=10
+[23:01:26] [INFO] [ReplayManager] Recording frame 2520 (42,0s): player_valid=True, enemies=10
+[23:01:27] [INFO] [ReplayManager] Recording frame 2580 (43,0s): player_valid=True, enemies=10
+[23:01:28] [INFO] [ReplayManager] Recording frame 2640 (44,0s): player_valid=True, enemies=10
+[23:01:29] [INFO] [ReplayManager] Recording frame 2700 (45,0s): player_valid=True, enemies=10
+[23:01:30] [INFO] [ReplayManager] Recording frame 2760 (46,0s): player_valid=True, enemies=10
+[23:01:31] [INFO] [ReplayManager] Recording frame 2820 (47,0s): player_valid=True, enemies=10
+[23:01:32] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[23:01:32] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[23:01:32] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1111), corner_timer=0.30
+[23:01:32] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1111), corner_timer=0.30
+[23:01:32] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1019), corner_timer=-0.02
+[23:01:32] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[23:01:32] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1019), corner_timer=-0.02
+[23:01:32] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[23:01:32] [INFO] [ReplayManager] Recording frame 2880 (48,0s): player_valid=True, enemies=10
+[23:01:33] [INFO] [PauseMenu] Armory button pressed
+[23:01:33] [INFO] [PauseMenu] Creating new armory menu instance
+[23:01:33] [INFO] [PauseMenu] armory_menu_scene resource path: res://scenes/ui/ArmoryMenu.tscn
+[23:01:33] [INFO] [PauseMenu] Instance created, class: CanvasLayer, name: ArmoryMenu
+[23:01:33] [INFO] [PauseMenu] Script attached: res://scripts/ui/armory_menu.gd
+[23:01:33] [INFO] [PauseMenu] back_pressed signal exists on instance
+[23:01:33] [INFO] [PauseMenu] back_pressed signal connected
+[23:01:33] [INFO] [PauseMenu] Armory menu instance added as child, is_inside_tree: true
+[23:01:33] [INFO] [PauseMenu] _populate_weapon_grid method exists
+[23:01:33] [INFO] [ReplayManager] Recording frame 2940 (49,0s): player_valid=True, enemies=10
+[23:01:33] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1016), corner_timer=0.30
+[23:01:33] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1016), corner_timer=0.30
+[23:01:34] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,1004), corner_timer=-0.02
+[23:01:34] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[23:01:34] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,1004), corner_timer=0.30
+[23:01:34] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[23:01:34] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[23:01:34] [INFO] [Player.Grenade] G pressed - starting grab animation
+[23:01:34] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(450,1004), corner_timer=-0.02
+[23:01:34] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[23:01:34] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(450,1004), corner_timer=0.30
+[23:01:34] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[23:01:34] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (676.74286, 880.0393)
+[23:01:34] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[23:01:34] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[23:01:34] [INFO] [DefensiveGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[23:01:34] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 700
+[23:01:34] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[23:01:34] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[23:01:34] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[23:01:34] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1004.44446)
+[23:01:34] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[23:01:34] [INFO] [Player.Grenade] Step 1 complete! Drag: (154.98956, -0.34124756)
+[23:01:34] [INFO] [ReplayManager] Recording frame 3000 (50,0s): player_valid=True, enemies=10
+[23:01:34] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[23:01:34] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - starting trajectory aiming
+[23:01:34] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(450,1004), corner_timer=-0.02
+[23:01:34] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[23:01:34] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(450,1004), corner_timer=0.30
+[23:01:35] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(450,1004), corner_timer=-0.02
+[23:01:35] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[23:01:35] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(450,1004), corner_timer=0.30
+[23:01:35] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:35] [INFO] [ReplayManager] Recording frame 3060 (51,0s): player_valid=True, enemies=10
+[23:01:35] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(428,1004), corner_timer=-0.02
+[23:01:35] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[23:01:35] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(424,1003), corner_timer=0.30
+[23:01:35] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:36] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(351,951), corner_timer=-0.02
+[23:01:36] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[23:01:36] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(348,949), corner_timer=0.30
+[23:01:36] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:36] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(324,935), corner_timer=-0.02
+[23:01:36] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[23:01:36] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(324,935), corner_timer=0.30
+[23:01:36] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:36] [INFO] [ReplayManager] Recording frame 3120 (52,0s): player_valid=True, enemies=10
+[23:01:36] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(324,935), corner_timer=-0.02
+[23:01:36] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[23:01:36] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(324,935), corner_timer=0.30
+[23:01:36] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:37] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(324,935), corner_timer=-0.02
+[23:01:37] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[23:01:37] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(324,935), corner_timer=0.30
+[23:01:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:37] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(324,935), corner_timer=-0.02
+[23:01:37] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[23:01:37] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(324,935), corner_timer=0.30
+[23:01:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:37] [INFO] [Player.Grenade.Simple] Throwing! Target: (663.38165, 630.69684), Distance: 395,4, Speed: 487,0, Friction: 300,0
+[23:01:37] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,7326241
+[23:01:37] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[23:01:37] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.7434219, -0.66882277), speed=487,0, spawn=(369.4647, 895.1205)
+[23:01:37] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.743422, -0.668823), Speed: 487.0 (clamped from 487.0, max: 1000.0)
+[23:01:37] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[23:01:37] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[23:01:37] [INFO] [Player.Grenade] State reset to IDLE
+[23:01:37] [INFO] [Player.Grenade] State reset to IDLE
+[23:01:37] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[23:01:37] [INFO] [ReplayManager] Recording frame 3180 (53,0s): player_valid=True, enemies=10
+[23:01:37] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(324,935), corner_timer=-0.02
+[23:01:37] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[23:01:37] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(324,935), corner_timer=0.30
+[23:01:37] [INFO] [Player.Grenade] Player rotation restored to 0
+[23:01:37] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:38] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[23:01:38] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(375,935), corner_timer=-0.02
+[23:01:38] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:38] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(381,935), corner_timer=0.30
+[23:01:38] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:38] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,935), corner_timer=-0.02
+[23:01:38] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:38] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,935), corner_timer=0.30
+[23:01:38] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:38] [INFO] [ReplayManager] Recording frame 3240 (54,0s): player_valid=True, enemies=10
+[23:01:38] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,935), corner_timer=-0.02
+[23:01:38] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:38] [INFO] [GrenadeBase] EXPLODED at (624.7548, 665.4474)!
+[23:01:38] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(624.7548, 665.4474), source=NEUTRAL (DefensiveGrenade), range=2937, listeners=10
+[23:01:38] [ENEMY] [Enemy1] Heard EXPLOSION at (624.7548, 665.4474), intensity=0.01, distance=453
+[23:01:38] [ENEMY] [Enemy2] Heard EXPLOSION at (624.7548, 665.4474), intensity=0.04, distance=253
+[23:01:38] [ENEMY] [Enemy3] Heard EXPLOSION at (624.7548, 665.4474), intensity=0.20, distance=113
+[23:01:38] [ENEMY] [Enemy4] Heard EXPLOSION at (624.7548, 665.4474), intensity=0.03, distance=293
+[23:01:38] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=0, self=0, below_threshold=6
+[23:01:38] [ENEMY] [Enemy2] Hit: dmg=1, hp=4/4->3/4
+[23:01:38] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.889514, -0.456907), lethal=false
+[23:01:38] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:38] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:38] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[23:01:38] [ENEMY] [Enemy2] Hit: dmg=1, hp=3/4->2/4
+[23:01:38] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.889514, -0.456907), lethal=false
+[23:01:38] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:38] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:38] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[23:01:38] [ENEMY] [Enemy2] Hit: dmg=1, hp=2/4->1/4
+[23:01:38] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.889514, -0.456907), lethal=false
+[23:01:38] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:38] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:38] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[23:01:38] [ENEMY] [Enemy2] Hit: dmg=1, hp=1/4->0/4
+[23:01:38] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.889514, -0.456907), lethal=true
+[23:01:38] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:38] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[23:01:38] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1.5)
+[23:01:38] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[23:01:38] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[23:01:38] [ENEMY] [Enemy2] [AllyDeath] Notified 2 enemies
+[23:01:38] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 9)
+[23:01:38] [INFO] [DeathAnim] Started - Angle: -152.8 deg, Index: 1
+[23:01:38] [ENEMY] [Enemy2] Death animation started with hit direction: (-0.889514, -0.456907)
+[23:01:38] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 252.7
+[23:01:38] [ENEMY] [Enemy3] Hit: dmg=1, hp=4/4->3/4
+[23:01:38] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.664795, 0.747026), lethal=false
+[23:01:38] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:38] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:38] [INFO] [ImpactEffects] Wall found for blood splatter at (753.3953, 810) (dist=80 px)
+[23:01:38] [INFO] [BloodDecal] Blood puddle created at (753.3953, 809) (added to group)
+[23:01:38] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[23:01:38] [ENEMY] [Enemy3] Hit: dmg=1, hp=3/4->2/4
+[23:01:38] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.664795, 0.747026), lethal=false
+[23:01:38] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:38] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:38] [INFO] [ImpactEffects] Wall found for blood splatter at (753.3953, 810) (dist=80 px)
+[23:01:38] [INFO] [BloodDecal] Blood puddle created at (753.3953, 809) (added to group)
+[23:01:38] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[23:01:38] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/4->1/4
+[23:01:38] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.664795, 0.747026), lethal=false
+[23:01:38] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:38] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:38] [INFO] [ImpactEffects] Wall found for blood splatter at (753.3953, 810) (dist=80 px)
+[23:01:38] [INFO] [BloodDecal] Blood puddle created at (753.3953, 809) (added to group)
+[23:01:38] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[23:01:38] [ENEMY] [Enemy3] Hit: dmg=1, hp=1/4->0/4
+[23:01:38] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.664795, 0.747026), lethal=true
+[23:01:38] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:38] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[23:01:38] [INFO] [ImpactEffects] Wall found for blood splatter at (753.3953, 810) (dist=80 px)
+[23:01:38] [INFO] [BloodDecal] Blood puddle created at (753.3953, 809) (added to group)
+[23:01:38] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1.5)
+[23:01:38] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[23:01:38] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[23:01:38] [ENEMY] [Enemy3] [AllyDeath] Notified 1 enemies
+[23:01:38] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 8)
+[23:01:38] [INFO] [DeathAnim] Started - Angle: 48.3 deg, Index: 15
+[23:01:38] [ENEMY] [Enemy3] Death animation started with hit direction: (0.664795, 0.747026)
+[23:01:38] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 113.2
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #1 at angle 3.4 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #2 at angle 21.7 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #3 at angle 18.6 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #4 at angle 33.7 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #5 at angle 31.8 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #6 at angle 49.8 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #7 at angle 40.6 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #8 at angle 75.5 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #9 at angle 63.9 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #10 at angle 86.4 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #11 at angle 96.5 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #12 at angle 93.2 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #13 at angle 119.6 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #14 at angle 120.0 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #15 at angle 124.6 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #16 at angle 146.1 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #17 at angle 133.9 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #18 at angle 165.9 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #19 at angle 149.9 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #20 at angle 172.5 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #21 at angle 172.5 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #22 at angle 188.8 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #23 at angle 184.7 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #24 at angle 192.3 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #25 at angle 203.2 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #26 at angle 237.1 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #27 at angle 248.0 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #28 at angle 231.9 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #29 at angle 253.7 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #30 at angle 254.7 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #31 at angle 271.4 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #32 at angle 271.5 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #33 at angle 283.4 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #34 at angle 294.9 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #35 at angle 304.0 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #36 at angle 325.0 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #37 at angle 328.3 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #38 at angle 338.4 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #39 at angle 342.9 degrees
+[23:01:38] [INFO] [DefensiveGrenade] Spawned shrapnel #40 at angle 357.5 degrees
+[23:01:38] [INFO] [GrenadeTimer] Timer expired for Flashbang grenade!
+[23:01:38] [INFO] [GrenadeTimer] Flashbang grenade activated at (624.75476, 665.4474)!
+[23:01:38] [INFO] [GrenadeTimer] Applying flashbang effects (radius: 700, blindness: 12s, stun: 6s)
+[23:01:38] [INFO] [FlashbangStatus] Flashbang: blind=7.7s, stun=3.8s
+[23:01:38] [INFO] [FlashbangStatus] Status: BLINDED applied
+[23:01:38] [INFO] [FlashbangStatus] Status: STUNNED applied
+[23:01:38] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 252,7 (intensity: 0,64)
+[23:01:38] [INFO] [FlashbangStatus] Flashbang: blind=10.1s, stun=5.0s
+[23:01:38] [INFO] [FlashbangStatus] Status: BLINDED applied
+[23:01:38] [INFO] [FlashbangStatus] Status: STUNNED applied
+[23:01:38] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 113,2 (intensity: 0,84)
+[23:01:38] [INFO] [GrenadeTimer] Player behind wall - flashbang blocked (distance: 304,3)
+[23:01:38] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(624.7548, 665.4474), source=NEUTRAL (DefensiveGrenade), range=2938, listeners=8
+[23:01:38] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=6
+[23:01:38] [INFO] [GrenadeTimer] Spawned flashbang effect at (624.75476, 665.4474) (radius: 700)
+[23:01:38] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=72.5°, current=-157.5°, player=(483,935), corner_timer=0.00
+[23:01:38] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=173.6°, current=168.8°, player=(483,935), corner_timer=0.00
+[23:01:38] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,935), corner_timer=0.30
+[23:01:39] [ENEMY] [Enemy4] Hit: dmg=1, hp=2/2->1/2
+[23:01:39] [INFO] [ImpactEffects] spawn_blood_effect called at (778.7569, 905.0839), dir=(-0.858248, 0.513235), lethal=false
+[23:01:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:39] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:39] [INFO] [ImpactEffects] Blood effect spawned at (778.7569, 905.0839) (scale=1)
+[23:01:39] [ENEMY] [Enemy4] Hit: dmg=1, hp=1/2->0/2
+[23:01:39] [INFO] [ImpactEffects] spawn_blood_effect called at (778.4516, 905.4561), dir=(0.3179, 0.948124), lethal=true
+[23:01:39] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:39] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[23:01:39] [INFO] [ImpactEffects] Wall found for blood splatter at (810.1516, 1000) (dist=99 px)
+[23:01:39] [INFO] [BloodDecal] Blood puddle created at (810.1516, 999) (added to group)
+[23:01:39] [INFO] [ImpactEffects] Blood effect spawned at (778.4516, 905.4561) (scale=1.5)
+[23:01:39] [ENEMY] [Enemy4] Enemy died (ricochet: false, penetration: false)
+[23:01:39] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[23:01:39] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 7)
+[23:01:39] [INFO] [DeathAnim] Started - Angle: 71.5 deg, Index: 16
+[23:01:39] [ENEMY] [Enemy4] Death animation started with hit direction: (0.3179, 0.948124)
+[23:01:39] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,935), corner_timer=-0.02
+[23:01:39] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,935), corner_timer=0.30
+[23:01:39] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:39] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[23:01:39] [ENEMY] [Enemy2] Ragdoll activated
+[23:01:39] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[23:01:39] [ENEMY] [Enemy3] Ragdoll activated
+[23:01:39] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[23:01:39] [ENEMY] [Enemy4] Ragdoll activated
+[23:01:39] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[23:01:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(483,935), corner_timer=-0.02
+[23:01:39] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,935), corner_timer=0.30
+[23:01:39] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:39] [INFO] [ReplayManager] Recording frame 3300 (55,0s): player_valid=True, enemies=10
+[23:01:39] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,935), corner_timer=-0.02
+[23:01:39] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:39] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,935), corner_timer=0.30
+[23:01:40] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:40] [WARN] [FPS] Drop detected: 7 fps (threshold: 30)
+[23:01:40] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,935), corner_timer=-0.02
+[23:01:40] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:40] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,935), corner_timer=0.30
+[23:01:40] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:40] [ENEMY] [Enemy2] Death animation completed
+[23:01:40] [ENEMY] [Enemy3] Death animation completed
+[23:01:40] [ENEMY] [Enemy4] Death animation completed
+[23:01:40] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,935), corner_timer=-0.02
+[23:01:40] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:40] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,935), corner_timer=0.30
+[23:01:40] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:40] [INFO] [ReplayManager] Recording frame 3360 (56,0s): player_valid=True, enemies=10
+[23:01:40] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,935), corner_timer=-0.02
+[23:01:40] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:40] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,935), corner_timer=0.30
+[23:01:40] [ENEMY] [Enemy1] PURSUING corner check: angle -139.2°
+[23:01:41] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [WARN] [FPS] Drop detected: 18 fps (threshold: 30)
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,895), corner_timer=-0.02
+[23:01:41] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,889), corner_timer=0.30
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [ENEMY] [Enemy1] PURSUING corner check: angle -80.1°
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,785), corner_timer=-0.02
+[23:01:41] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,779), corner_timer=0.30
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [ENEMY] [Enemy1] PURSUING corner check: angle 116.4°
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:41] [INFO] [ReplayManager] Recording frame 3420 (57,0s): player_valid=True, enemies=10
+[23:01:41] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,728), corner_timer=-0.02
+[23:01:41] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:41] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,728), corner_timer=0.30
+[23:01:42] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:42] [WARN] [FPS] Drop detected: 27 fps (threshold: 30)
+[23:01:42] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(483,728), corner_timer=-0.02
+[23:01:42] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:42] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(483,728), corner_timer=0.30
+[23:01:42] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[23:01:42] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[23:01:42] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[23:01:42] [INFO] [LastChance] Resetting all effects (scene change detected)
+[23:01:42] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[23:01:42] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[23:01:42] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[23:01:42] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:01:42] [ENEMY] [Enemy1] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[23:01:42] [ENEMY] [Enemy2] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[23:01:42] [ENEMY] [Enemy3] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[23:01:42] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:01:42] [ENEMY] [Enemy4] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[23:01:42] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[23:01:42] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[23:01:42] [ENEMY] [Grenadier] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[23:01:42] [ENEMY] [Enemy6] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[23:01:42] [ENEMY] [Enemy7] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[23:01:42] [ENEMY] [Enemy8] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[23:01:42] [ENEMY] [Enemy9] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[23:01:42] [ENEMY] [Enemy10] Death animation component initialized
+[23:01:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:01:42] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[23:01:42] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[23:01:42] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[23:01:42] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[23:01:42] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[23:01:42] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[23:01:42] [INFO] [Player.Weapon] Removed default MakarovPM
+[23:01:42] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[23:01:42] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[23:01:42] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[23:01:42] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[23:01:42] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[23:01:42] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[23:01:42] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[23:01:42] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[23:01:42] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[23:01:42] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[23:01:42] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[23:01:42] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[23:01:42] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[23:01:42] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[23:01:42] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[23:01:42] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[23:01:42] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[23:01:42] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[23:01:42] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[23:01:42] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[23:01:42] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[23:01:42] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[23:01:42] [INFO] [BuildingLevel] Setting up weapon: m16
+[23:01:42] [INFO] [BuildingLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[23:01:42] [INFO] [ScoreManager] Level started with 10 enemies
+[23:01:42] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[23:01:42] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[23:01:42] [INFO] [ReplayManager] Replay data cleared
+[23:01:42] [INFO] [BuildingLevel] Previous replay data cleared
+[23:01:42] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[23:01:42] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[23:01:42] [INFO] [ReplayManager] Level: BuildingLevel
+[23:01:42] [INFO] [ReplayManager] Player: Player (valid: True)
+[23:01:42] [INFO] [ReplayManager] Enemies count: 10
+[23:01:42] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[23:01:42] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[23:01:42] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[23:01:42] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[23:01:42] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[23:01:42] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[23:01:42] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[23:01:42] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[23:01:42] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[23:01:42] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[23:01:42] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[23:01:42] [INFO] [BuildingLevel] Replay recording started successfully
+[23:01:42] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[23:01:42] [INFO] [CinemaEffects] Found player node: Player
+[23:01:42] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 8)
+[23:01:42] [ENEMY] [Enemy1] Registered as sound listener
+[23:01:42] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 3, behavior: GUARD
+[23:01:42] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 9)
+[23:01:42] [ENEMY] [Enemy2] Registered as sound listener
+[23:01:42] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[23:01:42] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 10)
+[23:01:42] [ENEMY] [Enemy3] Registered as sound listener
+[23:01:42] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[23:01:42] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 11)
+[23:01:42] [ENEMY] [Enemy4] Registered as sound listener
+[23:01:42] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 4, behavior: GUARD
+[23:01:42] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 12)
+[23:01:42] [ENEMY] [Grenadier] Registered as sound listener
+[23:01:42] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[23:01:42] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 13)
+[23:01:42] [ENEMY] [Enemy6] Registered as sound listener
+[23:01:42] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[23:01:42] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 14)
+[23:01:42] [ENEMY] [Enemy7] Registered as sound listener
+[23:01:42] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 2, behavior: PATROL
+[23:01:42] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 15)
+[23:01:42] [ENEMY] [Enemy8] Registered as sound listener
+[23:01:42] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 4, behavior: GUARD
+[23:01:42] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 16)
+[23:01:42] [ENEMY] [Enemy9] Registered as sound listener
+[23:01:42] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[23:01:42] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[23:01:42] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 17)
+[23:01:42] [ENEMY] [Enemy10] Registered as sound listener
+[23:01:42] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[23:01:42] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[23:01:42] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[23:01:42] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:01:42] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:01:42] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:01:42] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:01:42] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:01:42] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=225.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:01:42] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=213.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:01:42] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:01:42] [INFO] [Player] Detecting weapon pose (frame 3)...
+[23:01:42] [INFO] [Player] Detected weapon: Rifle (default pose)
+[23:01:42] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[23:01:42] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[23:01:42] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[23:01:42] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[23:01:42] [INFO] [LastChance] Found player: Player
+[23:01:42] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[23:01:42] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[23:01:42] [INFO] [LastChance] Connected to player Died signal (C#)
+[23:01:42] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[23:01:42] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[23:01:42] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[23:01:42] [INFO] [Player.Grenade] G pressed - starting grab animation
+[23:01:42] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[23:01:42] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (516.91815, 890)
+[23:01:42] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[23:01:42] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[23:01:43] [INFO] [DefensiveGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[23:01:43] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 700
+[23:01:43] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[23:01:43] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[23:01:43] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[23:01:43] [INFO] [Player.Grenade] Timer started, grenade created at (450, 1250)
+[23:01:43] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[23:01:43] [INFO] [Player.Grenade] Step 1 complete! Drag: (317.54932, 62.11505)
+[23:01:43] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[23:01:43] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - starting trajectory aiming
+[23:01:43] [WARN] [FPS] Drop detected: 28 fps (threshold: 30)
+[23:01:43] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[23:01:44] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[23:01:44] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[23:01:44] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(306,1209), corner_timer=0.30
+[23:01:44] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(306,1209), corner_timer=0.30
+[23:01:44] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(327,1139), corner_timer=-0.02
+[23:01:44] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[23:01:44] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(327,1139), corner_timer=-0.02
+[23:01:44] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[23:01:44] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(331,1137), corner_timer=0.30
+[23:01:44] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(331,1137), corner_timer=0.30
+[23:01:44] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[23:01:44] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(423,1131), corner_timer=-0.02
+[23:01:44] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[23:01:44] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(426,1131), corner_timer=0.30
+[23:01:45] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(428,1124), corner_timer=-0.02
+[23:01:45] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[23:01:45] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(425,1122), corner_timer=0.30
+[23:01:45] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(356,1053), corner_timer=-0.02
+[23:01:45] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[23:01:45] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(352,1049), corner_timer=0.30
+[23:01:45] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[23:01:45] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(278,975), corner_timer=-0.02
+[23:01:45] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[23:01:45] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(274,972), corner_timer=0.30
+[23:01:45] [INFO] [Player.Grenade.Simple] Throwing! Target: (647.34827, 667.32654), Distance: 430,8, Speed: 508,4, Friction: 300,0
+[23:01:45] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,6048212
+[23:01:45] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[23:01:45] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.8226038, -0.568615), speed=508,4, spawn=(292.96536, 912.2895)
+[23:01:45] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.822604, -0.568615), Speed: 508.4 (clamped from 508.4, max: 1000.0)
+[23:01:45] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[23:01:45] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[23:01:45] [INFO] [Player.Grenade] State reset to IDLE
+[23:01:45] [INFO] [Player.Grenade] State reset to IDLE
+[23:01:45] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[23:01:45] [INFO] [Player.Grenade] Player rotation restored to 0
+[23:01:46] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:46] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[23:01:46] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-130.1°, player=(280,924), corner_timer=-0.02
+[23:01:46] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[23:01:46] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-133.0°, player=(285,924), corner_timer=0.30
+[23:01:46] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:46] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[23:01:46] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.1°, current=172.4°, player=(358,981), corner_timer=-0.02
+[23:01:46] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[23:01:46] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=175.3°, player=(359,986), corner_timer=0.30
+[23:01:46] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:46] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.4°, current=120.7°, player=(357,1086), corner_timer=-0.02
+[23:01:46] [ENEMY] [Enemy7] PATROL corner check: angle 89.7°
+[23:01:46] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.7°, current=123.6°, player=(355,1090), corner_timer=0.30
+[23:01:47] [INFO] [GrenadeBase] EXPLODED at (608.3726, 694.2685)!
+[23:01:47] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(608.3726, 694.2685), source=NEUTRAL (DefensiveGrenade), range=2937, listeners=17
+[23:01:47] [INFO] [SoundPropagation] Cleaned up 7 invalid listeners
+[23:01:47] [ENEMY] [Enemy1] Heard EXPLOSION at (608.3726, 694.2685), intensity=0.01, distance=462
+[23:01:47] [ENEMY] [Enemy2] Heard EXPLOSION at (608.3726, 694.2685), intensity=0.04, distance=253
+[23:01:47] [ENEMY] [Enemy3] Heard EXPLOSION at (608.3726, 694.2685), intensity=0.22, distance=107
+[23:01:47] [ENEMY] [Enemy4] Heard EXPLOSION at (608.3726, 694.2685), intensity=0.03, distance=281
+[23:01:47] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=0, self=0, below_threshold=6
+[23:01:47] [ENEMY] [Enemy2] Hit: dmg=1, hp=2/2->1/2
+[23:01:47] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.822173, -0.569238), lethal=false
+[23:01:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:47] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:47] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1)
+[23:01:47] [ENEMY] [Enemy2] Hit: dmg=1, hp=1/2->0/2
+[23:01:47] [INFO] [ImpactEffects] spawn_blood_effect called at (400, 550), dir=(-0.822173, -0.569238), lethal=true
+[23:01:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:47] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[23:01:47] [INFO] [ImpactEffects] Blood effect spawned at (400, 550) (scale=1.5)
+[23:01:47] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[23:01:47] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[23:01:47] [ENEMY] [Enemy2] [AllyDeath] Notified 2 enemies
+[23:01:47] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 9)
+[23:01:47] [INFO] [DeathAnim] Started - Angle: -145.3 deg, Index: 2
+[23:01:47] [ENEMY] [Enemy2] Death animation started with hit direction: (-0.822173, -0.569238)
+[23:01:47] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 253.4
+[23:01:47] [ENEMY] [Enemy3] Hit: dmg=1, hp=3/3->2/3
+[23:01:47] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.854371, 0.519663), lethal=false
+[23:01:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:47] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:47] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[23:01:47] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/3->1/3
+[23:01:47] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.854371, 0.519663), lethal=false
+[23:01:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:47] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:47] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1)
+[23:01:47] [ENEMY] [Enemy3] Hit: dmg=1, hp=1/3->0/3
+[23:01:47] [INFO] [ImpactEffects] spawn_blood_effect called at (700, 750), dir=(0.854371, 0.519663), lethal=true
+[23:01:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:47] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[23:01:47] [INFO] [ImpactEffects] Blood effect spawned at (700, 750) (scale=1.5)
+[23:01:47] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[23:01:47] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[23:01:47] [ENEMY] [Enemy3] [AllyDeath] Notified 1 enemies
+[23:01:47] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 8)
+[23:01:47] [INFO] [DeathAnim] Started - Angle: 31.3 deg, Index: 14
+[23:01:47] [ENEMY] [Enemy3] Death animation started with hit direction: (0.854371, 0.519663)
+[23:01:47] [INFO] [DefensiveGrenade] Applied 99 HE damage to enemy at distance 107.2
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #1 at angle -3.0 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #2 at angle 2.1 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #3 at angle 29.8 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #4 at angle 32.9 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #5 at angle 34.5 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #6 at angle 50.6 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #7 at angle 58.8 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #8 at angle 76.0 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #9 at angle 83.6 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #10 at angle 74.2 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #11 at angle 91.9 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #12 at angle 95.5 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #13 at angle 120.2 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #14 at angle 116.3 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #15 at angle 116.5 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #16 at angle 142.5 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #17 at angle 156.9 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #18 at angle 142.4 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #19 at angle 170.4 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #20 at angle 176.4 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #21 at angle 181.7 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #22 at angle 197.2 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #23 at angle 212.8 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #24 at angle 219.9 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #25 at angle 208.5 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #26 at angle 234.6 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #27 at angle 226.6 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #28 at angle 233.1 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #29 at angle 265.9 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #30 at angle 260.4 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #31 at angle 269.7 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #32 at angle 268.3 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #33 at angle 279.6 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #34 at angle 286.4 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #35 at angle 318.0 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #36 at angle 316.3 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #37 at angle 337.5 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #38 at angle 321.3 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #39 at angle 356.1 degrees
+[23:01:47] [INFO] [DefensiveGrenade] Spawned shrapnel #40 at angle 361.5 degrees
+[23:01:47] [INFO] [GrenadeTimer] Timer expired for Flashbang grenade!
+[23:01:47] [INFO] [GrenadeTimer] Flashbang grenade activated at (608.3726, 694.2685)!
+[23:01:47] [INFO] [GrenadeTimer] Applying flashbang effects (radius: 700, blindness: 12s, stun: 6s)
+[23:01:47] [INFO] [FlashbangStatus] Flashbang: blind=7.7s, stun=3.8s
+[23:01:47] [INFO] [FlashbangStatus] Status: BLINDED applied
+[23:01:47] [INFO] [FlashbangStatus] Status: STUNNED applied
+[23:01:47] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 253,4 (intensity: 0,64)
+[23:01:47] [INFO] [FlashbangStatus] Flashbang: blind=10.2s, stun=5.1s
+[23:01:47] [INFO] [FlashbangStatus] Status: BLINDED applied
+[23:01:47] [INFO] [FlashbangStatus] Status: STUNNED applied
+[23:01:47] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 107,2 (intensity: 0,85)
+[23:01:47] [INFO] [GrenadeTimer] Player behind wall - flashbang blocked (distance: 507,4)
+[23:01:47] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(608.3726, 694.2685), source=NEUTRAL (DefensiveGrenade), range=2938, listeners=8
+[23:01:47] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=6
+[23:01:47] [INFO] [GrenadeTimer] Spawned flashbang effect at (608.3726, 694.2685) (radius: 700)
+[23:01:47] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=87.6°, current=-157.5°, player=(332,1119), corner_timer=0.00
+[23:01:47] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=154.8°, current=-67.5°, player=(332,1119), corner_timer=0.00
+[23:01:47] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:47] [ENEMY] [Enemy1] Hit: dmg=1, hp=3/3->2/3
+[23:01:47] [INFO] [ImpactEffects] spawn_blood_effect called at (298.7202, 376.2652), dir=(-0.686997, -0.72666), lethal=false
+[23:01:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:47] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:47] [INFO] [ImpactEffects] Blood effect spawned at (298.7202, 376.2652) (scale=1)
+[23:01:47] [ENEMY] [Enemy4] Hit: dmg=1, hp=4/4->3/4
+[23:01:47] [INFO] [ImpactEffects] spawn_blood_effect called at (752.0021, 914.9169), dir=(0.159008, -0.987277), lethal=false
+[23:01:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:01:47] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:01:47] [INFO] [ImpactEffects] Wall found for blood splatter at (756.0151, 890) (dist=25 px)
+[23:01:47] [INFO] [BloodDecal] Blood puddle created at (756.0151, 891) (added to group)
+[23:01:47] [INFO] [ImpactEffects] Blood effect spawned at (752.0021, 914.9169) (scale=1)
+[23:01:47] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.9°, current=89.7°, player=(285,1166), corner_timer=-0.02
+[23:01:47] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[23:01:47] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=92.5°, player=(281,1170), corner_timer=0.30
+[23:01:47] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[23:01:47] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[23:01:47] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=180.0°, current=114.1°, player=(269,1182), corner_timer=0.00
+[23:01:47] [ENEMY] [Enemy4] State: RETREATING -> IN_COVER
+[23:01:47] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=0.0°, current=84.8°, player=(265,1185), corner_timer=0.00
+[23:01:47] [ENEMY] [Enemy1] State: RETREATING -> IN_COVER
+[23:01:47] [ENEMY] [Enemy4] State: IN_COVER -> SUPPRESSED
+[23:01:47] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[23:01:47] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:47] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[23:01:47] [ENEMY] [Enemy2] Ragdoll activated
+[23:01:47] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[23:01:47] [ENEMY] [Enemy3] Ragdoll activated
+[23:01:47] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[23:01:47] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.7°, current=89.6°, player=(196,1216), corner_timer=-0.02
+[23:01:47] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[23:01:47] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(191,1215), corner_timer=0.30
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:47] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.5°, player=(140,1164), corner_timer=-0.02
+[23:01:47] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:47] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.4°, player=(140,1159), corner_timer=0.30
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:47] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.4°, current=89.5°, player=(144,1057), corner_timer=-0.02
+[23:01:48] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=92.3°, player=(146,1052), corner_timer=0.30
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [WARN] [FPS] Drop detected: 16 fps (threshold: 30)
+[23:01:48] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy2] Death animation completed
+[23:01:48] [ENEMY] [Enemy3] Death animation completed
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.5°, player=(214,976), corner_timer=-0.02
+[23:01:48] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(218,972), corner_timer=0.30
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [BloodyFeet:Enemy4] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(302,922), corner_timer=-0.02
+[23:01:48] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(308,922), corner_timer=0.30
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (198 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (196 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (193 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:48] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (190 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (187 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (185 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (182 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (179 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (176 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (174 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (171 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (168 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (165 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (163 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (160 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (158 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (156 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (154 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(408,922), corner_timer=-0.02
+[23:01:49] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (152 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(412,922), corner_timer=0.30
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (150 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (148 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (147 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (146 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (144 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (143 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (142 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (141 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (141 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (140 < 275 safe distance, blast=225, margin=50) - skipping throw
+[23:01:49] [INFO] [EnemyGrenade] Unsafe throw distance (200 < 275 safe, blast=225) for Offensive - skipping
+[23:01:49] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[23:01:49] [WARN] [FPS] Drop detected: 19 fps (threshold: 30)
+[23:01:49] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(436,922), corner_timer=-0.02
+[23:01:49] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:49] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(436,922), corner_timer=0.30
+[23:01:49] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:49] [ENEMY] [Enemy4] State: SUPPRESSED -> IN_COVER
+[23:01:49] [ENEMY] [Enemy4] State: IN_COVER -> PURSUING
+[23:01:49] [ENEMY] [Enemy4] ROT_CHANGE: P4:velocity -> P2:combat_state, state=PURSUING, target=178.3°, current=119.8°, player=(436,922), corner_timer=0.00
+[23:01:49] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.3°, current=89.4°, player=(436,922), corner_timer=-0.02
+[23:01:49] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:49] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(436,922), corner_timer=0.30
+[23:01:50] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:50] [ENEMY] [Enemy1] State: SUPPRESSED -> IN_COVER
+[23:01:50] [ENEMY] [Enemy1] State: IN_COVER -> PURSUING
+[23:01:50] [ENEMY] [Enemy1] ROT_CHANGE: P4:velocity -> P2:combat_state, state=PURSUING, target=76.9°, current=79.1°, player=(436,922), corner_timer=0.00
+[23:01:50] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(436,922), corner_timer=-0.02
+[23:01:50] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:50] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(436,922), corner_timer=0.30
+[23:01:50] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:50] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=10
+[23:01:50] [WARN] [FPS] Drop detected: 20 fps (threshold: 30)
+[23:01:50] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(436,922), corner_timer=-0.02
+[23:01:50] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:50] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(436,922), corner_timer=0.30
+[23:01:50] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:50] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(436,922), corner_timer=-0.02
+[23:01:50] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:50] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(436,922), corner_timer=0.30
+[23:01:51] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:01:51] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(436,922), corner_timer=-0.02
+[23:01:51] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:01:51] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(436,922), corner_timer=0.30
+[23:01:51] [INFO] ------------------------------------------------------------
+[23:01:51] [INFO] GAME LOG ENDED: 2026-03-05T23:01:51
+[23:01:51] [INFO] ============================================================

--- a/docs/case-studies/issue-966/game_log_20260305_230201.txt
+++ b/docs/case-studies/issue-966/game_log_20260305_230201.txt
@@ -1,0 +1,2011 @@
+[23:02:01] [INFO] ============================================================
+[23:02:01] [INFO] GAME LOG STARTED
+[23:02:01] [INFO] ============================================================
+[23:02:01] [INFO] Timestamp: 2026-03-05T23:02:01
+[23:02:01] [INFO] Log file: I:/Загрузки/godot exe/оптимизация/game_log_20260305_230201.txt
+[23:02:01] [INFO] Executable: I:/Загрузки/godot exe/оптимизация/Godot-Top-Down-Template.exe
+[23:02:01] [INFO] OS: Windows
+[23:02:01] [INFO] Debug build: false
+[23:02:01] [INFO] Engine version: 4.3-stable (official)
+[23:02:01] [INFO] Project: Godot Top-Down Template
+[23:02:01] [INFO] ------------------------------------------------------------
+[23:02:01] [INFO] [GameManager] GameManager ready
+[23:02:01] [INFO] [ScoreManager] ScoreManager ready
+[23:02:01] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[23:02:01] [INFO] [DifficultyManager] Loaded difficulty: Hard (value: 2)
+[23:02:01] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[23:02:01] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[23:02:01] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [BloodDecal] Blood puddle created at (0, 0) (added to group)
+[23:02:01] [INFO] [ImpactEffects] Blood decal pool initialized: 150 decals pre-created
+[23:02:01] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[23:02:01] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[23:02:01] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[23:02:01] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[23:02:01] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[23:02:01] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[23:02:01] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[23:02:01] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[23:02:01] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[23:02:01] [INFO] [LastChance] Resetting all effects (scene change detected)
+[23:02:01] [INFO] [LastChance] Last chance shader loaded successfully
+[23:02:01] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[23:02:01] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[23:02:01] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[23:02:01] [INFO] [LastChance]   Sepia intensity: 0.70
+[23:02:01] [INFO] [LastChance]   Brightness: 0.60
+[23:02:01] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[23:02:01] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[23:02:01] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[23:02:02] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[23:02:02] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: true, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: true, FPS drop logging: true
+[23:02:02] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.29, music: 1.00
+[23:02:02] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[23:02:02] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[23:02:02] [INFO] [CinemaEffects] Created effects layer at layer 99
+[23:02:02] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[23:02:02] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[23:02:02] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[23:02:02] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[23:02:02] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[23:02:02] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[23:02:02] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[23:02:02] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[23:02:02] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[23:02:02] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[23:02:02] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[23:02:02] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[23:02:02] [INFO] [GrenadeTimerHelper] Autoload ready
+[23:02:02] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[23:02:02] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[23:02:02] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[23:02:02] [INFO] [PowerFantasy]   Kill effect duration: 300ms
+[23:02:02] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[23:02:02] [INFO] [ProgressManager] ProgressManager ready, loaded 5 entries
+[23:02:02] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[23:02:02] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[23:02:02] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[23:02:02] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[23:02:02] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[23:02:02] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[23:02:02] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[23:02:02] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[23:02:02] [INFO] [PersistManager] Restored unlocked weapon: m16
+[23:02:02] [INFO] [PersistManager] Restored unlocked weapon: shotgun
+[23:02:02] [INFO] [PersistManager] Restored unlocked weapon: mini_uzi
+[23:02:02] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[23:02:02] [INFO] [PersistManager] Restored unlocked weapon: sniper
+[23:02:02] [INFO] [PersistManager] Restored unlocked weapon: revolver
+[23:02:02] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[23:02:02] [INFO] [GameManager] Weapon selected: m16
+[23:02:02] [INFO] [PersistManager] Restored selected weapon: m16
+[23:02:02] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[23:02:02] [INFO] [PersistManager] Restored unlocked grenade type: 1
+[23:02:02] [INFO] [PersistManager] Restored unlocked grenade type: 2
+[23:02:02] [INFO] [PersistManager] Restored unlocked grenade type: 3
+[23:02:02] [INFO] [GrenadeManager] Grenade type changed from Flashbang to F-1 Grenade
+[23:02:02] [INFO] [PersistManager] Restored selected grenade type: 2
+[23:02:02] [INFO] [PersistManager] Restored unlocked active item type: 0
+[23:02:02] [INFO] [PersistManager] Restored unlocked active item type: 1
+[23:02:02] [INFO] [PersistManager] Restored unlocked active item type: 2
+[23:02:02] [INFO] [PersistManager] Restored unlocked active item type: 3
+[23:02:02] [INFO] [PersistManager] Restored unlocked active item type: 4
+[23:02:02] [INFO] [PersistManager] Restored unlocked active item type: 5
+[23:02:02] [INFO] [PersistManager] Restored unlocked active item type: 6
+[23:02:02] [INFO] [PersistManager] Restored unlocked active item type: 7
+[23:02:02] [INFO] [PersistManager] Restored unlocked active item type: 8
+[23:02:02] [INFO] [ActiveItemManager] Active item changed from None to BFF Pendant
+[23:02:02] [INFO] [PersistManager] Restored selected active item type: 4
+[23:02:02] [INFO] [PersistManager] State loaded successfully
+[23:02:02] [INFO] [PersistManager] PersistManager ready
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[23:02:02] [ENEMY] [Enemy1] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[23:02:02] [ENEMY] [Enemy2] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[23:02:02] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:02:02] [ENEMY] [Enemy3] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[23:02:02] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:02:02] [ENEMY] [Enemy4] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[23:02:02] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:02:02] [ENEMY] [Enemy5] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[23:02:02] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[23:02:02] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[23:02:02] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[23:02:02] [INFO] [Player.Weapon] Removed default MakarovPM
+[23:02:02] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[23:02:02] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[23:02:02] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[23:02:02] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[23:02:02] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[23:02:02] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[23:02:02] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[23:02:02] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[23:02:02] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[23:02:02] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[23:02:02] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[23:02:02] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[23:02:02] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[23:02:02] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[23:02:02] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[23:02:02] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[23:02:02] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[23:02:02] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[23:02:02] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[23:02:02] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[23:02:02] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[23:02:02] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[23:02:02] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[23:02:02] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[23:02:02] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[23:02:02] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[23:02:02] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[23:02:02] [INFO] [LabyrinthLevel] Setting up weapon: m16
+[23:02:02] [INFO] [LabyrinthLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[23:02:02] [INFO] [ScoreManager] Level started with 5 enemies
+[23:02:02] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[23:02:02] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[23:02:02] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[23:02:02] [INFO] [ReplayManager] Replay data cleared
+[23:02:02] [INFO] [LabyrinthLevel] Previous replay data cleared
+[23:02:02] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[23:02:02] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[23:02:02] [INFO] [ReplayManager] Level: LabyrinthLevel
+[23:02:02] [INFO] [ReplayManager] Player: Player (valid: True)
+[23:02:02] [INFO] [ReplayManager] Enemies count: 5
+[23:02:02] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[23:02:02] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[23:02:02] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[23:02:02] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[23:02:02] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[23:02:02] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[23:02:02] [INFO] [LabyrinthLevel] Replay recording started successfully
+[23:02:02] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[23:02:02] [INFO] [CinemaEffects] Found player node: Player
+[23:02:02] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[23:02:02] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/BuildingLevel.tscn
+[23:02:02] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[23:02:02] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[23:02:02] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[23:02:02] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[23:02:02] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[23:02:02] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[23:02:02] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[23:02:02] [INFO] [PenultimateHit] Shader warmup complete in 710 ms
+[23:02:02] [INFO] [LastChance] Shader warmup complete in 709 ms
+[23:02:02] [INFO] [CinemaEffects] Cinema shader warmup complete in 627 ms
+[23:02:02] [INFO] [FlashbangPlayer] Shader warmup complete in 617 ms
+[23:02:02] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[23:02:02] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[23:02:02] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[23:02:02] [INFO] [LastChance] Resetting all effects (scene change detected)
+[23:02:02] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[23:02:02] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[23:02:02] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[23:02:02] [ENEMY] [Enemy1] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[23:02:02] [ENEMY] [Enemy2] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[23:02:02] [ENEMY] [Enemy3] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[23:02:02] [ENEMY] [Enemy4] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[23:02:02] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[23:02:02] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[23:02:02] [ENEMY] [Grenadier] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[23:02:02] [ENEMY] [Enemy6] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[23:02:02] [ENEMY] [Enemy7] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[23:02:02] [ENEMY] [Enemy8] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[23:02:02] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:02:02] [ENEMY] [Enemy9] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[23:02:02] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:02:02] [ENEMY] [Enemy10] Death animation component initialized
+[23:02:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:02] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[23:02:02] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[23:02:02] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[23:02:02] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[23:02:02] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[23:02:02] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[23:02:02] [INFO] [Player.Weapon] Removed default MakarovPM
+[23:02:02] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[23:02:02] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[23:02:02] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[23:02:02] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[23:02:02] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[23:02:02] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[23:02:02] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[23:02:02] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[23:02:02] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[23:02:02] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[23:02:02] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[23:02:02] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[23:02:02] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[23:02:02] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[23:02:02] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[23:02:02] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[23:02:02] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[23:02:02] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[23:02:02] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[23:02:02] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[23:02:02] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[23:02:02] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[23:02:02] [INFO] [BuildingLevel] Setting up weapon: m16
+[23:02:02] [INFO] [BuildingLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[23:02:02] [INFO] [ScoreManager] Level started with 10 enemies
+[23:02:02] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[23:02:02] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[23:02:02] [INFO] [ReplayManager] Replay data cleared
+[23:02:02] [INFO] [BuildingLevel] Previous replay data cleared
+[23:02:02] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[23:02:02] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[23:02:02] [INFO] [ReplayManager] Level: BuildingLevel
+[23:02:02] [INFO] [ReplayManager] Player: Player (valid: True)
+[23:02:02] [INFO] [ReplayManager] Enemies count: 10
+[23:02:02] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[23:02:02] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[23:02:02] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[23:02:02] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[23:02:02] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[23:02:02] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[23:02:02] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[23:02:02] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[23:02:02] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[23:02:02] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[23:02:02] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[23:02:02] [INFO] [BuildingLevel] Replay recording started successfully
+[23:02:02] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[23:02:02] [INFO] [CinemaEffects] Found player node: Player
+[23:02:02] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[23:02:02] [ENEMY] [Enemy1] Registered as sound listener
+[23:02:02] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[23:02:02] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[23:02:02] [ENEMY] [Enemy2] Registered as sound listener
+[23:02:02] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 3, behavior: GUARD
+[23:02:02] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[23:02:02] [ENEMY] [Enemy3] Registered as sound listener
+[23:02:02] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[23:02:02] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[23:02:02] [ENEMY] [Enemy4] Registered as sound listener
+[23:02:02] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 3, behavior: GUARD
+[23:02:02] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[23:02:02] [ENEMY] [Grenadier] Registered as sound listener
+[23:02:02] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[23:02:02] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[23:02:02] [ENEMY] [Enemy6] Registered as sound listener
+[23:02:02] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[23:02:02] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[23:02:02] [ENEMY] [Enemy7] Registered as sound listener
+[23:02:02] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 4, behavior: PATROL
+[23:02:02] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[23:02:02] [ENEMY] [Enemy8] Registered as sound listener
+[23:02:02] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[23:02:02] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[23:02:02] [ENEMY] [Enemy9] Registered as sound listener
+[23:02:02] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[23:02:02] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[23:02:02] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[23:02:02] [ENEMY] [Enemy10] Registered as sound listener
+[23:02:02] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[23:02:02] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[23:02:03] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[23:02:03] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:02:03] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=45.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:02:03] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:02:03] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:02:03] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:02:03] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=225.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:02:03] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=157.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:02:03] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[23:02:03] [INFO] [Player] Detecting weapon pose (frame 3)...
+[23:02:03] [INFO] [Player] Detected weapon: Rifle (default pose)
+[23:02:03] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[23:02:03] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[23:02:03] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[23:02:03] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[23:02:03] [INFO] [LastChance] Found player: Player
+[23:02:03] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[23:02:03] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[23:02:03] [INFO] [LastChance] Connected to player Died signal (C#)
+[23:02:03] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[23:02:03] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 1298 ms
+[23:02:03] [WARN] [FPS] Drop detected: 18 fps (threshold: 30)
+[23:02:04] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[23:02:04] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[23:02:04] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[23:02:04] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,935), corner_timer=0.30
+[23:02:04] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,935), corner_timer=0.30
+[23:02:04] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,830), corner_timer=-0.02
+[23:02:04] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[23:02:04] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,830), corner_timer=-0.02
+[23:02:04] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[23:02:04] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,825), corner_timer=0.30
+[23:02:04] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,825), corner_timer=0.30
+[23:02:05] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450, 781.4999), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:05] [ENEMY] [Enemy1] Heard gunshot at (450, 781.4999), intensity=0.01, distance=457
+[23:02:05] [ENEMY] [Enemy2] Heard gunshot at (450, 781.4999), intensity=0.04, distance=237
+[23:02:05] [ENEMY] [Enemy3] Heard gunshot at (450, 781.4999), intensity=0.04, distance=252
+[23:02:05] [ENEMY] [Enemy4] Heard gunshot at (450, 781.4999), intensity=0.02, distance=370
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:05] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=70.8°, current=-33.8°, player=(450,781), corner_timer=0.00
+[23:02:05] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=77.8°, current=45.0°, player=(450,781), corner_timer=0.00
+[23:02:05] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=172.8°, current=11.3°, player=(450,781), corner_timer=0.00
+[23:02:05] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-161.3°, current=168.8°, player=(450,781), corner_timer=0.00
+[23:02:05] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=176.6°, current=178.5°, player=(448,765), corner_timer=0.00
+[23:02:05] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(450, 781.49994), shooter_id=110897401188, bullet_pos=(918.58453, 772.72754)
+[23:02:05] [INFO] [Bullet] Using shooter_position, distance=468,66666
+[23:02:05] [INFO] [Bullet] Distance to wall: 468,66666 (31,912374% of viewport)
+[23:02:05] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:05] [INFO] [Bullet] Starting wall penetration at (918.58453, 772.72754)
+[23:02:05] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(439,754), corner_timer=-0.02
+[23:02:05] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(437.1147, 752.8458), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:05] [INFO] [Bullet] Raycast backward hit penetrating body at distance 29,248167
+[23:02:05] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:05] [INFO] [Bullet] Exiting penetration at (965.24304, 771.85406) after traveling 41,66667 pixels through wall
+[23:02:05] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:05] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(437,752), corner_timer=0.30
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(689.417, 751.3335), source=ENEMY (Enemy3), range=1469, listeners=10
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[23:02:05] [INFO] [LastChance] Threat detected: Bullet
+[23:02:05] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:05] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:05] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[23:02:05] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/2->1/2
+[23:02:05] [INFO] [ImpactEffects] spawn_blood_effect called at (689.417, 751.3335), dir=(1, 0), lethal=false
+[23:02:05] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:05] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:05] [INFO] [ImpactEffects] Blood effect spawned at (689.417, 751.3335) (scale=1)
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(412.0198, 745.5123), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:05] [INFO] [Player] Spawning blood effect at (412.01984, 745.5123), dir=(1, 0), lethal=False (C#)
+[23:02:05] [INFO] [ImpactEffects] spawn_blood_effect called at (412.0198, 745.5123), dir=(1, 0), lethal=false
+[23:02:05] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:05] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:05] [INFO] [ImpactEffects] Blood effect spawned at (412.0198, 745.5123) (scale=1)
+[23:02:05] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[23:02:05] [INFO] [PenultimateHit] Hard mode active - skipping regular penultimate hit effect (using last chance instead)
+[23:02:05] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(683.3312, 758.8955), source=ENEMY (Enemy3), range=1469, listeners=10
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(672.9758, 738.1713), source=NEUTRAL (null), range=900, listeners=10
+[23:02:05] [ENEMY] [Enemy2] Heard CASING_KICK at (672.9758, 738.1713), intensity=0.02, dist=332
+[23:02:05] [ENEMY] [Enemy3] Heard CASING_KICK at (672.9758, 738.1713), intensity=1.00, dist=26
+[23:02:05] [ENEMY] [Enemy4] Heard CASING_KICK at (672.9758, 738.1713), intensity=0.06, dist=197
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(672.7063, 736.4745), source=NEUTRAL (null), range=900, listeners=10
+[23:02:05] [ENEMY] [Enemy2] Heard CASING_KICK at (672.7063, 736.4745), intensity=0.02, dist=330
+[23:02:05] [ENEMY] [Enemy3] Heard CASING_KICK at (672.7063, 736.4745), intensity=1.00, dist=30
+[23:02:05] [ENEMY] [Enemy4] Heard CASING_KICK at (672.7063, 736.4745), intensity=0.06, dist=199
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:05] [INFO] [LastChance] Threat detected: Bullet
+[23:02:05] [INFO] [LastChance] Triggering last chance effect!
+[23:02:05] [INFO] [LastChance] Starting last chance effect:
+[23:02:05] [INFO] [LastChance]   - Time will be frozen (except player)
+[23:02:05] [INFO] [LastChance]   - Duration: 6.00 real seconds
+[23:02:05] [INFO] [LastChance]   - Trigger: threat detected
+[23:02:05] [INFO] [LastChance]   - Sepia intensity: 0.70
+[23:02:05] [INFO] [LastChance]   - Brightness: 0.60
+[23:02:05] [INFO] [LastChance] Set player Player and all 33 children to PROCESS_MODE_ALWAYS
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'WallTop' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'WallBottom' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'WallLeft' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'WallRight' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room1_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room1_WallRight' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room2_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room2_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room2_WallRight' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallTop' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Corridor_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room3_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room3_WallBottom' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room4_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room4_WallTop' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room5_WallTop' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room5_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Left' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'LobbyDivider_Right' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallTop' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_WallRight' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallLeft' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallRight' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'MainHall_WallTop' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBL' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Room2_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Corridor_CornerBR' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTL' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'MainHall_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'StorageRoom_CornerTR' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Desk1' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Desk2' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Table1' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Cabinet1' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Cabinet2' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Desk3' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Desk4' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Table2' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Table3' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'Cabinet3' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'StorageCrate1' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'StorageCrate2' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Set StaticBody2D 'HallTable' to PROCESS_MODE_ALWAYS for collision
+[23:02:05] [INFO] [LastChance] Skipping player node: Player
+[23:02:05] [INFO] [LastChance] Froze existing bullet casing: Casing
+[23:02:05] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@609
+[23:02:05] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@611
+[23:02:05] [INFO] [LastChance] Froze existing bullet casing: @RigidBody2D@614
+[23:02:05] [INFO] [LastChance] Froze all nodes except player and autoloads (including GameManager for quick restart)
+[23:02:05] [INFO] [LastChance] Applied visual effects: sepia=0.70, brightness=0.60, ripple=0.0080
+[23:02:05] [INFO] [LastChance] Applied 4.0x saturation to 6 player sprites
+[23:02:05] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@618
+[23:02:05] [INFO] [LastChance] Registered frozen player bullet: @Area2D@618
+[23:02:05] [INFO] [LastChance] Freezing newly created explosion effect: PointLight2D
+[23:02:05] [INFO] [LastChance] Registered frozen explosion effect: PointLight2D
+[23:02:05] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@620
+[23:02:05] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@620
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(364.91, 744.7435), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:05] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@622
+[23:02:05] [INFO] [LastChance] Registered frozen player bullet: @Area2D@622
+[23:02:05] [INFO] [LastChance] Freezing newly created explosion effect: PointLight2D
+[23:02:05] [INFO] [LastChance] Registered frozen explosion effect: PointLight2D
+[23:02:05] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@623
+[23:02:05] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@623
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(325.3101, 744.7435), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:05] [INFO] [LastChance] Freezing newly fired player bullet: @Area2D@625
+[23:02:05] [INFO] [LastChance] Registered frozen player bullet: @Area2D@625
+[23:02:05] [INFO] [LastChance] Freezing newly created explosion effect: PointLight2D
+[23:02:05] [INFO] [LastChance] Registered frozen explosion effect: PointLight2D
+[23:02:05] [INFO] [LastChance] Freezing newly created bullet casing: @RigidBody2D@627
+[23:02:05] [INFO] [LastChance] Registered frozen bullet casing: @RigidBody2D@627
+[23:02:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(290.1101, 744.7435), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:05] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=4
+[23:02:06] [INFO] [ReplayManager] Recording frame 180 (2,9s): player_valid=True, enemies=10
+[23:02:06] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[23:02:06] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[23:02:06] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[23:02:06] [INFO] [LastChance] Resetting all effects (scene change detected)
+[23:02:06] [INFO] [LastChance] All process modes restored
+[23:02:06] [INFO] [LastChance] Restored original colors to 5 player sprites
+[23:02:06] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[23:02:06] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[23:02:06] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[23:02:06] [ENEMY] [Enemy1] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[23:02:06] [ENEMY] [Enemy2] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[23:02:06] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:02:06] [ENEMY] [Enemy3] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[23:02:06] [ENEMY] [Enemy4] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[23:02:06] [INFO] [EnemyGrenade] Grenade bag built (hard): [Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Offensive, Defensive]
+[23:02:06] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[23:02:06] [ENEMY] [Grenadier] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[23:02:06] [ENEMY] [Enemy6] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[23:02:06] [ENEMY] [Enemy7] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[23:02:06] [ENEMY] [Enemy8] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[23:02:06] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[23:02:06] [ENEMY] [Enemy9] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[23:02:06] [ENEMY] [Enemy10] Death animation component initialized
+[23:02:06] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[23:02:06] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[23:02:06] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[23:02:06] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[23:02:06] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[23:02:06] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[23:02:06] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[23:02:06] [INFO] [Player.Weapon] Removed default MakarovPM
+[23:02:06] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[23:02:06] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[23:02:06] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[23:02:06] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[23:02:06] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[23:02:06] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[23:02:06] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[23:02:06] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[23:02:06] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[23:02:06] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[23:02:06] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[23:02:06] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[23:02:06] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[23:02:06] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[23:02:06] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[23:02:06] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[23:02:06] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[23:02:06] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[23:02:06] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[23:02:06] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[23:02:06] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[23:02:06] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[23:02:06] [INFO] [BuildingLevel] Setting up weapon: m16
+[23:02:06] [INFO] [BuildingLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[23:02:06] [INFO] [ScoreManager] Level started with 10 enemies
+[23:02:06] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[23:02:06] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[23:02:06] [INFO] [ReplayManager] Replay data cleared
+[23:02:06] [INFO] [BuildingLevel] Previous replay data cleared
+[23:02:06] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[23:02:06] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[23:02:06] [INFO] [ReplayManager] Level: BuildingLevel
+[23:02:06] [INFO] [ReplayManager] Player: Player (valid: True)
+[23:02:06] [INFO] [ReplayManager] Enemies count: 10
+[23:02:06] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[23:02:06] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[23:02:06] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[23:02:06] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[23:02:06] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[23:02:06] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[23:02:06] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[23:02:06] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[23:02:06] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[23:02:06] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[23:02:06] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[23:02:06] [INFO] [BuildingLevel] Replay recording started successfully
+[23:02:06] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[23:02:06] [INFO] [CinemaEffects] Found player node: Player
+[23:02:06] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 11)
+[23:02:06] [ENEMY] [Enemy1] Registered as sound listener
+[23:02:06] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[23:02:06] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 12)
+[23:02:06] [ENEMY] [Enemy2] Registered as sound listener
+[23:02:06] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[23:02:06] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 13)
+[23:02:06] [ENEMY] [Enemy3] Registered as sound listener
+[23:02:06] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 4, behavior: GUARD
+[23:02:06] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 14)
+[23:02:06] [ENEMY] [Enemy4] Registered as sound listener
+[23:02:06] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[23:02:06] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 15)
+[23:02:06] [ENEMY] [Grenadier] Registered as sound listener
+[23:02:06] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[23:02:06] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 16)
+[23:02:06] [ENEMY] [Enemy6] Registered as sound listener
+[23:02:06] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[23:02:06] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 17)
+[23:02:06] [ENEMY] [Enemy7] Registered as sound listener
+[23:02:06] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[23:02:06] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 18)
+[23:02:06] [ENEMY] [Enemy8] Registered as sound listener
+[23:02:06] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[23:02:06] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 19)
+[23:02:06] [ENEMY] [Enemy9] Registered as sound listener
+[23:02:06] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[23:02:06] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[23:02:06] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 20)
+[23:02:06] [ENEMY] [Enemy10] Registered as sound listener
+[23:02:06] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[23:02:06] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[23:02:06] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[23:02:06] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[23:02:06] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[23:02:06] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(450,1249), corner_timer=0.00
+[23:02:06] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[23:02:06] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[23:02:06] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=225.0°, current=0.0°, player=(450,1249), corner_timer=0.00
+[23:02:06] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[23:02:06] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1249), corner_timer=0.00
+[23:02:06] [INFO] [Player] Detecting weapon pose (frame 3)...
+[23:02:06] [INFO] [Player] Detected weapon: Rifle (default pose)
+[23:02:06] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[23:02:06] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[23:02:06] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[23:02:06] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[23:02:06] [INFO] [LastChance] Found player: Player
+[23:02:06] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[23:02:06] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[23:02:06] [INFO] [LastChance] Connected to player Died signal (C#)
+[23:02:06] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[23:02:07] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[23:02:07] [WARN] [FPS] Drop detected: 25 fps (threshold: 30)
+[23:02:08] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[23:02:08] [ENEMY] [Enemy10] PATROL corner check: angle -0.0°
+[23:02:08] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=94.3°, current=4.3°, player=(450,1015), corner_timer=0.30
+[23:02:08] [ENEMY] [Enemy10] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=90.0°, player=(450,1015), corner_timer=0.30
+[23:02:08] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[23:02:08] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=4.3°, current=58.7°, player=(450,1015), corner_timer=-0.02
+[23:02:08] [ENEMY] [Enemy7] PATROL corner check: angle 94.3°
+[23:02:08] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=50.4°, player=(450,1015), corner_timer=-0.02
+[23:02:08] [ENEMY] [Enemy10] PATROL corner check: angle 14.3°
+[23:02:08] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=94.3°, current=55.9°, player=(450,1015), corner_timer=0.30
+[23:02:08] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=14.3°, current=52.7°, player=(450,1015), corner_timer=0.30
+[23:02:08] [INFO] [Player] Invincibility mode: ON
+[23:02:08] [INFO] [GameManager] Invincibility mode toggled: ON
+[23:02:08] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=14.0°, player=(450,1015), corner_timer=-0.02
+[23:02:08] [ENEMY] [Enemy10] PATROL corner check: angle 7.0°
+[23:02:08] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=7.0°, current=16.7°, player=(450,1015), corner_timer=0.30
+[23:02:09] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=6.9°, player=(450,1015), corner_timer=-0.02
+[23:02:09] [ENEMY] [Enemy10] PATROL corner check: angle 3.5°
+[23:02:09] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=3.5°, current=9.6°, player=(450,1015), corner_timer=0.30
+[23:02:09] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[23:02:09] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=3.5°, player=(450,997), corner_timer=-0.02
+[23:02:09] [ENEMY] [Enemy10] PATROL corner check: angle 1.8°
+[23:02:09] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=1.8°, current=6.3°, player=(450,993), corner_timer=0.30
+[23:02:09] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.8°, player=(450,893), corner_timer=-0.02
+[23:02:09] [ENEMY] [Enemy10] PATROL corner check: angle 0.9°
+[23:02:09] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=0.9°, current=4.6°, player=(450,887), corner_timer=0.30
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(449.692, 805.2387), source=PLAYER (AssaultRifle), range=1469, listeners=20
+[23:02:10] [INFO] [SoundPropagation] Cleaned up 10 invalid listeners
+[23:02:10] [ENEMY] [Enemy1] Heard gunshot at (449.692, 805.2387), intensity=0.01, distance=479
+[23:02:10] [ENEMY] [Enemy2] Heard gunshot at (449.692, 805.2387), intensity=0.04, distance=260
+[23:02:10] [ENEMY] [Enemy3] Heard gunshot at (449.692, 805.2387), intensity=0.04, distance=256
+[23:02:10] [ENEMY] [Enemy4] Heard gunshot at (449.692, 805.2387), intensity=0.02, distance=363
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:10] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=71.8°, current=168.8°, player=(449,805), corner_timer=0.00
+[23:02:10] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=79.0°, current=-101.3°, player=(449,805), corner_timer=0.00
+[23:02:10] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=167.6°, current=-78.7°, player=(449,805), corner_timer=0.00
+[23:02:10] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-164.9°, current=168.8°, player=(449,805), corner_timer=0.00
+[23:02:10] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[23:02:10] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(440.6102, 773.6474), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(449.69205, 805.2387), shooter_id=163644968806, bullet_pos=(908.1813, 764.07306)
+[23:02:10] [INFO] [Bullet] Using shooter_position, distance=460,33356
+[23:02:10] [INFO] [Bullet] Distance to wall: 460,33356 (31,34496% of viewport)
+[23:02:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:10] [INFO] [Bullet] Starting wall penetration at (908.1813, 764.07306)
+[23:02:10] [ENEMY] [Enemy3] Hit: dmg=1, hp=4/4->3/4
+[23:02:10] [INFO] [ImpactEffects] spawn_blood_effect called at (684.3301, 753.229), dir=(1, 0), lethal=false
+[23:02:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:10] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:10] [INFO] [ImpactEffects] Blood effect spawned at (684.3301, 753.229) (scale=1)
+[23:02:10] [INFO] [Bullet] Raycast backward hit penetrating body at distance 18,736076
+[23:02:10] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:10] [INFO] [Bullet] Exiting penetration at (954.661, 759.89984) after traveling 41,666668 pixels through wall
+[23:02:10] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(684.3301, 753.229), source=ENEMY (Enemy3), range=1469, listeners=10
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[23:02:10] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=179.3°, current=179.4°, player=(424,756), corner_timer=0.00
+[23:02:10] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(419.6805, 753.5237), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:10] [INFO] [LastChance] Threat detected: @Area2D@904
+[23:02:10] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:10] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[23:02:10] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-127.8°, player=(417,752), corner_timer=-0.00
+[23:02:10] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[23:02:10] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-130.1°, player=(414,751), corner_timer=0.30
+[23:02:10] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[23:02:10] [INFO] [Player] Spawning blood effect at (409.50998, 749.927), dir=(1, 0), lethal=False (C#)
+[23:02:10] [INFO] [ImpactEffects] spawn_blood_effect called at (409.51, 749.927), dir=(1, 0), lethal=false
+[23:02:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:10] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:10] [INFO] [ImpactEffects] Blood effect spawned at (409.51, 749.927) (scale=1)
+[23:02:10] [ENEMY] [Enemy3] Hit: dmg=1, hp=3/4->2/4
+[23:02:10] [INFO] [ImpactEffects] spawn_blood_effect called at (678.5333, 747.1493), dir=(1, 0), lethal=false
+[23:02:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:10] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:10] [INFO] [ImpactEffects] Blood effect spawned at (678.5333, 747.1493) (scale=1)
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(678.5333, 747.1493), source=ENEMY (Enemy3), range=1469, listeners=10
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(666.2247, 736.4111), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (666.2247, 736.4111), intensity=0.02, dist=317
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (666.2247, 736.4111), intensity=1.00, dist=14
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (666.2247, 736.4111), intensity=0.06, dist=202
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(402.7721, 749.2592), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(665.631, 734.6339), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (665.631, 734.6339), intensity=0.03, dist=316
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (665.631, 734.6339), intensity=1.00, dist=14
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (665.631, 734.6339), intensity=0.06, dist=205
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(664.7563, 732.6583), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (664.7563, 732.6583), intensity=0.03, dist=314
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (664.7563, 732.6583), intensity=1.00, dist=14
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (664.7563, 732.6583), intensity=0.06, dist=206
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(663.6223, 730.4814), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (663.6223, 730.4814), intensity=0.03, dist=312
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (663.6223, 730.4814), intensity=1.00, dist=14
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (663.6223, 730.4814), intensity=0.06, dist=208
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(662.2498, 728.1016), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (662.2498, 728.1016), intensity=0.03, dist=310
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (662.2498, 728.1016), intensity=1.00, dist=14
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (662.2498, 728.1016), intensity=0.06, dist=211
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(671.9901, 738.7252), source=ENEMY (Enemy3), range=1469, listeners=10
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(660.6575, 725.5187), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (660.6575, 725.5187), intensity=0.03, dist=307
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (660.6575, 725.5187), intensity=1.00, dist=15
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (660.6575, 725.5187), intensity=0.05, dist=214
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(658.8625, 722.7339), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (658.8625, 722.7339), intensity=0.03, dist=304
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (658.8625, 722.7339), intensity=1.00, dist=16
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (658.8625, 722.7339), intensity=0.05, dist=218
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/4->1/4
+[23:02:10] [INFO] [ImpactEffects] spawn_blood_effect called at (669.3727, 735.3556), dir=(1, 0), lethal=false
+[23:02:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:10] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:10] [INFO] [ImpactEffects] Blood effect spawned at (669.3727, 735.3556) (scale=1)
+[23:02:10] [INFO] [EnemyGrenade] Facing throw direction: (-0.997962, 0.063816) (waiting 0.3s)
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(656.8801, 719.75), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (656.8801, 719.75), intensity=0.03, dist=301
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (656.8801, 719.75), intensity=1.00, dist=18
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (656.8801, 719.75), intensity=0.05, dist=221
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [LastChance] Threat detected: Bullet
+[23:02:10] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:10] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P0:grenade_throw, state=RETREATING, target=176.3°, current=177.7°, player=(390,754), corner_timer=0.00
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(654.7233, 716.5705), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (654.7233, 716.5705), intensity=0.03, dist=297
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (654.7233, 716.5705), intensity=1.00, dist=20
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (654.7233, 716.5705), intensity=0.05, dist=224
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(388.9063, 755.9212), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=0, below_threshold=3
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(652.4041, 713.2), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (652.4041, 713.2), intensity=0.03, dist=293
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (652.4041, 713.2), intensity=1.00, dist=22
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (652.4041, 713.2), intensity=0.05, dist=229
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(649.9326, 709.6435), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (649.9326, 709.6435), intensity=0.03, dist=289
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (649.9326, 709.6435), intensity=1.00, dist=24
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (649.9326, 709.6435), intensity=0.05, dist=233
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(664.1381, 728.6163), source=ENEMY (Enemy3), range=1469, listeners=10
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=1, self=1, below_threshold=6
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(647.3182, 705.9066), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (647.3182, 705.9066), intensity=0.03, dist=285
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (647.3182, 705.9066), intensity=1.00, dist=26
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (647.3182, 705.9066), intensity=0.04, dist=236
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=1
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(644.569, 701.9951), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy1] Heard CASING_KICK at (644.569, 701.9951), intensity=0.01, dist=496
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (644.569, 701.9951), intensity=0.03, dist=281
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (644.569, 701.9951), intensity=1.00, dist=29
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (644.569, 701.9951), intensity=0.04, dist=243
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=6, self=0, below_threshold=0
+[23:02:10] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[23:02:10] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(641.6924, 697.9147), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy1] Heard CASING_KICK at (641.6924, 697.9147), intensity=0.01, dist=492
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (641.6924, 697.9147), intensity=0.03, dist=276
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (641.6924, 697.9147), intensity=1.00, dist=32
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (641.6924, 697.9147), intensity=0.04, dist=247
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=6, self=0, below_threshold=0
+[23:02:10] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[23:02:10] [INFO] [LastChance] Threat detected: @Area2D@936
+[23:02:10] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:10] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(638.6954, 693.6713), source=NEUTRAL (null), range=900, listeners=10
+[23:02:10] [ENEMY] [Enemy1] Heard CASING_KICK at (638.6954, 693.6713), intensity=0.01, dist=487
+[23:02:10] [ENEMY] [Enemy2] Heard CASING_KICK at (638.6954, 693.6713), intensity=0.03, dist=272
+[23:02:10] [ENEMY] [Enemy3] Heard CASING_KICK at (638.6954, 693.6713), intensity=1.00, dist=35
+[23:02:10] [ENEMY] [Enemy4] Heard CASING_KICK at (638.6954, 693.6713), intensity=0.04, dist=251
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=6, self=0, below_threshold=0
+[23:02:10] [ENEMY] [Enemy3] Hit: dmg=1, hp=1/4->0/4
+[23:02:10] [INFO] [ImpactEffects] spawn_blood_effect called at (658.9035, 721.8771), dir=(1, 0), lethal=true
+[23:02:10] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:10] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[23:02:10] [INFO] [ImpactEffects] Blood effect spawned at (658.9035, 721.8771) (scale=1.5)
+[23:02:10] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[23:02:10] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[23:02:10] [ENEMY] [Enemy3] [AllyDeath] Notified 2 enemies
+[23:02:10] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 9)
+[23:02:10] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[23:02:10] [ENEMY] [Enemy3] Death animation started with hit direction: (1, 0)
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(381.0073, 774.8638), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[23:02:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(610.99646, 755.4779), shooter_id=160289525406, bullet_pos=(53.80756, 858.68567)
+[23:02:10] [INFO] [Bullet] Using shooter_position, distance=566,6669
+[23:02:10] [INFO] [Bullet] Distance to wall: 566,6669 (38,585392% of viewport)
+[23:02:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:10] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=179.0°, current=177.0°, player=(379,781), corner_timer=-0.01
+[23:02:10] [ENEMY] [Enemy7] PATROL corner check: angle 89.8°
+[23:02:10] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.8°, current=179.0°, player=(379,785), corner_timer=0.30
+[23:02:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(604.80396, 749.52466), shooter_id=160289525406, bullet_pos=(43.94932, 830.478)
+[23:02:10] [INFO] [Bullet] Using shooter_position, distance=566,6669
+[23:02:10] [INFO] [Bullet] Distance to wall: 566,6669 (38,585392% of viewport)
+[23:02:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:10] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(377.9563, 800.5567), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[23:02:10] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=3, self=0, below_threshold=3
+[23:02:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(597.45, 743.8719), shooter_id=160289525406, bullet_pos=(64.25804, 731.5926)
+[23:02:10] [INFO] [Bullet] Using shooter_position, distance=533,3333
+[23:02:10] [INFO] [Bullet] Distance to wall: 533,3333 (36,315647% of viewport)
+[23:02:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:10] [INFO] [Bullet] Starting wall penetration at (64.25804, 731.5926)
+[23:02:10] [INFO] [Bullet] Raycast backward hit penetrating body at distance 6,066745
+[23:02:10] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:10] [INFO] [Bullet] Exiting penetration at (25.934864, 730.71) after traveling 33,333336 pixels through wall
+[23:02:10] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:10] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(381.00726, 774.8638), shooter_id=163644968806, bullet_pos=(927.7066, 698.54974)
+[23:02:10] [INFO] [Bullet] Using shooter_position, distance=552
+[23:02:10] [INFO] [Bullet] Distance to wall: 552 (37,586697% of viewport)
+[23:02:10] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:10] [INFO] [Bullet] Starting wall penetration at (927.7066, 698.54974)
+[23:02:11] [INFO] [Bullet] Raycast backward hit penetrating body at distance 29,959505
+[23:02:11] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:11] [INFO] [Bullet] Exiting penetration at (965.6718, 693.2502) after traveling 33,333336 pixels through wall
+[23:02:11] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(381.00726, 774.8638), shooter_id=163644968806, bullet_pos=(965.6718, 693.2502)
+[23:02:11] [INFO] [Bullet] Using shooter_position, distance=590,3333
+[23:02:11] [INFO] [Bullet] Distance to wall: 590,3333 (40,19688% of viewport)
+[23:02:11] [INFO] [Bullet] Distance-based penetration chance: 99,77031%
+[23:02:11] [INFO] [Bullet] Starting wall penetration at (965.6718, 693.2502)
+[23:02:11] [INFO] [Bullet] Raycast backward hit penetrating body at distance 0,3571287
+[23:02:11] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:11] [INFO] [Bullet] Exiting penetration at (1003.637, 687.9506) after traveling 33,333336 pixels through wall
+[23:02:11] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(377.95633, 800.5567), shooter_id=163644968806, bullet_pos=(920.66626, 699.71094)
+[23:02:11] [INFO] [Bullet] Using shooter_position, distance=552
+[23:02:11] [INFO] [Bullet] Distance to wall: 552 (37,586697% of viewport)
+[23:02:11] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:11] [INFO] [Bullet] Starting wall penetration at (920.66626, 699.71094)
+[23:02:11] [INFO] [Bullet] Raycast backward hit penetrating body at distance 22,73709
+[23:02:11] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:11] [INFO] [Bullet] Exiting penetration at (958.35443, 692.70776) after traveling 33,333332 pixels through wall
+[23:02:11] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.0°, current=126.1°, player=(376,820), corner_timer=-0.01
+[23:02:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.6°
+[23:02:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.6°, current=128.4°, player=(376,820), corner_timer=0.30
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(404.9788, 818.8143), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (404.9788, 818.8143), intensity=0.01, dist=445
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (404.9788, 818.8143), intensity=0.04, dist=258
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (404.9788, 818.8143), intensity=0.02, dist=386
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(405.2224, 819.4236), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (405.2224, 819.4236), intensity=0.01, dist=446
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (405.2224, 819.4236), intensity=0.04, dist=259
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (405.2224, 819.4236), intensity=0.02, dist=385
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(405.7012, 819.999), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (405.7012, 819.999), intensity=0.01, dist=447
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (405.7012, 819.999), intensity=0.04, dist=260
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (405.7012, 819.999), intensity=0.02, dist=385
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(404.1763, 811.888), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (404.1763, 811.888), intensity=0.01, dist=438
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (404.1763, 811.888), intensity=0.04, dist=251
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (404.1763, 811.888), intensity=0.02, dist=388
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(406.4465, 820.547), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (406.4465, 820.547), intensity=0.01, dist=447
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (406.4465, 820.547), intensity=0.04, dist=260
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (406.4465, 820.547), intensity=0.02, dist=384
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(404.4069, 812.374), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (404.4069, 812.374), intensity=0.01, dist=439
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (404.4069, 812.374), intensity=0.04, dist=252
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (404.4069, 812.374), intensity=0.02, dist=388
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [ENEMY] [Enemy3] Ragdoll activated
+[23:02:11] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(407.4882, 821.0757), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (407.4882, 821.0757), intensity=0.01, dist=448
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (407.4882, 821.0757), intensity=0.04, dist=261
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (407.4882, 821.0757), intensity=0.02, dist=383
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(404.9338, 812.7234), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (404.9338, 812.7234), intensity=0.01, dist=440
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (404.9338, 812.7234), intensity=0.04, dist=252
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (404.9338, 812.7234), intensity=0.02, dist=387
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(408.8547, 821.5955), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (408.8547, 821.5955), intensity=0.01, dist=449
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (408.8547, 821.5955), intensity=0.04, dist=261
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (408.8547, 821.5955), intensity=0.02, dist=381
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(405.782, 812.9249), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (405.782, 812.9249), intensity=0.01, dist=440
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (405.782, 812.9249), intensity=0.04, dist=252
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (405.782, 812.9249), intensity=0.02, dist=386
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(410.5731, 822.1185), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (410.5731, 822.1185), intensity=0.01, dist=450
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (410.5731, 822.1185), intensity=0.04, dist=262
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (410.5731, 822.1185), intensity=0.02, dist=380
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(406.974, 812.964), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (406.974, 812.964), intensity=0.01, dist=440
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (406.974, 812.964), intensity=0.04, dist=253
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (406.974, 812.964), intensity=0.02, dist=385
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [ReplayManager] Recording frame 300 (4,8s): player_valid=True, enemies=10
+[23:02:11] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(412.6686, 822.6592), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (412.6686, 822.6592), intensity=0.01, dist=452
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (412.6686, 822.6592), intensity=0.04, dist=262
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (412.6686, 822.6592), intensity=0.02, dist=377
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(408.5299, 812.8233), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (408.5299, 812.8233), intensity=0.01, dist=441
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (408.5299, 812.8233), intensity=0.04, dist=252
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (408.5299, 812.8233), intensity=0.02, dist=384
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(415.165, 823.2344), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (415.165, 823.2344), intensity=0.01, dist=453
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (415.165, 823.2344), intensity=0.04, dist=263
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (415.165, 823.2344), intensity=0.02, dist=375
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(410.4662, 812.4807), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (410.4662, 812.4807), intensity=0.01, dist=441
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (410.4662, 812.4807), intensity=0.04, dist=252
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (410.4662, 812.4807), intensity=0.02, dist=382
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(418.0843, 823.8634), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (418.0843, 823.8634), intensity=0.01, dist=455
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (418.0843, 823.8634), intensity=0.04, dist=264
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (418.0843, 823.8634), intensity=0.02, dist=372
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(412.7951, 811.9084), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (412.7951, 811.9084), intensity=0.01, dist=442
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (412.7951, 811.9084), intensity=0.04, dist=252
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (412.7951, 811.9084), intensity=0.02, dist=380
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(421.4466, 824.5676), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (421.4466, 824.5676), intensity=0.01, dist=457
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (421.4466, 824.5676), intensity=0.04, dist=265
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (421.4466, 824.5676), intensity=0.02, dist=368
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(415.5234, 811.0732), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (415.5234, 811.0732), intensity=0.01, dist=442
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (415.5234, 811.0732), intensity=0.04, dist=251
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (415.5234, 811.0732), intensity=0.02, dist=377
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(425.27, 825.3706), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (425.27, 825.3706), intensity=0.01, dist=459
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (425.27, 825.3706), intensity=0.04, dist=266
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (425.27, 825.3706), intensity=0.02, dist=365
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(418.6517, 809.9356), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (418.6517, 809.9356), intensity=0.01, dist=442
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (418.6517, 809.9356), intensity=0.04, dist=250
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (418.6517, 809.9356), intensity=0.02, dist=374
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(429.5705, 826.2982), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (429.5705, 826.2982), intensity=0.01, dist=461
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (429.5705, 826.2982), intensity=0.04, dist=267
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (429.5705, 826.2982), intensity=0.02, dist=360
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(422.1734, 808.4512), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (422.1734, 808.4512), intensity=0.01, dist=442
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (422.1734, 808.4512), intensity=0.04, dist=249
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (422.1734, 808.4512), intensity=0.02, dist=371
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(434.362, 827.3777), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (434.362, 827.3777), intensity=0.01, dist=464
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (434.362, 827.3777), intensity=0.03, dist=269
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (434.362, 827.3777), intensity=0.02, dist=355
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(426.0746, 806.5723), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (426.0746, 806.5723), intensity=0.01, dist=442
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (426.0746, 806.5723), intensity=0.04, dist=247
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (426.0746, 806.5723), intensity=0.02, dist=368
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[23:02:11] [INFO] [GrenadeBase] Grenade created at (619.103, 725.8676) (frozen)
+[23:02:11] [INFO] [FragGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[23:02:11] [INFO] [GrenadeTimer] Initialized for Frag grenade, effect radius: 225
+[23:02:11] [INFO] [GrenadeTimerHelper] Attached GrenadeTimer to FragGrenade (type: Frag)
+[23:02:11] [INFO] [EnemyGrenade] Attached C# GrenadeTimer to grenade (type: Frag)
+[23:02:11] [INFO] [FragGrenade] Pin pulled - waiting for impact (no timer, impact-triggered only)
+[23:02:11] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[23:02:11] [INFO] [GrenadeBase] LEGACY throw_grenade() called! Direction: (-0.995011, 0.099763), Speed: 537.8 (unfrozen)
+[23:02:11] [INFO] [GrenadeBase] NOTE: Using DRAG-BASED system. If velocity-based is expected, ensure grenade has throw_grenade_velocity_based() method.
+[23:02:11] [INFO] [FragGrenade] Grenade thrown (legacy) - impact detection enabled
+[23:02:11] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[23:02:11] [INFO] [GrenadeTimer] Thrower set to instance ID: 160289525406
+[23:02:11] [INFO] [EnemyGrenade] Enemy grenade thrown! Target: (391.8134, 753.1044), Distance: 269
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(439.6565, 828.6379), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (439.6565, 828.6379), intensity=0.01, dist=468
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (439.6565, 828.6379), intensity=0.03, dist=271
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (439.6565, 828.6379), intensity=0.02, dist=350
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(430.335, 804.2502), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (430.335, 804.2502), intensity=0.01, dist=441
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (430.335, 804.2502), intensity=0.04, dist=245
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (430.335, 804.2502), intensity=0.02, dist=365
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(445.4637, 830.108), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (445.4637, 830.108), intensity=0.01, dist=471
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (445.4637, 830.108), intensity=0.03, dist=273
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (445.4637, 830.108), intensity=0.02, dist=344
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(434.9286, 801.437), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (434.9286, 801.437), intensity=0.01, dist=441
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (434.9286, 801.437), intensity=0.04, dist=243
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (434.9286, 801.437), intensity=0.02, dist=361
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.5°, current=89.6°, player=(442,820), corner_timer=-0.01
+[23:02:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.5°
+[23:02:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.5°, current=91.9°, player=(446,820), corner_timer=0.30
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(466.1004, 807.0604), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (466.1004, 807.0604), intensity=0.01, dist=460
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (466.1004, 807.0604), intensity=0.04, dist=255
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (466.1004, 807.0604), intensity=0.02, dist=329
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(466.6503, 806.6599), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (466.6503, 806.6599), intensity=0.01, dist=460
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (466.6503, 806.6599), intensity=0.04, dist=255
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (466.6503, 806.6599), intensity=0.02, dist=329
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(467.658, 805.7924), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (467.658, 805.7924), intensity=0.01, dist=459
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (467.658, 805.7924), intensity=0.04, dist=254
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (467.658, 805.7924), intensity=0.02, dist=328
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(469.03, 804.4432), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (469.03, 804.4432), intensity=0.01, dist=459
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (469.03, 804.4432), intensity=0.04, dist=253
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (469.03, 804.4432), intensity=0.02, dist=327
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(470.6764, 802.6075), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (470.6764, 802.6075), intensity=0.01, dist=458
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (470.6764, 802.6075), intensity=0.04, dist=252
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (470.6764, 802.6075), intensity=0.02, dist=326
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(472.5178, 800.2917), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (472.5178, 800.2917), intensity=0.01, dist=457
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (472.5178, 800.2917), intensity=0.04, dist=250
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (472.5178, 800.2917), intensity=0.02, dist=325
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(474.4883, 797.5112), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (474.4883, 797.5112), intensity=0.01, dist=456
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (474.4883, 797.5112), intensity=0.04, dist=248
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (474.4883, 797.5112), intensity=0.02, dist=324
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(476.5371, 794.287), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (476.5371, 794.287), intensity=0.01, dist=454
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (476.5371, 794.287), intensity=0.04, dist=245
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (476.5371, 794.287), intensity=0.02, dist=323
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(478.6266, 790.6428), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (478.6266, 790.6428), intensity=0.01, dist=452
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (478.6266, 790.6428), intensity=0.04, dist=243
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (478.6266, 790.6428), intensity=0.02, dist=322
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(480.7256, 786.6244), source=NEUTRAL (null), range=900, listeners=9
+[23:02:11] [ENEMY] [Enemy1] Heard CASING_KICK at (480.7256, 786.6244), intensity=0.01, dist=449
+[23:02:11] [ENEMY] [Enemy2] Heard CASING_KICK at (480.7256, 786.6244), intensity=0.04, dist=239
+[23:02:11] [ENEMY] [Enemy4] Heard CASING_KICK at (480.7256, 786.6244), intensity=0.02, dist=322
+[23:02:11] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:11] [WARN] [FPS] Drop detected: 29 fps (threshold: 30)
+[23:02:11] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.1°, current=89.5°, player=(483,809), corner_timer=-0.01
+[23:02:11] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:02:11] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=91.8°, player=(483,809), corner_timer=0.30
+[23:02:12] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:12] [INFO] [ReplayManager] Recording frame 360 (5,6s): player_valid=True, enemies=10
+[23:02:12] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.9°, current=89.4°, player=(483,809), corner_timer=-0.01
+[23:02:12] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[23:02:12] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.7°, player=(483,809), corner_timer=0.30
+[23:02:12] [ENEMY] [Enemy3] Death animation completed
+[23:02:12] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:12] [ENEMY] [Enemy1] PURSUING corner check: angle -138.2°
+[23:02:12] [ENEMY] [Enemy2] PURSUING corner check: angle 156.2°
+[23:02:12] [ENEMY] [Enemy4] PURSUING corner check: angle -38.8°
+[23:02:12] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(458.5445, 785.8227), source=NEUTRAL (null), range=900, listeners=9
+[23:02:12] [ENEMY] [Enemy1] Heard CASING_KICK at (458.5445, 785.8227), intensity=0.01, dist=436
+[23:02:12] [ENEMY] [Enemy2] Heard CASING_KICK at (458.5445, 785.8227), intensity=0.05, dist=216
+[23:02:12] [ENEMY] [Enemy4] Heard CASING_KICK at (458.5445, 785.8227), intensity=0.02, dist=346
+[23:02:12] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:12] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(458.0208, 785.7463), source=NEUTRAL (null), range=900, listeners=9
+[23:02:12] [ENEMY] [Enemy1] Heard CASING_KICK at (458.0208, 785.7463), intensity=0.01, dist=435
+[23:02:12] [ENEMY] [Enemy2] Heard CASING_KICK at (458.0208, 785.7463), intensity=0.06, dist=211
+[23:02:12] [ENEMY] [Enemy4] Heard CASING_KICK at (458.0208, 785.7463), intensity=0.02, dist=348
+[23:02:12] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:12] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(456.9816, 785.6484), source=NEUTRAL (null), range=900, listeners=9
+[23:02:12] [ENEMY] [Enemy1] Heard CASING_KICK at (456.9816, 785.6484), intensity=0.01, dist=434
+[23:02:12] [ENEMY] [Enemy2] Heard CASING_KICK at (456.9816, 785.6484), intensity=0.06, dist=207
+[23:02:12] [ENEMY] [Enemy4] Heard CASING_KICK at (456.9816, 785.6484), intensity=0.02, dist=345
+[23:02:12] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:12] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.8°, current=89.3°, player=(491,766), corner_timer=-0.01
+[23:02:12] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[23:02:12] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(493,763), corner_timer=0.30
+[23:02:12] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=63.2°, current=25.3°, player=(515,739), corner_timer=0.03
+[23:02:12] [ENEMY] [Enemy1] Player distracted - priority attack triggered
+[23:02:12] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:12] [ENEMY] [Enemy1] State: PURSUING -> COMBAT
+[23:02:12] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-134.5°, current=-136.0°, player=(524,729), corner_timer=0.01
+[23:02:12] [ENEMY] [Enemy4] State: PURSUING -> COMBAT
+[23:02:12] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[23:02:12] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(701.4839, 914.0657), source=ENEMY (Enemy4), range=1469, listeners=9
+[23:02:12] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=1, below_threshold=6
+[23:02:12] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(550.856, 722.1376), source=NEUTRAL (null), range=900, listeners=9
+[23:02:12] [ENEMY] [Enemy1] Heard CASING_KICK at (550.856, 722.1376), intensity=0.02, dist=393
+[23:02:12] [ENEMY] [Enemy2] Heard CASING_KICK at (550.856, 722.1376), intensity=0.13, dist=138
+[23:02:12] [ENEMY] [Enemy4] Heard CASING_KICK at (550.856, 722.1376), intensity=0.04, dist=242
+[23:02:12] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:12] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(551.7311, 722.0345), source=NEUTRAL (null), range=900, listeners=9
+[23:02:12] [ENEMY] [Enemy1] Heard CASING_KICK at (551.7311, 722.0345), intensity=0.02, dist=390
+[23:02:12] [ENEMY] [Enemy2] Heard CASING_KICK at (551.7311, 722.0345), intensity=0.13, dist=138
+[23:02:12] [ENEMY] [Enemy4] Heard CASING_KICK at (551.7311, 722.0345), intensity=0.04, dist=239
+[23:02:12] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:12] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(553.3026, 722.0114), source=NEUTRAL (null), range=900, listeners=9
+[23:02:12] [ENEMY] [Enemy1] Heard CASING_KICK at (553.3026, 722.0114), intensity=0.02, dist=387
+[23:02:12] [ENEMY] [Enemy2] Heard CASING_KICK at (553.3026, 722.0114), intensity=0.13, dist=140
+[23:02:12] [ENEMY] [Enemy4] Heard CASING_KICK at (553.3026, 722.0114), intensity=0.04, dist=236
+[23:02:12] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [LastChance] Threat detected: Bullet
+[23:02:13] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:13] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(555.4898, 722.163), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (555.4898, 722.163), intensity=0.02, dist=385
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (555.4898, 722.163), intensity=0.12, dist=142
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (555.4898, 722.163), intensity=0.05, dist=232
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [ENEMY] [Enemy1] Player distracted - priority attack triggered
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(352.7963, 395.1117), source=ENEMY (Enemy1), range=1469, listeners=9
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(558.2064, 722.5582), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (558.2064, 722.5582), intensity=0.02, dist=383
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (558.2064, 722.5582), intensity=0.12, dist=144
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (558.2064, 722.5582), intensity=0.05, dist=228
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(526.6574, 690.9601), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (526.6574, 690.9601), intensity=0.02, dist=340
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (526.6574, 690.9601), intensity=0.24, dist=101
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (526.6574, 690.9601), intensity=0.03, dist=272
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=31.9°, current=45.6°, player=(538,711), corner_timer=0.03
+[23:02:13] [ENEMY] [Enemy2] State: PURSUING -> COMBAT
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(561.3907, 723.2522), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (561.3907, 723.2522), intensity=0.02, dist=383
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (561.3907, 723.2522), intensity=0.12, dist=147
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (561.3907, 723.2522), intensity=0.05, dist=224
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(526.3387, 690.3822), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (526.3387, 690.3822), intensity=0.02, dist=336
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (526.3387, 690.3822), intensity=0.25, dist=101
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (526.3387, 690.3822), intensity=0.03, dist=271
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(564.9863, 724.2825), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (564.9863, 724.2825), intensity=0.02, dist=384
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (564.9863, 724.2825), intensity=0.11, dist=151
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (564.9863, 724.2825), intensity=0.05, dist=221
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(525.6407, 689.3047), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (525.6407, 689.3047), intensity=0.02, dist=334
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (525.6407, 689.3047), intensity=0.25, dist=100
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (525.6407, 689.3047), intensity=0.03, dist=272
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(524.5152, 687.808), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (524.5152, 687.808), intensity=0.02, dist=331
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (524.5152, 687.808), intensity=0.26, dist=98
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (524.5152, 687.808), intensity=0.03, dist=274
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(649.7361, 869.87555), shooter_id=160641846963, bullet_pos=(491.27176, 698.6054)
+[23:02:13] [INFO] [Bullet] Using shooter_position, distance=233,33324
+[23:02:13] [INFO] [Bullet] Distance to wall: 233,33324 (15,888089% of viewport)
+[23:02:13] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:13] [INFO] [Bullet] Starting wall penetration at (491.27176, 698.6054)
+[23:02:13] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(678.9845, 914.0654), source=ENEMY (Enemy4), range=1469, listeners=9
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=1, below_threshold=6
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(522.9297, 685.9658), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (522.9297, 685.9658), intensity=0.02, dist=326
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (522.9297, 685.9658), intensity=0.27, dist=96
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (522.9297, 685.9658), intensity=0.03, dist=276
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(548.317, 702.754), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[23:02:13] [INFO] [Bullet] Raycast backward hit penetrating body at distance 23,88481
+[23:02:13] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:13] [INFO] [Bullet] Exiting penetration at (465.2383, 670.4682) after traveling 33,333336 pixels through wall
+[23:02:13] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:13] [INFO] [LastChance] Threat detected: @Area2D@1006
+[23:02:13] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:13] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:13] [INFO] [LastChance] Threat detected: @Area2D@1010
+[23:02:13] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:13] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:13] [ENEMY] [Enemy2] Hit: dmg=1, hp=2/2->1/2
+[23:02:13] [INFO] [ImpactEffects] spawn_blood_effect called at (435.0806, 647.6407), dir=(1, 0), lethal=false
+[23:02:13] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:13] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:13] [INFO] [ImpactEffects] Blood effect spawned at (435.0806, 647.6407) (scale=1)
+[23:02:13] [ENEMY] [Enemy2] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=23.4°, current=180.0°, player=(554,699), corner_timer=0.03
+[23:02:13] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.7°, current=89.3°, player=(554,699), corner_timer=-0.01
+[23:02:13] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[23:02:13] [ENEMY] [Enemy1] Player distracted - priority attack triggered
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(367.8203, 411.8677), source=ENEMY (Enemy1), range=1469, listeners=9
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=1, below_threshold=4
+[23:02:13] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(557,697), corner_timer=0.30
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(345.8369, 416.4687), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (345.8369, 416.4687), intensity=1.00, dist=29
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (345.8369, 416.4687), intensity=0.04, dist=248
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(343.729, 417.2128), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (343.729, 417.2128), intensity=1.00, dist=35
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (343.729, 417.2128), intensity=0.04, dist=248
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0, below_threshold=1
+[23:02:13] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[23:02:13] [ENEMY] [Enemy4] Player distracted - priority attack triggered
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(678.9845, 914.0654), source=ENEMY (Enemy4), range=1469, listeners=9
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=1, below_threshold=6
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(575.3983, 692.9443), source=PLAYER (AssaultRifle), range=1469, listeners=9
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0, below_threshold=4
+[23:02:13] [INFO] [LastChance] Threat detected: Bullet
+[23:02:13] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:13] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(707.3356, 898.033), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (707.3356, 898.033), intensity=0.02, dist=370
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (707.3356, 898.033), intensity=1.00, dist=30
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(679.4085, 895.8533), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (679.4085, 895.8533), intensity=0.02, dist=348
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (679.4085, 895.8533), intensity=1.00, dist=18
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [LastChance] Threat detected: @Area2D@1019
+[23:02:13] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:13] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(708.2959, 897.8709), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (708.2959, 897.8709), intensity=0.02, dist=370
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (708.2959, 897.8709), intensity=1.00, dist=28
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(679.9424, 896.5668), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (679.9424, 896.5668), intensity=0.02, dist=349
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (679.9424, 896.5668), intensity=1.00, dist=18
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(709.6819, 897.3939), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (709.6819, 897.3939), intensity=0.02, dist=371
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (709.6819, 897.3939), intensity=1.00, dist=28
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(680.5768, 896.6807), source=NEUTRAL (null), range=900, listeners=9
+[23:02:13] [ENEMY] [Enemy2] Heard CASING_KICK at (680.5768, 896.6807), intensity=0.02, dist=350
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (680.5768, 896.6807), intensity=1.00, dist=19
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [ENEMY] [Enemy2] Hit: dmg=1, hp=1/2->0/2
+[23:02:13] [INFO] [ImpactEffects] spawn_blood_effect called at (435.0806, 647.6407), dir=(1, 0), lethal=true
+[23:02:13] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:13] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[23:02:13] [INFO] [ImpactEffects] Blood effect spawned at (435.0806, 647.6407) (scale=1.5)
+[23:02:13] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[23:02:13] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[23:02:13] [ENEMY] [Enemy2] [AllyDeath] Notified 2 enemies
+[23:02:13] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 8)
+[23:02:13] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[23:02:13] [ENEMY] [Enemy2] Death animation started with hit direction: (1, 0)
+[23:02:13] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P3:corner, state=RETREATING, target=-138.2°, current=54.2°, player=(587,691), corner_timer=0.01
+[23:02:13] [ENEMY] [Enemy1] State: RETREATING -> IN_COVER
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(711.3911, 896.6527), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (711.3911, 896.6527), intensity=1.00, dist=28
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0, below_threshold=3
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(680.6536, 896.7213), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (680.6536, 896.7213), intensity=1.00, dist=20
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [ReplayManager] Recording frame 420 (6,4s): player_valid=True, enemies=10
+[23:02:13] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(712.84, 896.9686), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (712.84, 896.9686), intensity=1.00, dist=27
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0, below_threshold=3
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(680.591, 896.7252), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (680.591, 896.7252), intensity=1.00, dist=21
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(714.5634, 896.7535), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (714.5634, 896.7535), intensity=1.00, dist=29
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0, below_threshold=3
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(680.2344, 896.6331), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (680.2344, 896.6331), intensity=1.00, dist=24
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [ENEMY] [Enemy4] ROT_CHANGE: P1:visible -> P3:corner, state=RETREATING, target=-38.8°, current=-112.9°, player=(600,691), corner_timer=0.01
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(716.2278, 896.5543), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (716.2278, 896.5543), intensity=1.00, dist=28
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0, below_threshold=3
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(680.0016, 896.6926), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (680.0016, 896.6926), intensity=1.00, dist=24
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(379.661, 457.63275), shooter_id=159584882292, bullet_pos=(691.2951, 1008.99)
+[23:02:13] [INFO] [Bullet] Using shooter_position, distance=633,33295
+[23:02:13] [INFO] [Bullet] Distance to wall: 633,33295 (43,124805% of viewport)
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(718.1545, 896.0642), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (718.1545, 896.0642), intensity=1.00, dist=30
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0, below_threshold=3
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(679.7596, 896.7033), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (679.7596, 896.7033), intensity=1.00, dist=27
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(609.7982, 691.9774), source=PLAYER (AssaultRifle), range=1469, listeners=8
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=0, below_threshold=4
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(679.2378, 896.6837), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (679.2378, 896.6837), intensity=1.00, dist=31
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(687.2777, 896.6085), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (687.2777, 896.6085), intensity=1.00, dist=27
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(642.3574, 856.715), shooter_id=160641846963, bullet_pos=(509.40637, 587.784)
+[23:02:13] [INFO] [Bullet] Using shooter_position, distance=299,99982
+[23:02:13] [INFO] [Bullet] Distance to wall: 299,99982 (20,42754% of viewport)
+[23:02:13] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(678.6404, 896.5798), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (678.6404, 896.5798), intensity=1.00, dist=34
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(687.7504, 896.7381), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (687.7504, 896.7381), intensity=1.00, dist=29
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [ENEMY] [Enemy4] Hit: dmg=1, hp=2/2->1/2
+[23:02:13] [INFO] [ImpactEffects] spawn_blood_effect called at (700.3946, 922.9973), dir=(1, 0), lethal=false
+[23:02:13] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:13] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:13] [INFO] [ImpactEffects] Blood effect spawned at (700.3946, 922.9973) (scale=1)
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(687.5243, 896.708), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (687.5243, 896.708), intensity=1.00, dist=29
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(687.462, 896.7103), source=NEUTRAL (null), range=900, listeners=8
+[23:02:13] [ENEMY] [Enemy4] Heard CASING_KICK at (687.462, 896.7103), intensity=1.00, dist=32
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=2
+[23:02:13] [ENEMY] [Enemy4] Hit: dmg=1, hp=1/2->0/2
+[23:02:13] [INFO] [ImpactEffects] spawn_blood_effect called at (704.549, 923.5956), dir=(1, 0), lethal=true
+[23:02:13] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:13] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[23:02:13] [INFO] [ImpactEffects] Blood effect spawned at (704.549, 923.5956) (scale=1.5)
+[23:02:13] [ENEMY] [Enemy4] Enemy died (ricochet: false, penetration: false)
+[23:02:13] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[23:02:13] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 7)
+[23:02:13] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[23:02:13] [ENEMY] [Enemy4] Death animation started with hit direction: (1, 0)
+[23:02:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(642.3574, 856.715), shooter_id=160641846963, bullet_pos=(474.26566, 700.7791)
+[23:02:13] [INFO] [Bullet] Using shooter_position, distance=229,28334
+[23:02:13] [INFO] [Bullet] Distance to wall: 229,28334 (15,612325% of viewport)
+[23:02:13] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(636.0716, 861.25366), shooter_id=160641846963, bullet_pos=(257.37817, 272.5336)
+[23:02:13] [INFO] [Bullet] Using shooter_position, distance=700,00006
+[23:02:13] [INFO] [Bullet] Distance to wall: 700,00006 (47,664295% of viewport)
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(644.9984, 691.9774), source=PLAYER (AssaultRifle), range=1469, listeners=7
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=5
+[23:02:13] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.7°, current=89.3°, player=(653,691), corner_timer=-0.01
+[23:02:13] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[23:02:13] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(658,691), corner_timer=0.30
+[23:02:13] [INFO] [GrenadeTimer] Frag grenade landed - EXPLODING!
+[23:02:13] [INFO] [GrenadeTimer] Frag grenade activated at (113.27861, 776.583)!
+[23:02:13] [INFO] [GrenadeTimer] Applying frag explosion damage (radius: 225, damage: 99)
+[23:02:13] [INFO] [GrenadeTimer] Skipping all enemies - enemy-thrown grenade (thrower ID: 160289525406)
+[23:02:13] [INFO] [GrenadeTimer] Spawned 4 shrapnel pieces (source_id: 214446377561, thrower_id: 160289525406)
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(113.2786, 776.583), source=NEUTRAL (FragGrenade), range=2938, listeners=7
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=6
+[23:02:13] [INFO] [GrenadeTimer] Spawned PointLight2D frag explosion flash at (113.27861, 776.583)
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(443.1237, 785.0756), source=NEUTRAL (null), range=900, listeners=7
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (443.1237, 785.0756), intensity=0.02, dist=355
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(435.9219, 790.6623), source=NEUTRAL (null), range=900, listeners=7
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (435.9219, 790.6623), intensity=0.02, dist=360
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(426.0615, 790.6758), source=NEUTRAL (null), range=900, listeners=7
+[23:02:13] [ENEMY] [Enemy1] Heard CASING_KICK at (426.0615, 790.6758), intensity=0.02, dist=359
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:13] [INFO] [GrenadeTimer] Scattered 3 casings
+[23:02:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(609.7982, 691.97736), shooter_id=163644968806, bullet_pos=(51.42578, 516.3774)
+[23:02:13] [INFO] [Bullet] Using shooter_position, distance=585,3334
+[23:02:13] [INFO] [Bullet] Distance to wall: 585,3334 (39,856426% of viewport)
+[23:02:13] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:13] [INFO] [Bullet] Starting wall penetration at (51.42578, 516.3774)
+[23:02:13] [INFO] [Bullet] Raycast backward hit penetrating body at distance 17,96958
+[23:02:13] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:13] [INFO] [Bullet] Exiting penetration at (14.858112, 504.87738) after traveling 33,333332 pixels through wall
+[23:02:13] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(697.7987, 691.9774), source=PLAYER (AssaultRifle), range=1469, listeners=7
+[23:02:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=5
+[23:02:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(636.0716, 861.25366), shooter_id=160641846963, bullet_pos=(58.501007, 653.7788)
+[23:02:13] [INFO] [Bullet] Using shooter_position, distance=613,7048
+[23:02:13] [INFO] [Bullet] Distance to wall: 613,7048 (41,78829% of viewport)
+[23:02:13] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:13] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(644.9984, 691.97736), shooter_id=163644968806, bullet_pos=(45.279537, 540.0378)
+[23:02:13] [INFO] [Bullet] Using shooter_position, distance=618,66656
+[23:02:13] [INFO] [Bullet] Distance to wall: 618,66656 (42,126144% of viewport)
+[23:02:13] [INFO] [Bullet] Distance-based penetration chance: 97,5195%
+[23:02:13] [INFO] [Bullet] Starting wall penetration at (45.279537, 540.0378)
+[23:02:13] [INFO] [Bullet] Raycast backward hit penetrating body at distance 24,634243
+[23:02:13] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:13] [INFO] [Bullet] Exiting penetration at (8.120228, 530.6234) after traveling 33,333332 pixels through wall
+[23:02:13] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:13] [ENEMY] [Enemy2] Ragdoll activated
+[23:02:13] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[23:02:13] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.3°, player=(757,697), corner_timer=-0.01
+[23:02:13] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[23:02:13] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(760,699), corner_timer=0.30
+[23:02:14] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(697.7987, 691.97736), shooter_id=163644968806, bullet_pos=(62.951115, 543.40894)
+[23:02:14] [INFO] [Bullet] Using shooter_position, distance=652
+[23:02:14] [INFO] [Bullet] Distance to wall: 652 (44,395878% of viewport)
+[23:02:14] [INFO] [Bullet] Distance-based penetration chance: 94,871475%
+[23:02:14] [INFO] [Bullet] Starting wall penetration at (62.951115, 543.40894)
+[23:02:14] [INFO] [Bullet] Raycast backward hit penetrating body at distance 6,545966
+[23:02:14] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:14] [INFO] [Bullet] Exiting penetration at (25.626236, 534.6741) after traveling 33,333336 pixels through wall
+[23:02:14] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:14] [ENEMY] [Enemy4] Ragdoll activated
+[23:02:14] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[23:02:14] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:14] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(636.0716, 861.25366), shooter_id=160641846963, bullet_pos=(372.74805, 1389.2026)
+[23:02:14] [INFO] [Bullet] Using shooter_position, distance=589,97406
+[23:02:14] [INFO] [Bullet] Distance to wall: 589,97406 (40,17242% of viewport)
+[23:02:14] [INFO] [ReplayManager] Recording frame 480 (7,2s): player_valid=True, enemies=10
+[23:02:14] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(834,765), corner_timer=-0.01
+[23:02:14] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[23:02:14] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(837,768), corner_timer=0.30
+[23:02:14] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:14] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(870,856), corner_timer=-0.01
+[23:02:14] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[23:02:14] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(870,860), corner_timer=0.30
+[23:02:14] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:15] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(841,941), corner_timer=-0.01
+[23:02:15] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[23:02:15] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(838,943), corner_timer=0.30
+[23:02:15] [ENEMY] [Enemy2] Death animation completed
+[23:02:15] [ENEMY] [Enemy4] Death animation completed
+[23:02:15] [INFO] [ReplayManager] Recording frame 540 (8,0s): player_valid=True, enemies=10
+[23:02:15] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:15] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(744,949), corner_timer=-0.01
+[23:02:15] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[23:02:15] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(740,948), corner_timer=0.30
+[23:02:15] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:15] [ENEMY] [Enemy1] State: SUPPRESSED -> SEEKING_COVER
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(682.4938, 898.1192), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(682.061, 897.3951), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(681.2594, 895.951), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(679.8165, 896.195), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(678.6638, 895.614), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(677.9248, 895.0428), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(657.3168, 892.2748), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [ENEMY] [Enemy1] State: SEEKING_COVER -> IN_COVER
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(677.2587, 894.3756), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(656.8223, 891.939), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(676.5214, 893.4158), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(655.874, 891.2478), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [ENEMY] [Enemy1] Heard CASING_KICK at (655.874, 891.2478), intensity=0.01, dist=500
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(675.941, 892.3245), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(654.5131, 890.1799), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [ENEMY] [Enemy1] Heard CASING_KICK at (654.5131, 890.1799), intensity=0.01, dist=498
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(675.7214, 890.7629), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(652.7802, 888.7139), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [ENEMY] [Enemy1] Heard CASING_KICK at (652.7802, 888.7139), intensity=0.01, dist=496
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[23:02:15] [ENEMY] [Enemy1] State: SUPPRESSED -> SEEKING_COVER
+[23:02:15] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.5°, current=89.2°, player=(665,903), corner_timer=-0.01
+[23:02:15] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(675.3521, 889.7844), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(650.7151, 886.8291), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [ENEMY] [Enemy1] Heard CASING_KICK at (650.7151, 886.8291), intensity=0.01, dist=493
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[23:02:15] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(661,902), corner_timer=0.30
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(675.033, 889.5385), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(648.3559, 884.5063), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [ENEMY] [Enemy1] Heard CASING_KICK at (648.3559, 884.5063), intensity=0.01, dist=490
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[23:02:15] [ENEMY] [Enemy1] State: SEEKING_COVER -> IN_COVER
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(675.1079, 888.7059), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:15] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(645.7373, 881.7288), source=NEUTRAL (null), range=900, listeners=7
+[23:02:15] [ENEMY] [Enemy1] Heard CASING_KICK at (645.7373, 881.7288), intensity=0.01, dist=486
+[23:02:15] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[23:02:16] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[23:02:16] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(675.2023, 888.2525), source=NEUTRAL (null), range=900, listeners=7
+[23:02:16] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:16] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(642.8901, 878.482), source=NEUTRAL (null), range=900, listeners=7
+[23:02:16] [ENEMY] [Enemy1] Heard CASING_KICK at (642.8901, 878.482), intensity=0.01, dist=481
+[23:02:16] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[23:02:16] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(675.3582, 887.7456), source=NEUTRAL (null), range=900, listeners=7
+[23:02:16] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0, below_threshold=2
+[23:02:16] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(639.8408, 874.7532), source=NEUTRAL (null), range=900, listeners=7
+[23:02:16] [ENEMY] [Enemy1] Heard CASING_KICK at (639.8408, 874.7532), intensity=0.01, dist=477
+[23:02:16] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[23:02:16] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(636.6111, 870.5315), source=NEUTRAL (null), range=900, listeners=7
+[23:02:16] [ENEMY] [Enemy1] Heard CASING_KICK at (636.6111, 870.5315), intensity=0.01, dist=472
+[23:02:16] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=5, self=0, below_threshold=1
+[23:02:16] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(633.2187, 865.8069), source=NEUTRAL (null), range=900, listeners=7
+[23:02:16] [ENEMY] [Enemy1] Heard CASING_KICK at (633.2187, 865.8069), intensity=0.01, dist=466
+[23:02:16] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:16] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(629.6772, 860.5704), source=NEUTRAL (null), range=900, listeners=7
+[23:02:16] [ENEMY] [Enemy1] Heard CASING_KICK at (629.6772, 860.5704), intensity=0.01, dist=460
+[23:02:16] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:16] [ENEMY] [Enemy1] State: SUPPRESSED -> SEEKING_COVER
+[23:02:16] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:16] [ENEMY] [Enemy1] State: SEEKING_COVER -> IN_COVER
+[23:02:16] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[23:02:16] [ENEMY] [Enemy1] State: SUPPRESSED -> SEEKING_COVER
+[23:02:16] [ENEMY] [Enemy1] State: SEEKING_COVER -> IN_COVER
+[23:02:16] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[23:02:16] [INFO] [ReplayManager] Recording frame 600 (8,8s): player_valid=True, enemies=10
+[23:02:16] [ENEMY] [Enemy1] State: SUPPRESSED -> SEEKING_COVER
+[23:02:16] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(588,836), corner_timer=-0.01
+[23:02:16] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[23:02:16] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=92.1°, player=(584,832), corner_timer=0.30
+[23:02:16] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:16] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.8°, current=89.2°, player=(514,757), corner_timer=-0.02
+[23:02:16] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[23:02:16] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=92.1°, player=(511,752), corner_timer=0.30
+[23:02:16] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:17] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.9°, current=89.3°, player=(519,706), corner_timer=-0.02
+[23:02:17] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[23:02:17] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=92.2°, player=(520,703), corner_timer=0.30
+[23:02:17] [ENEMY] [Enemy1] State: SEEKING_COVER -> IN_COVER
+[23:02:17] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:17] [ENEMY] [Enemy1] State: IN_COVER -> PURSUING
+[23:02:17] [ENEMY] [Enemy1] ROT_CHANGE: P3:corner -> P2:combat_state, state=PURSUING, target=68.7°, current=-140.9°, player=(537,670), corner_timer=0.01
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(551.5942, 644.7519), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (551.5942, 644.7519), intensity=0.01, dist=428
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(552.0842, 644.2549), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (552.0842, 644.2549), intensity=0.01, dist=428
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(553.0821, 643.3834), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (553.0821, 643.3834), intensity=0.01, dist=427
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(554.5944, 642.2578), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (554.5944, 642.2578), intensity=0.01, dist=427
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(556.6118, 640.9825), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (556.6118, 640.9825), intensity=0.01, dist=426
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(559.1133, 639.6372), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (559.1133, 639.6372), intensity=0.01, dist=426
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [ReplayManager] Recording frame 660 (9,8s): player_valid=True, enemies=10
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(562.0744, 638.2767), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (562.0744, 638.2767), intensity=0.01, dist=426
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.1°, current=89.3°, player=(528,638), corner_timer=-0.02
+[23:02:17] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:02:17] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.2°, player=(526,636), corner_timer=0.30
+[23:02:17] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(473.1091, 634.6495), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (473.1091, 634.6495), intensity=0.02, dist=392
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(472.2749, 635.0419), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (472.2749, 635.0419), intensity=0.02, dist=392
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(470.6682, 635.9412), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (470.6682, 635.9412), intensity=0.02, dist=393
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(468.4019, 637.4963), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (468.4019, 637.4963), intensity=0.02, dist=394
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(465.6766, 639.8406), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (465.6766, 639.8406), intensity=0.02, dist=395
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(462.7317, 643.0428), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (462.7317, 643.0428), intensity=0.02, dist=398
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(459.7739, 647.0867), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (459.7739, 647.0867), intensity=0.02, dist=401
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(456.9384, 651.9229), source=NEUTRAL (null), range=900, listeners=7
+[23:02:17] [ENEMY] [Enemy1] Heard CASING_KICK at (456.9384, 651.9229), intensity=0.02, dist=405
+[23:02:17] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:17] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.1°, current=89.4°, player=(440,618), corner_timer=-0.02
+[23:02:17] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:02:17] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=80.4°, current=130.3°, player=(436,616), corner_timer=0.01
+[23:02:17] [ENEMY] [Enemy1] State: PURSUING -> COMBAT
+[23:02:17] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.2°, player=(436,616), corner_timer=0.30
+[23:02:17] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=85.8°, current=-16.3°, player=(411,597), corner_timer=0.01
+[23:02:17] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:18] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.2°, current=89.4°, player=(371,542), corner_timer=-0.02
+[23:02:18] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:02:18] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=92.3°, player=(370,537), corner_timer=0.30
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(369.2488, 526.586), source=PLAYER (AssaultRifle), range=1469, listeners=7
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=3
+[23:02:18] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=97.5°, current=47.8°, player=(369,515), corner_timer=0.01
+[23:02:18] [ENEMY] [Enemy1] Hit: dmg=1, hp=2/2->1/2
+[23:02:18] [INFO] [ImpactEffects] spawn_blood_effect called at (394.3443, 324.1577), dir=(1, 0), lethal=false
+[23:02:18] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:18] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:18] [INFO] [ImpactEffects] Blood effect spawned at (394.3443, 324.1577) (scale=1)
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(394.3443, 324.1577), source=ENEMY (Enemy1), range=1469, listeners=7
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=4, self=1, below_threshold=2
+[23:02:18] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:18] [INFO] [LastChance] Threat detected: Bullet
+[23:02:18] [INFO] [LastChance] Player health is 0.0 - effect requires exactly 1 HP or less but alive
+[23:02:18] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(369.0552, 491.4662), source=PLAYER (AssaultRifle), range=1469, listeners=7
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0, below_threshold=3
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(387.1945, 502.3771), source=NEUTRAL (null), range=900, listeners=7
+[23:02:18] [ENEMY] [Enemy1] Heard CASING_KICK at (387.1945, 502.3771), intensity=0.08, dist=178
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=98.8°, current=169.0°, player=(369,487), corner_timer=0.01
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(389.0474, 503.0495), source=NEUTRAL (null), range=900, listeners=7
+[23:02:18] [ENEMY] [Enemy1] Heard CASING_KICK at (389.0474, 503.0495), intensity=0.08, dist=179
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[23:02:18] [INFO] [Player] Spawning blood effect at (369.05524, 482.66623), dir=(1, 0), lethal=False (C#)
+[23:02:18] [INFO] [ImpactEffects] spawn_blood_effect called at (369.0552, 482.6662), dir=(1, 0), lethal=false
+[23:02:18] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:18] [INFO] [ImpactEffects] Blood decals scheduled: 10 to spawn at particle landing times
+[23:02:18] [INFO] [ImpactEffects] Blood effect spawned at (369.0552, 482.6662) (scale=1)
+[23:02:18] [ENEMY] [Enemy1] Hit: dmg=1, hp=1/2->0/2
+[23:02:18] [INFO] [ImpactEffects] spawn_blood_effect called at (394.3443, 324.1577), dir=(1, 0), lethal=true
+[23:02:18] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[23:02:18] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[23:02:18] [INFO] [ImpactEffects] Blood effect spawned at (394.3443, 324.1577) (scale=1.5)
+[23:02:18] [ENEMY] [Enemy1] Enemy died (ricochet: false, penetration: false)
+[23:02:18] [INFO] [ScoreManager] Kill registered. Combo: 4 (points: 5000)
+[23:02:18] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 6)
+[23:02:18] [INFO] [DeathAnim] Started - Angle: 0.0 deg, Index: 12
+[23:02:18] [ENEMY] [Enemy1] Death animation started with hit direction: (1, 0)
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(369.0552, 456.2663), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0, below_threshold=3
+[23:02:18] [INFO] [ReplayManager] Recording frame 720 (10,8s): player_valid=True, enemies=10
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(390.4352, 466.2443), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(392.6866, 466.7565), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=177.0°, current=89.4°, player=(369,438), corner_timer=-0.00
+[23:02:18] [ENEMY] [Enemy7] PATROL corner check: angle 89.4°
+[23:02:18] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.4°, current=91.7°, player=(369,434), corner_timer=0.30
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(369.0552, 421.2441), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0, below_threshold=3
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(386.4655, 435.1431), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(388.2361, 436.1128), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(369.05524, 456.26627), shooter_id=163644968806, bullet_pos=(427.84476, 41.74782)
+[23:02:18] [INFO] [Bullet] Using shooter_position, distance=418,66663
+[23:02:18] [INFO] [Bullet] Distance to wall: 418,66663 (28,507782% of viewport)
+[23:02:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:18] [INFO] [Bullet] Starting wall penetration at (427.84476, 41.74782)
+[23:02:18] [INFO] [Bullet] Raycast backward hit penetrating body at distance 28,487967
+[23:02:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:18] [INFO] [Bullet] Exiting penetration at (433.22757, 3.7943) after traveling 33,333332 pixels through wall
+[23:02:18] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:18] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(369.0552, 393.8663), source=PLAYER (AssaultRifle), range=1469, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0, below_threshold=3
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(389.3353, 398.1667), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(391.3197, 398.5704), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(369.05524, 421.24408), shooter_id=163644968806, bullet_pos=(419.6334, 39.24455)
+[23:02:18] [INFO] [Bullet] Using shooter_position, distance=385,33337
+[23:02:18] [INFO] [Bullet] Distance to wall: 385,33337 (26,23806% of viewport)
+[23:02:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:18] [INFO] [Bullet] Starting wall penetration at (419.6334, 39.24455)
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(393.6512, 399.1457), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [Bullet] Raycast backward hit penetrating body at distance 31,02556
+[23:02:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:18] [INFO] [Bullet] Exiting penetration at (424.66495, 1.2428665) after traveling 33,333332 pixels through wall
+[23:02:18] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(385.0481, 370.649), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(369.05524, 393.86633), shooter_id=163644968806, bullet_pos=(413.81018, 44.72311)
+[23:02:18] [INFO] [Bullet] Using shooter_position, distance=352
+[23:02:18] [INFO] [Bullet] Distance to wall: 352 (23,968328% of viewport)
+[23:02:18] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[23:02:18] [INFO] [Bullet] Starting wall penetration at (413.81018, 44.72311)
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(386.3982, 370.798), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [Bullet] Raycast backward hit penetrating body at distance 25,506123
+[23:02:18] [INFO] [Bullet] Body exited signal received for penetrating body
+[23:02:18] [INFO] [Bullet] Exiting penetration at (418.68405, 6.700878) after traveling 33,333336 pixels through wall
+[23:02:18] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(387.8812, 370.8881), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(389.4614, 370.9415), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.9°, current=89.4°, player=(369,374), corner_timer=-0.01
+[23:02:18] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[23:02:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(391.1026, 370.973), source=NEUTRAL (null), range=900, listeners=6
+[23:02:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0, below_threshold=0
+[23:02:18] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(369,373), corner_timer=0.30
+[23:02:18] [ENEMY] [Enemy1] Ragdoll activated
+[23:02:18] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[23:02:18] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:19] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.7°, current=89.3°, player=(369,373), corner_timer=-0.01
+[23:02:19] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[23:02:19] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(369,373), corner_timer=0.30
+[23:02:19] [INFO] [ReplayManager] Recording frame 780 (11,6s): player_valid=True, enemies=10
+[23:02:19] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:19] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.7°, current=89.3°, player=(369,373), corner_timer=-0.01
+[23:02:19] [ENEMY] [Enemy7] PATROL corner check: angle 89.3°
+[23:02:19] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.3°, current=91.6°, player=(369,373), corner_timer=0.30
+[23:02:19] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:19] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.3°, player=(369,373), corner_timer=-0.01
+[23:02:19] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[23:02:19] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.6°, player=(369,373), corner_timer=0.30
+[23:02:20] [ENEMY] [Enemy1] Death animation completed
+[23:02:20] [ENEMY] [Enemy10] PATROL corner check: angle 0.6°
+[23:02:20] [INFO] [ReplayManager] Recording frame 840 (12,4s): player_valid=True, enemies=10
+[23:02:20] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=176.6°, current=89.2°, player=(369,373), corner_timer=-0.01
+[23:02:20] [ENEMY] [Enemy7] PATROL corner check: angle 89.2°
+[23:02:20] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=89.2°, current=91.5°, player=(369,373), corner_timer=0.30
+[23:02:20] [INFO] ------------------------------------------------------------
+[23:02:20] [INFO] GAME LOG ENDED: 2026-03-05T23:02:20
+[23:02:20] [INFO] ============================================================


### PR DESCRIPTION
## Summary

Comprehensive case study and fixes for FPS drops (10-29 fps) that occur after grenade explosions.

### Problem Analysis (Updated After Deep Investigation)

After analyzing 3 log files (7769 lines total), identified **multiple root causes**:

| Cause | Impact | Details |
|-------|--------|---------|
| **Ragdoll Physics** | PRIMARY | Creates 12+ RigidBody2D + 9 PinJoint2D at once |
| **Shrapnel Spawning** | HIGH | 40 Area2D spawned synchronously |
| **Shader Warmup** | MEDIUM | 1300ms warmup at level start |
| **Blood Decal Timers** | LOW | 100+ individual timers created |

### Key Finding

Even with blood decal optimization, FPS still dropped to 7 fps because **ragdoll activation** is the primary bottleneck, not blood spawning.

### Case Study

See `docs/case-studies/issue-966/README.md` for:
- Timeline reconstruction from log files
- Root cause analysis with code references
- Performance research from Godot documentation
- Recommended solutions

### Current Status

- [x] Reverted broken blood optimization
- [x] Downloaded and analyzed all log files
- [x] Created comprehensive case study
- [x] Identified primary cause (ragdoll physics)
- [ ] Waiting for user direction on which fix to implement

### Proposed Fixes

**Option A: Stagger Ragdoll Creation** (Highest Impact)
- Spread 4 body parts across 4 frames per enemy
- Prevents 12+ physics bodies created at once

**Option B: Stagger Shrapnel Spawning** (Medium Impact)
- Spawn 10 shrapnel per frame instead of 40 at once

**Option C: Blood Decal Timer Replacement** (Lower Impact)
- Replace 100+ timers with single queue processor

---

Fixes #966

## Test Plan

- [ ] Test grenade explosion with FPS counter enabled
- [ ] Monitor ragdoll activation FPS impact
- [ ] Verify blood spawning works correctly
- [ ] Check shrapnel behavior unchanged

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>