### PR TITLE
fix: increase gothic font rating size by 40% on score screen (Issue #895)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/895
-Your prepared branch: issue-895-1a3a8c855b24
-Your prepared working directory: /tmp/gh-issue-solver-1772740419629
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/godot-topdown-MVP#895

Increases the gothic font size for the rating/grade display on the score page by 40% as requested:
- Big rank label (fullscreen reveal): 200 → 280
- Final rank label (in container): 48 → 67

### Changed files

- `scripts/ui/animated_score_screen.gd` — Increased font sizes for both gothic font rank labels

## Test Plan

- [ ] Complete a level and view the score screen
- [ ] Verify the gothic font rating (S, A+, A, B, C, D, F) appears 40% larger during the fullscreen reveal
- [ ] Verify the final rank label in the score container is also 40% larger
- [ ] Verify the rank animation still works correctly (flash, shrink, fade)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)