### PR TITLE
fix: add boundary walls to Castle level to prevent walking outside map (Issue #764)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/764
-Your prepared branch: issue-764-5938a35d7172
-Your prepared working directory: /tmp/gh-issue-solver-1772744757146
-Your forked repository: konard/Jhon-Crow-godot-topdown-MVP
-Original repository (upstream): Jhon-Crow/godot-topdown-MVP
-
-Proceed.


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/godot-topdown-MVP#764

The castle map ("ЗАМОК") had no collision boundaries around its perimeter, allowing the player to walk into the gray forest area surrounding the playable zone. This PR adds invisible boundary walls to make the gray space impassable.

### Problem

The CastleLevel had visual boundaries (WallOvalTop polygon, ForestDecoration) and a navigation polygon defining the walkable area, but no physics collision bodies to actually block player movement at the map edges. Players could walk off the map into the surrounding "forest" decoration.

### Solution

Added 4 StaticBody2D boundary walls around the castle map perimeter, following the same pattern used in BeachLevel.tscn:

| Wall | Position | Size | Purpose |
|------|----------|------|---------|
| BoundaryTop | (3000, -100) | 6000 x 200 | Blocks top edge |
| BoundaryBottom | (3000, 2660) | 6000 x 200 | Blocks bottom edge |
| BoundaryLeft | (100, 1280) | 600 x 2560 | Blocks left edge |
| BoundaryRight | (5900, 1280) | 600 x 2560 | Blocks right edge |

All walls use:
- `collision_layer = 4` (environment layer, matching existing castle walls)
- `collision_mask = 0` (walls don't detect other bodies, only block them)

### Changed Files

- `scenes/levels/CastleLevel.tscn` — Added boundary wall collision shapes and StaticBody2D nodes

## Test Plan

- [ ] Load the Castle level ("ЗАМОК")
- [ ] Attempt to walk to the edges of the map in all 4 directions
- [ ] Verify the player cannot walk into the gray/forest area surrounding the castle
- [ ] Verify normal gameplay is not affected (can still move within the playable area)
- [ ] Verify enemies still move correctly within the playable area

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)