### PR TITLE
fix: add bottom padding to armory menu footer

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/Jhon-Crow/godot-topdown-MVP/issues/818
-# Branch: issue-818-9aeb1f7a2c85
-# Timestamp: 2026-03-09T15:50:23.668Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete

--- a/scripts/ui/armory_menu.gd
+++ b/scripts/ui/armory_menu.gd
@@ -287,7 +287,7 @@ func _build_ui() -> void:
 	margin.add_theme_constant_override("margin_left", 16)
 	margin.add_theme_constant_override("margin_top", 12)
 	margin.add_theme_constant_override("margin_right", 16)
-	margin.add_theme_constant_override("margin_bottom", 12)
+	margin.add_theme_constant_override("margin_bottom", 24)
 	panel.add_child(margin)
 
 	# Main vertical layout (title + content + buttons)
@@ -383,6 +383,11 @@ func _build_ui() -> void:
 	apply_style_disabled.corner_radius_bottom_left = 4
 	apply_style_disabled.corner_radius_bottom_right = 4
 	_apply_button.add_theme_stylebox_override("disabled", apply_style_disabled)
+
+	# Bottom spacer for footer padding
+	var bottom_spacer := Control.new()
+	bottom_spacer.custom_minimum_size = Vector2(0, 8)
+	main_vbox.add_child(bottom_spacer)
 
 	# Initial highlight and stats
 	_highlight_selected_items()


### PR DESCRIPTION
## Summary
- Increased bottom margin from 12px to 24px in the armory menu panel
- Added an 8px spacer after the Back/Apply buttons for better visual spacing

## Test plan
- [ ] Open the armory menu in-game
- [ ] Verify there is adequate spacing below the Back and Apply buttons
- [ ] Confirm the footer doesn't look cramped against the panel edge

Fixes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)