### PR TITLE
fix: add cover barrier at player spawn to block enemy line-of-sight on Castle map

### DIFF
--- a/scenes/levels/CastleLevel.tscn
+++ b/scenes/levels/CastleLevel.tscn
@@ -622,6 +622,36 @@ color = Color(0.3, 0.25, 0.18, 1)
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Environment/Cover/CoverBottom3"]
 shape = SubResource("RectangleShape2D_cover_large")
 
+[node name="CoverBottom4" type="StaticBody2D" parent="Environment/Cover"]
+position = Vector2(2850, 1950)
+collision_layer = 4
+collision_mask = 0
+
+[node name="ColorRect" type="ColorRect" parent="Environment/Cover/CoverBottom4"]
+offset_left = -80.0
+offset_top = -24.0
+offset_right = 80.0
+offset_bottom = 24.0
+color = Color(0.3, 0.25, 0.18, 1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Environment/Cover/CoverBottom4"]
+shape = SubResource("RectangleShape2D_cover_large")
+
+[node name="CoverBottom5" type="StaticBody2D" parent="Environment/Cover"]
+position = Vector2(3150, 1950)
+collision_layer = 4
+collision_mask = 0
+
+[node name="ColorRect" type="ColorRect" parent="Environment/Cover/CoverBottom5"]
+offset_left = -80.0
+offset_top = -24.0
+offset_right = 80.0
+offset_bottom = 24.0
+color = Color(0.3, 0.25, 0.18, 1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Environment/Cover/CoverBottom5"]
+shape = SubResource("RectangleShape2D_cover_large")
+
 [node name="PatrolZones" type="Node2D" parent="Environment"]
 
 [node name="PatrolZoneLeft" type="ColorRect" parent="Environment/PatrolZones"]


### PR DESCRIPTION
## Problem

On the Castle map, enemies immediately detect and attack the player at game start. The player spawns at \`Vector2(3000, 2100)\` with enemies at \`LowerEnemy1 (2150, 1250)\` and \`LowerEnemy2 (3850, 1250)\` casting diagonal line-of-sight rays toward the player.

The original cover row at y=1950 had only two objects:
- \`CoverBottom1\` at x=2700 (x range: 2620–2780)
- \`CoverBottom2\` at x=3300 (x range: 3220–3380)

This left a **520-pixel gap** (x=2780 to x=3220) directly above the player spawn.

## Root Cause Analysis

Adding \`CoverBottom3\` at x=3000 (the initial fix) only covered the center, but still left two 140-pixel gaps:
- **Gap left**: x=2780 to x=2920 — `LowerEnemy1`'s ray passes through at x≈2850
- **Gap right**: x=3080 to x=3220 — `LowerEnemy2`'s ray passes through at x≈3150

Geometric proof:
- `LowerEnemy1 (2150, 1250)` → `Player (3000, 2100)`: ray intersects y=1950 at **x=2850** (in gap)
- `LowerEnemy2 (3850, 1250)` → `Player (3000, 2100)`: ray intersects y=1950 at **x=3150** (in gap)

## Solution

Added two additional cover objects to close the remaining gaps:
- \`CoverBottom4\` at \`Vector2(2850, 1950)\` — fills gap between CoverBottom1 and CoverBottom3
- \`CoverBottom5\` at \`Vector2(3150, 1950)\` — fills gap between CoverBottom3 and CoverBottom2

The five cover objects now form a **continuous barrier** (with 10px overlap between adjacent covers) spanning x=2620 to x=3380, fully blocking all enemy line-of-sight rays to the player spawn.

## Changes

- \`scenes/levels/CastleLevel.tscn\`: Added \`CoverBottom4\` and \`CoverBottom5\` cover objects to close the remaining gaps in the spawn cover row

Closes #976