### PR TITLE
feat: lock levels sequentially — only Labyrinth open at start (Issue #984)

### DIFF
--- a/docs/case-studies/issue-984/analysis.md
+++ b/docs/case-studies/issue-984/analysis.md
@@ -83,3 +83,82 @@ The canonical level order (from `LEVELS` in `levels_menu.gd`) is:
   well". Even an F rank means the player finished the level.
 - **All 8 levels still shown**: locked levels remain visible as greyed-out cards so players
   can see what's ahead and plan their progression.
+
+---
+
+## Bug Report — March 11, 2026
+
+**Reporter**: Jhon-Crow (repo owner)
+**Comment**: https://github.com/Jhon-Crow/godot-topdown-MVP/pull/989#issuecomment-4040842432
+
+### Symptoms
+
+1. **After completing a level and pressing "Next Level", the next level still shows as locked.**
+2. **Weapons that unlock via conditions stopped working — progress appears not saved.**
+
+Game log attached: `game_log_20260311_202842.txt`
+
+### Timeline From Game Log
+
+| Time     | Event |
+|----------|-------|
+| 20:28:42 | Game starts. DifficultyManager loads **Black Metal** (value: 4). |
+| 20:28:42 | ProgressManager ready, loaded **2 entries** from `progress.cfg`. |
+| 20:28:42 | UnlockManager resets condition-gated items to locked state. |
+| 20:29:14 | Labyrinth completed. ProgressManager: _"No improvement for LabyrinthLevel on Black Metal (existing: rank=A, score=12369)"_ — level WAS previously completed on Black Metal. |
+| 20:29:15 | Player presses "Next Level" → transitions to BuildingLevel directly. |
+| 20:29:15 | BuildingLevel loads successfully. Log ends ~3 s into BuildingLevel. |
+
+**Key evidence**: The 2 loaded entries are from Black Metal difficulty. The level WAS completed. Yet `is_level_completed_any_difficulty` returned `false`.
+
+### Root Cause Analysis
+
+**All three bugs share a single root cause**: hardcoded difficulty name lists that **omit "Black Metal"**.
+
+#### Bug 1 — `progress_manager.gd:117`
+
+```gdscript
+func is_level_completed_any_difficulty(level_path: String) -> bool:
+    var difficulties: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]  # ← missing "Black Metal"
+    for difficulty_name in difficulties:
+        if is_level_completed(level_path, difficulty_name):
+            return true
+    return false
+```
+
+Progress is saved under key `"LabyrinthLevel.tscn:Black Metal"`, but this function only checks Easy/Normal/Hard/Power Fantasy → returns `false` → level stays locked.
+
+Same bug in `get_progress_for_all_difficulties` (line 130).
+
+#### Bug 2 — `unlock_manager.gd:84`
+
+```gdscript
+func _get_best_rank_any_difficulty(level_path: String) -> String:
+    var difficulties: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]  # ← missing "Black Metal"
+```
+
+Because `is_level_condition_met()` calls this, all weapon/item unlock conditions ignore Black Metal completions.
+
+#### Bug 3 — `levels_menu.gd:96`
+
+```gdscript
+const DIFFICULTY_NAMES: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]  # ← missing "Black Metal"
+```
+
+Black Metal grades don't appear in the level card display.
+
+### How "Black Metal" was missed
+
+"Black Metal" difficulty was added in a previous PR (Issue #958 / PR #963). The `DifficultyManager` was updated correctly. However, the three files above had hardcoded lists that were not updated when the new difficulty was added.
+
+### Fix Applied
+
+1. **Added `get_all_difficulty_names()` to `DifficultyManager`** — single source of truth for all difficulty names.
+2. **Updated `progress_manager.gd`** — both `is_level_completed_any_difficulty` and `get_progress_for_all_difficulties` now use the dynamic list from DifficultyManager (with a static fallback including "Black Metal").
+3. **Updated `unlock_manager.gd`** — `_get_best_rank_any_difficulty` now uses the dynamic list.
+4. **Updated `levels_menu.gd`** — `DIFFICULTY_NAMES` now includes "Black Metal".
+
+### Tests Added
+
+- `test_progress_manager.gd`: Tests that `is_level_completed_any_difficulty` returns `true` when completed on Black Metal.
+- `test_ui_menus.gd`: Tests that level unlock detection works correctly with Black Metal completions.

--- a/docs/case-studies/issue-984/game_log_20260311_202842.txt
+++ b/docs/case-studies/issue-984/game_log_20260311_202842.txt
@@ -1,0 +1,2261 @@
+[20:28:42] [INFO] ============================================================
+[20:28:42] [INFO] GAME LOG STARTED
+[20:28:42] [INFO] ============================================================
+[20:28:42] [INFO] Timestamp: 2026-03-11T20:28:42
+[20:28:42] [INFO] Log file: I:/Загрузки/godot exe/UNLOCKES/game_log_20260311_202842.txt
+[20:28:42] [INFO] Executable: I:/Загрузки/godot exe/UNLOCKES/Godot-Top-Down-Template.exe
+[20:28:42] [INFO] OS: Windows
+[20:28:42] [INFO] Debug build: false
+[20:28:42] [INFO] Engine version: 4.3-stable (official)
+[20:28:42] [INFO] Project: Godot Top-Down Template
+[20:28:42] [INFO] ------------------------------------------------------------
+[20:28:42] [INFO] [GameManager] GameManager ready
+[20:28:42] [INFO] [ScoreManager] ScoreManager ready
+[20:28:42] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[20:28:42] [INFO] [DifficultyManager] Loaded difficulty: Black Metal (value: 4)
+[20:28:42] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[20:28:42] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[20:28:42] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[20:28:42] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[20:28:42] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:28:42] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[20:28:42] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[20:28:42] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[20:28:42] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[20:28:42] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[20:28:42] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[20:28:42] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[20:28:42] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:28:42] [INFO] [LastChance] Last chance shader loaded successfully
+[20:28:42] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[20:28:42] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[20:28:42] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[20:28:42] [INFO] [LastChance]   Sepia intensity: 0.70
+[20:28:42] [INFO] [LastChance]   Brightness: 0.60
+[20:28:42] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[20:28:42] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[20:28:42] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[20:28:42] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[20:28:42] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: false, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: true, FPS drop logging: true, All weapons unlocked: false, Ricochet points: false
+[20:28:42] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.29, music: 1.00
+[20:28:42] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[20:28:42] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[20:28:42] [INFO] [CinemaEffects] Created effects layer at layer 99
+[20:28:42] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[20:28:42] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[20:28:42] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[20:28:42] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[20:28:42] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[20:28:42] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[20:28:42] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[20:28:42] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[20:28:42] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[20:28:42] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[20:28:42] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[20:28:42] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[20:28:42] [INFO] [GrenadeTimerHelper] Autoload ready
+[20:28:42] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[20:28:42] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[20:28:42] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[20:28:42] [INFO] [PowerFantasy]   Kill effect duration: 300ms
+[20:28:42] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[20:28:42] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[20:28:42] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[20:28:42] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[20:28:42] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[20:28:42] [INFO] [BlackMetalEffectsManager] Black Metal filter ENABLED (will show after 3 frames)
+[20:28:42] [INFO] [ProgressManager] ProgressManager ready, loaded 2 entries
+[20:28:42] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[20:28:42] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[20:28:42] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[20:28:42] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[20:28:42] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[20:28:42] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[20:28:42] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[20:28:42] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[20:28:42] [INFO] [GameManager] Weapon selected: makarov_pm
+[20:28:42] [INFO] [PersistManager] Restored selected weapon: makarov_pm
+[20:28:42] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[20:28:42] [INFO] [PersistManager] Restored selected grenade type: 0
+[20:28:42] [INFO] [PersistManager] Restored unlocked active item type: 0
+[20:28:42] [INFO] [PersistManager] Restored selected active item type: 0
+[20:28:42] [INFO] [PersistManager] State loaded successfully
+[20:28:42] [INFO] [PersistManager] PersistManager ready
+[20:28:42] [INFO] [UnlockManager] UnlockManager ready
+[20:28:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:28:42] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[20:28:42] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[20:28:42] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[20:28:42] [ENEMY] [Enemy1] Death animation component initialized
+[20:28:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:28:42] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[20:28:42] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[20:28:42] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[20:28:42] [ENEMY] [Enemy2] Death animation component initialized
+[20:28:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:28:42] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[20:28:42] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[20:28:42] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[20:28:42] [ENEMY] [Enemy3] Death animation component initialized
+[20:28:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:28:42] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[20:28:42] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[20:28:42] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[20:28:42] [ENEMY] [Enemy4] Death animation component initialized
+[20:28:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:28:42] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[20:28:42] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[20:28:42] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[20:28:42] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[20:28:42] [ENEMY] [Enemy5] Death animation component initialized
+[20:28:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:28:42] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[20:28:42] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[20:28:42] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[20:28:42] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[20:28:42] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:28:42] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[20:28:42] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[20:28:42] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[20:28:42] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[20:28:42] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[20:28:42] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[20:28:42] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[20:28:42] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[20:28:42] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[20:28:42] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[20:28:42] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[20:28:42] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[20:28:42] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[20:28:42] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[20:28:42] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[20:28:42] [INFO] [Player] Ready! Ammo: 9/9, Grenades: 1/3, Health: 2/3
+[20:28:42] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[20:28:42] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[20:28:42] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[20:28:42] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[20:28:42] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[20:28:42] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[20:28:42] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[20:28:42] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[20:28:42] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[20:28:42] [INFO] [LabyrinthLevel] Setting up weapon: makarov_pm
+[20:28:42] [INFO] [ScoreManager] Level started with 5 enemies
+[20:28:42] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[20:28:42] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[20:28:42] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[20:28:42] [INFO] [ReplayManager] Replay data cleared
+[20:28:42] [INFO] [LabyrinthLevel] Previous replay data cleared
+[20:28:42] [INFO] [ReplayManager] Detected player weapon: Makarov PM
+[20:28:42] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[20:28:42] [INFO] [ReplayManager] Level: LabyrinthLevel
+[20:28:42] [INFO] [ReplayManager] Player: Player (valid: True)
+[20:28:42] [INFO] [ReplayManager] Enemies count: 5
+[20:28:42] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/makarov_pm_topdown.png
+[20:28:42] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[20:28:42] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[20:28:42] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[20:28:42] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[20:28:42] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[20:28:42] [INFO] [LabyrinthLevel] Replay recording started successfully
+[20:28:42] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[20:28:42] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:42] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:42] [INFO] [CinemaEffects] Found player node: Player
+[20:28:42] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[20:28:42] [INFO] [PersistManager] Already at last played level: res://scenes/levels/LabyrinthLevel.tscn
+[20:28:42] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[20:28:42] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[20:28:42] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[20:28:42] [ENEMY] [Enemy1] Registered as sound listener
+[20:28:42] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[20:28:42] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[20:28:42] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[20:28:42] [ENEMY] [Enemy2] Registered as sound listener
+[20:28:42] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[20:28:42] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[20:28:42] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[20:28:42] [ENEMY] [Enemy3] Registered as sound listener
+[20:28:42] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[20:28:42] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[20:28:42] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[20:28:42] [ENEMY] [Enemy4] Registered as sound listener
+[20:28:42] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[20:28:42] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[20:28:42] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[20:28:42] [ENEMY] [Enemy5] Registered as sound listener
+[20:28:42] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 1, behavior: GUARD
+[20:28:42] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[20:28:43] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(150,1000), corner_timer=0.00
+[20:28:43] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=45.0°, current=0.0°, player=(150,1000), corner_timer=0.00
+[20:28:43] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [Player] Detecting weapon pose (frame 3)...
+[20:28:43] [INFO] [Player] Detected weapon: Makarov PM (Pistol pose)
+[20:28:43] [INFO] [Player] Applied Pistol arm pose: Left=(16, 6), Right=(4, 6)
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [PenultimateHit] Shader warmup complete in 541 ms
+[20:28:43] [INFO] [LastChance] Shader warmup complete in 540 ms
+[20:28:43] [INFO] [CinemaEffects] Cinema shader warmup complete in 459 ms
+[20:28:43] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 451 ms
+[20:28:43] [INFO] [FlashbangPlayer] Shader warmup complete in 448 ms
+[20:28:43] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:28:43] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:28:43] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:28:43] [INFO] [LastChance] Found player: Player
+[20:28:43] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:28:43] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:28:43] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:28:43] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 814 ms
+[20:28:43] [INFO] [BlackMetalEffectsManager] Black Metal filter now visible (after 3 frames delay)
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:43] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:44] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[20:28:45] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[20:28:45] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:45] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:45] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:45] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:45] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:45] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:45] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:45] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.3473, 576.1903) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.3473, 576.1903) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.4011, 576.2939) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.4011, 576.2939) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.5085, 576.5011) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.5085, 576.5011) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.6699, 576.8116) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.6699, 576.8116) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (967.8852, 577.2252) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.8852, 577.2252) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (968.1545, 577.7416) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (968.1545, 577.7416) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (968.478, 578.3601) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (968.478, 578.3601) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (968.8557, 579.0802) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (968.8557, 579.0802) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (969.288, 579.9014) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (969.288, 579.9014) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (969.775, 580.8229) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (969.775, 580.8229) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (970.317, 581.8437) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (970.317, 581.8437) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (970.914, 582.963) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (970.914, 582.963) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (971.5666, 584.1797) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (971.5666, 584.1797) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (972.2748, 585.4928) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (972.2748, 585.4928) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (973.0391, 586.9009) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (973.0391, 586.9009) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (973.8596, 588.4029) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (973.8596, 588.4029) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (974.7105, 589.9498) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (974.7105, 589.9498) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target (975.5925, 591.5422) not in enemy FOV - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (975.5925, 591.5422) - skipping throw
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (976.5067, 593.1805)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (977.4537, 594.8651)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (978.4346, 596.5967)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (979.4503, 598.3757)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (980.5018, 600.2026)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (981.5902, 602.0783)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (982.7167, 604.0032)
+[20:28:46] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (983.8824, 605.9781)
+[20:28:46] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(171,1094), corner_timer=0.30
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (985.0886, 608.0037)
+[20:28:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(175.9894, 1105.259), source=PLAYER (MakarovPM), range=1469, listeners=5
+[20:28:46] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (986.3367, 610.0806)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (987.5627, 612.1027)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (988.7669, 614.0713)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (989.9039, 615.9146)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (990.4265, 616.7568)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (990.9913, 617.6637)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (991.5977, 618.6332)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (992.2471, 619.667)
+[20:28:46] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(192.7874, 1117.856), source=NEUTRAL (null), range=900, listeners=5
+[20:28:46] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0, below_threshold=2
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (992.9406, 620.7657)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (993.6791, 621.9304)
+[20:28:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(229.8727, 1117.924), source=PLAYER (MakarovPM), range=1469, listeners=5
+[20:28:46] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=3
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (994.4642, 623.1619)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (995.2626, 624.4075)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (996.0703, 625.6607)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (996.8156, 626.8109)
+[20:28:46] [INFO] [EnemyGrenade] Throw path blocked to (997.4968, 627.8575)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (998.1129, 628.7999)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (998.6625, 629.6371)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (999.1442, 630.3686)
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(282.1939, 1111.457), source=PLAYER (MakarovPM), range=1469, listeners=5
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=5
+[20:28:47] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-54.4°, player=(282,1105), corner_timer=-0.02
+[20:28:47] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (999.5568, 630.9932)
+[20:28:47] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[20:28:47] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(288,1103), corner_timer=0.30
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (999.8989, 631.51)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.17, 631.918)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.368, 632.2159)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.492, 632.4025)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.541, 632.4763)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.514, 632.436)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.41, 632.2798)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.228, 632.0062)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (999.9673, 631.6133)
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(333.8969, 1081.723), source=PLAYER (MakarovPM), range=1469, listeners=5
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=5
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.438, 632.3219)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.903, 633.0201)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1001.327, 633.6544)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1001.709, 634.2252)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1002.05, 634.7325)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1002.349, 635.1766)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1002.755, 635.7784)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1003.196, 636.4307)
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(353.1937, 1096.412), source=NEUTRAL (null), range=900, listeners=5
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0, below_threshold=2
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1003.654, 637.1065)
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(353.2957, 1098.595), source=NEUTRAL (null), range=900, listeners=5
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0, below_threshold=2
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(360.7954, 1082.065), source=PLAYER (MakarovPM), range=1469, listeners=5
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=5
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1004.129, 637.8043)
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(353.1858, 1101.286), source=NEUTRAL (null), range=900, listeners=5
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0, below_threshold=2
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1004.619, 638.5233)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1005.06, 639.1667)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1005.449, 639.7345)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1005.788, 640.2268)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.075, 640.6432)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.31, 640.9835)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.492, 641.2474)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.621, 641.4343)
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(395.8311, 1070.482), source=PLAYER (MakarovPM), range=1469, listeners=5
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=5
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.697, 641.5435)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.718, 641.5742)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.684, 641.5256)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.595, 641.3967)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.45, 641.1863)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1006.247, 640.8931)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1005.987, 640.5157)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1005.668, 640.0524)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1005.34, 639.5748)
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(437.6855, 1033.734), source=PLAYER (MakarovPM), range=1469, listeners=5
+[20:28:47] [ENEMY] [Enemy2] Heard gunshot at (437.6855, 1033.734), intensity=0.01, distance=470
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=4
+[20:28:47] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=170.5°, current=45.0°, player=(437,1027), corner_timer=0.00
+[20:28:47] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1005.008, 639.092)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1004.674, 638.6036)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1004.337, 638.1099)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1003.997, 637.6105)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1003.653, 637.1053)
+[20:28:47] [ENEMY] [Enemy3] Memory: medium confidence (0.62) - transitioning to PURSUING
+[20:28:47] [ENEMY] [Enemy3] State: IDLE -> PURSUING
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1003.307, 636.5945)
+[20:28:47] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P2:combat_state, state=PURSUING, target=-179.9°, current=-90.0°, player=(466,998), corner_timer=0.22
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1002.957, 636.0776)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1002.604, 635.5548)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1002.247, 635.0259)
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(481.4378, 989.9818), source=PLAYER (MakarovPM), range=1469, listeners=5
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=4
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1001.888, 634.4908)
+[20:28:47] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-179.4°, current=142.8°, player=(486,979), corner_timer=0.17
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1001.525, 633.9495)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1001.158, 633.4016)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.788, 632.8473)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.414, 632.2863)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (1000.037, 631.7185)
+[20:28:47] [ENEMY] [Enemy3] Hit: dmg=1, hp=1/1->0/1
+[20:28:47] [INFO] [ImpactEffects] spawn_blood_effect called at (1269.533, 966.0171), dir=(0.991996, -0.12627), lethal=true
+[20:28:47] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[20:28:47] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[20:28:47] [INFO] [ImpactEffects] Blood effect spawned at (1269.533, 966.0171) (scale=0.75)
+[20:28:47] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false)
+[20:28:47] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[20:28:47] [ENEMY] [Enemy3] [AllyDeath] Notified 2 enemies
+[20:28:47] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 4)
+[20:28:47] [INFO] [DeathAnim] Started - Angle: -7.3 deg, Index: 11
+[20:28:47] [ENEMY] [Enemy3] Death animation started with hit direction: (0.991996, -0.12627)
+[20:28:47] [INFO] [FlashbangStatus] Status: STUNNED applied
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (999.6564, 631.1438)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (999.2719, 630.5621)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (999.0205, 630.181)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (998.8263, 629.8861)
+[20:28:47] [INFO] [EnemyGrenade] Throw path blocked to (998.6898, 629.6787)
+[20:28:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(531.84, 942.3666), source=PLAYER (MakarovPM), range=1469, listeners=4
+[20:28:47] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=3
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (998.6117, 629.5599)
+[20:28:48] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(175.9894, 1105.259), shooter_id=59458455195, bullet_pos=(1444.616, 907.1602)
+[20:28:48] [INFO] [Bullet] Using shooter_position, distance=1284.00048828125
+[20:28:48] [INFO] [Bullet] Distance to wall: 1284.00048828125 (87.4299543157745% of viewport)
+[20:28:48] [INFO] [Bullet] Distance-based penetration chance: 44.6650532982631%
+[20:28:48] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (998.5928, 629.5313)
+[20:28:48] [INFO] [FlashbangStatus] Status: STUNNED removed
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (998.6339, 629.5938)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (998.7358, 629.7488)
+[20:28:48] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=5
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (998.8995, 629.9974)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (999.1257, 630.3407)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (999.4156, 630.7799)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (999.7704, 631.316)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1000.191, 631.9501)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1000.678, 632.683)
+[20:28:48] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P4:velocity, state=RETREATING, target=12.6°, current=28.8°, player=(578,916), corner_timer=0.00
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1001.234, 633.5159)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1001.86, 634.4493)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1002.429, 635.2951)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1325.088, 976.9193) (added to group)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1315.82, 956.5735) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1002.94, 636.0524)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1003.392, 636.7203)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1346.117, 1009.592) (added to group)
+[20:28:48] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(282.1939, 1111.457), shooter_id=59458455195, bullet_pos=(1445.492, 980.3162)
+[20:28:48] [INFO] [Bullet] Using shooter_position, distance=1170.66662597656
+[20:28:48] [INFO] [Bullet] Distance to wall: 1170.66662597656 (79.7128432288521% of viewport)
+[20:28:48] [INFO] [Bullet] Distance-based penetration chance: 53.6683495663393%
+[20:28:48] [INFO] [Bullet] Penetration failed (distance roll)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1003.784, 637.2981)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1315.43, 987.8487) (added to group)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1317.925, 963.5899) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.115, 637.7848)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1349.099, 958.7311) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.384, 638.1793)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.59, 638.4805)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.732, 638.6874)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1353.101, 962.0959) (added to group)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1356.207, 1022.125) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.808, 638.7985)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.817, 638.8127)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.76, 638.7284)
+[20:28:48] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(333.8969, 1081.723), shooter_id=59458455195, bullet_pos=(1441.434, 998.4071)
+[20:28:48] [INFO] [Bullet] Using shooter_position, distance=1110.66674804688
+[20:28:48] [INFO] [Bullet] Distance to wall: 1110.66674804688 (75.6273412105728% of viewport)
+[20:28:48] [INFO] [Bullet] Distance-based penetration chance: 58.4347685876651%
+[20:28:48] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.634, 638.5441)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.438, 638.2582)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1341.686, 997.4438) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1004.173, 637.869)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1003.836, 637.3747)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1356.395, 956.3525) (added to group)
+[20:28:48] [ENEMY] [Enemy2] Hit: dmg=1, hp=1/1->0/1
+[20:28:48] [INFO] [ImpactEffects] spawn_blood_effect called at (943.116, 944.0659), dir=(0.99969, -0.024905), lethal=true
+[20:28:48] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[20:28:48] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[20:28:48] [INFO] [ImpactEffects] Blood effect spawned at (943.116, 944.0659) (scale=0.75)
+[20:28:48] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false)
+[20:28:48] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[20:28:48] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 3)
+[20:28:48] [INFO] [DeathAnim] Started - Angle: -1.4 deg, Index: 11
+[20:28:48] [ENEMY] [Enemy2] Death animation started with hit direction: (0.99969, -0.024905)
+[20:28:48] [INFO] [FlashbangStatus] Status: STUNNED applied
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1003.497, 636.8748)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1003.154, 636.3692)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1002.808, 635.8579)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1360.809, 958.9608) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1002.459, 635.3407)
+[20:28:48] [ENEMY] [Enemy3] Ragdoll activated
+[20:28:48] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1002.107, 634.8175)
+[20:28:48] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(360.7954, 1082.065), shooter_id=59458455195, bullet_pos=(1435.378, 967.5435)
+[20:28:48] [INFO] [Bullet] Using shooter_position, distance=1080.66809082031
+[20:28:48] [INFO] [Bullet] Distance to wall: 1080.66809082031 (73.5846774773496% of viewport)
+[20:28:48] [INFO] [Bullet] Distance-based penetration chance: 60.8178762764255%
+[20:28:48] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1001.752, 634.2884)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1433.523, 1009.703) (added to group)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1359.499, 1044.156) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1001.393, 633.7531)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1344.337, 1002.825) (added to group)
+[20:28:48] [INFO] [FlashbangStatus] Status: STUNNED removed
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1001.031, 633.2114)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1000.665, 632.6635)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (1000.297, 632.109)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1426.16, 993.9996) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (999.9241, 631.5479)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (999.5481, 630.9802)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (999.1686, 630.4056)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (998.7854, 629.8241)
+[20:28:48] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(395.8311, 1070.482), shooter_id=59458455195, bullet_pos=(1443.426, 990.2114)
+[20:28:48] [INFO] [Bullet] Using shooter_position, distance=1050.66564941406
+[20:28:48] [INFO] [Bullet] Distance to wall: 1050.66564941406 (71.541756072373% of viewport)
+[20:28:48] [INFO] [Bullet] Distance-based penetration chance: 63.2012845822315%
+[20:28:48] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (998.3986, 629.2355)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1401.145, 1097.442) (added to group)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1397.347, 1023.163) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (997.9465, 628.5457)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (997.4286, 627.7529)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (996.8445, 626.8555)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (996.2756, 625.978)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1012.202, 979.6221) (added to group)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1006.795, 978.3262) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (995.7222, 625.1214)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1436.125, 1104.141) (added to group)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1026.659, 974.3348) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (995.1849, 624.2864)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1000.218, 964.1708) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (994.6639, 623.4741)
+[20:28:48] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[20:28:48] [ENEMY] [Enemy1] Player reloading: false -> true
+[20:28:48] [ENEMY] [Enemy2] Player reloading: false -> true
+[20:28:48] [ENEMY] [Enemy3] Player reloading: false -> true
+[20:28:48] [ENEMY] [Enemy4] Player reloading: false -> true
+[20:28:48] [ENEMY] [Enemy5] Player reloading: false -> true
+[20:28:48] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(734.1559, 788.5466), source=PLAYER (Player), range=900, listeners=3
+[20:28:48] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=1
+[20:28:48] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(437.6855, 1033.734), shooter_id=59458455195, bullet_pos=(1444.323, 996.3368)
+[20:28:48] [INFO] [Bullet] Using shooter_position, distance=1007.33184814453
+[20:28:48] [INFO] [Bullet] Distance to wall: 1007.33184814453 (68.5910778600965% of viewport)
+[20:28:48] [INFO] [Bullet] Distance-based penetration chance: 66.6437424965541%
+[20:28:48] [INFO] [Bullet] Penetration failed (distance roll)
+[20:28:48] [ENEMY] [Enemy1] Player vulnerable (reloading) but cannot attack: close=false (dist=592), can_see=false
+[20:28:48] [ENEMY] [Enemy4] Player vulnerable (reloading) but cannot attack: close=false (dist=926), can_see=false
+[20:28:48] [ENEMY] [Enemy5] Player vulnerable (reloading) but cannot attack: close=false (dist=908), can_see=false
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (994.1598, 622.6852)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (993.6729, 621.9205)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1004.996, 952.1151) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (993.2035, 621.1811)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (992.752, 620.4676)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (992.3188, 619.7808)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1013.346, 941.3657) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (991.9042, 619.1217)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1007.509, 955.898) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (991.5085, 618.4908)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1065.906, 952.2323) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (991.1321, 617.889)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1065.201, 990.2745) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (990.7751, 617.317)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1052.197, 980.4499) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (990.4381, 616.7755)
+[20:28:48] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[20:28:48] [ENEMY] [Enemy1] Player reloading: true -> false
+[20:28:48] [ENEMY] [Enemy2] Player reloading: true -> false
+[20:28:48] [ENEMY] [Enemy3] Player reloading: true -> false
+[20:28:48] [ENEMY] [Enemy4] Player reloading: true -> false
+[20:28:48] [ENEMY] [Enemy5] Player reloading: true -> false
+[20:28:48] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[20:28:48] [INFO] [BloodDecal] Blood puddle created at (1062.666, 978.4661) (added to group)
+[20:28:48] [INFO] [EnemyGrenade] Throw path blocked to (990.1212, 616.265)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (989.8246, 615.7864)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (989.5485, 615.34)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (989.2933, 614.9264)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (989.0591, 614.5463)
+[20:28:49] [ENEMY] [Enemy2] Ragdoll activated
+[20:28:49] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[20:28:49] [INFO] [BloodDecal] Blood puddle created at (1089.936, 999.9626) (added to group)
+[20:28:49] [INFO] [ReplayManager] Recording frame 360 (5,8s): player_valid=True, enemies=5
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (988.8461, 614.2)
+[20:28:49] [INFO] [BloodDecal] Blood puddle created at (1036.393, 1001.977) (added to group)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (988.6544, 613.8879)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (988.4843, 613.6107)
+[20:28:49] [INFO] [BloodDecal] Blood puddle created at (1082.608, 1017.953) (added to group)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (988.3358, 613.3684)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (988.2092, 613.1615)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (988.1044, 612.9902)
+[20:28:49] [INFO] [BloodDecal] Blood puddle created at (1131.522, 994.063) (added to group)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (988.0216, 612.8549)
+[20:28:49] [INFO] [BloodDecal] Blood puddle created at (1055.61, 1038.445) (added to group)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (987.9609, 612.7554)
+[20:28:49] [INFO] [BloodDecal] Blood puddle created at (1062.706, 1023.623) (added to group)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (987.9222, 612.6921)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (987.9058, 612.665)
+[20:28:49] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (987.85, 612.5737)
+[20:28:49] [INFO] [BloodDecal] Blood puddle created at (1060.667, 1061.304) (added to group)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (987.7551, 612.4182)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (987.6213, 612.1986)
+[20:28:49] [INFO] [BloodDecal] Blood puddle created at (1091.327, 995.9678) (added to group)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (987.4486, 611.9152)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (987.2375, 611.5681)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (986.9885, 611.1577)
+[20:28:49] [INFO] [BloodDecal] Blood puddle created at (1139.266, 1022.065) (added to group)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (986.7017, 610.6844)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (986.3777, 610.1487)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (986.0173, 609.551)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (985.6209, 608.8918)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (985.1894, 608.1721)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (984.7234, 607.3923)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (984.1872, 606.4917)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (983.582, 605.4708)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (982.9088, 604.3298)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (982.1688, 603.069)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (981.3632, 601.6884)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (980.4934, 600.1882)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (979.5608, 598.5683)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (978.5667, 596.8287)
+[20:28:49] [INFO] [EnemyGrenade] Throw path blocked to (977.5126, 594.9695)
+[20:28:49] [INFO] [EnemyGrenade] Target (976.4003, 592.9903) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (976.4003, 592.9903) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (975.2311, 590.891) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (975.2311, 590.891) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (974.0068, 588.6714) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (974.0068, 588.6714) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (972.7293, 586.3314) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (972.7293, 586.3314) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (971.4004, 583.8704) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (971.4004, 583.8704) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (970.0219, 581.2885) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (970.0219, 581.2885) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (968.5958, 578.585) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (968.5958, 578.585) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (967.1243, 575.7599) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (967.1243, 575.7599) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (965.6095, 572.8127) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (965.6095, 572.8127) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (964.1611, 569.9568) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (964.1611, 569.9568) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (963.6438, 568.9276) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (963.6438, 568.9276) - skipping throw
+[20:28:49] [ENEMY] [Enemy3] Death animation completed
+[20:28:49] [INFO] [EnemyGrenade] Target (963.1331, 567.9064) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (963.1331, 567.9064) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (962.6281, 566.8921) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (962.6281, 566.8921) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (962.1288, 565.8844) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (962.1288, 565.8844) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (961.635, 564.8832) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (961.635, 564.8832) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (961.1467, 563.8884) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (961.1467, 563.8884) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (960.6638, 562.9002) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (960.6638, 562.9002) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (960.1863, 561.9183) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (960.1863, 561.9183) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (959.7146, 560.9438) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (959.7146, 560.9438) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (959.2472, 559.9738) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (959.2472, 559.9738) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (958.7782, 558.9962) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (958.7782, 558.9962) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (958.2588, 557.9078) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (958.2588, 557.9078) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (957.6931, 556.7163) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (957.6931, 556.7163) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (957.1251, 555.5129) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (957.1251, 555.5129) - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target (956.5551, 554.2982) not in enemy FOV - skipping throw
+[20:28:49] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (956.5551, 554.2982) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (955.9836, 553.0734) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (955.9836, 553.0734) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (955.4112, 551.8393) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (955.4112, 551.8393) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (954.8383, 550.5967) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (954.8383, 550.5967) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (954.2654, 549.3466) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (954.2654, 549.3466) - skipping throw
+[20:28:50] [INFO] [ReplayManager] Recording frame 420 (6,6s): player_valid=True, enemies=5
+[20:28:50] [INFO] [EnemyGrenade] Target (953.6929, 548.0899) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (953.6929, 548.0899) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (953.1223, 546.8295) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (953.1223, 546.8295) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (952.5603, 545.5804) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (952.5603, 545.5804) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (952.0068, 544.3428) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (952.0068, 544.3428) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (951.4615, 543.1163) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (951.4615, 543.1163) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (950.9244, 541.9009) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (950.9244, 541.9009) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (950.3954, 540.6964) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (950.3954, 540.6964) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (949.8741, 539.5027) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (949.8741, 539.5027) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (949.3606, 538.3197) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (949.3606, 538.3197) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (948.8547, 537.1473) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (948.8547, 537.1473) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (948.3561, 535.9852) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (948.3561, 535.9852) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (947.831, 534.7539) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (947.831, 534.7539) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (947.28, 533.4535) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (947.28, 533.4535) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (946.7036, 532.0843) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (946.7036, 532.0843) - skipping throw
+[20:28:50] [ENEMY] [Enemy2] Death animation completed
+[20:28:50] [INFO] [EnemyGrenade] Target (946.1026, 530.6462) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (946.1026, 530.6462) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (945.4775, 529.1395) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (945.4775, 529.1395) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (944.8292, 527.5641) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (944.8292, 527.5641) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (944.1581, 525.9198) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (944.1581, 525.9198) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (943.4648, 524.2066) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (943.4648, 524.2066) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (942.7501, 522.4243) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (942.7501, 522.4243) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (942.0146, 520.5726) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (942.0146, 520.5726) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target (941.2589, 518.6512) not in enemy FOV - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (941.2589, 518.6512) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (940.4837, 516.6599) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (939.6897, 514.5981) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (938.8776, 512.4656) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (938.048, 510.2617) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (937.4232, 508.5842) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (936.8516, 507.0359) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (936.2766, 505.465) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (935.6985, 503.8721) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (935.1179, 502.2577) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (934.5351, 500.6227) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (933.9506, 498.9677) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (933.3649, 497.2934) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (932.7783, 495.6004) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (932.1912, 493.8895) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (931.5919, 492.1254) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (930.9811, 490.3089) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (930.3596, 488.4406) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (929.7283, 486.5215) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (929.0881, 484.5524) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (928.4397, 482.5343) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (927.7839, 480.4683) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (927.1219, 478.3553) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (926.4542, 476.1967) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (925.782, 473.9934) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (925.1061, 471.7469) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (924.4274, 469.4584) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (923.7468, 467.1294) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (923.0652, 464.7611) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (922.3835, 462.3551) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.7358, 460.0327) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1211, 457.7947) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.5386, 455.642) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.9873, 453.5752) - skipping throw
+[20:28:50] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.4666, 451.5948) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.9755, 449.7014) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.5131, 447.8951) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.0786, 446.1763) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.6713, 444.5451) - skipping throw
+[20:28:51] [INFO] [ReplayManager] Recording frame 480 (7,4s): player_valid=True, enemies=5
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.5064, 443.8793) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.3683, 443.3188) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.2253, 442.7362) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.0777, 442.1322) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.9257, 441.5074) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.7695, 440.8622) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.6174, 440.2306) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.4694, 439.6139) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.3254, 439.0106) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.1851, 438.4199) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.0482, 437.8412) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.9145, 437.274) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.7841, 436.7177) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.6566, 436.1717) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.532, 435.6361) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.4099, 435.109) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.2905, 434.5913) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.1736, 434.0822) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.059, 433.5813) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.9466, 433.0883) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.8363, 432.6028) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.728, 432.1238) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.6219, 431.6528) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.5175, 431.1878) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.415, 430.7296) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.2555, 430.0132) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.0657, 429.1548) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (913.8464, 428.1558) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (913.5986, 427.0175) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (913.3235, 425.741) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (913.0224, 424.3275) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (912.6964, 422.7778) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (912.3466, 421.0928) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (911.9746, 419.2735) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (911.5818, 417.3203) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (911.1697, 415.2341) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (910.7399, 413.0154) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (910.2939, 410.6647) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (909.8334, 408.1824) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (909.3676, 405.6096) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (908.9157, 403.0502) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (908.4775, 400.5045) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (908.0528, 397.9724) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (907.636, 395.4192) - skipping throw
+[20:28:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(198.4765, 509.8517), source=PLAYER (MakarovPM), range=1469, listeners=3
+[20:28:51] [ENEMY] [Enemy1] Heard gunshot at (198.4765, 509.8517), intensity=0.03, distance=291
+[20:28:51] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=2
+[20:28:51] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=134.7°, current=-56.3°, player=(198,503), corner_timer=0.00
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (907.2267, 392.8434) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (906.8253, 390.2432) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (906.4318, 387.6171) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (906.0461, 384.9634) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (905.6685, 382.2804) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (905.2991, 379.5664) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.938, 376.8197) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.5856, 374.0384) - skipping throw
+[20:28:51] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=145.8°, current=105.3°, player=(175,458), corner_timer=0.00
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.242, 371.2209) - skipping throw
+[20:28:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(174.1452, 458.2535), source=PLAYER (MakarovPM), range=1469, listeners=3
+[20:28:51] [ENEMY] [Enemy1] Heard gunshot at (174.1452, 458.2535), intensity=0.04, distance=239
+[20:28:51] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=1
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.9174, 368.4507) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.6108, 365.7261) - skipping throw
+[20:28:51] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.3214, 363.0453) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.0486, 360.4066) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.7913, 357.8083) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.5491, 355.2488) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.3212, 352.7266) - skipping throw
+[20:28:52] [INFO] [ReplayManager] Recording frame 540 (8,3s): player_valid=True, enemies=5
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.1071, 350.24) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.9061, 347.7875) - skipping throw
+[20:28:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(175.7864, 406.4151), source=PLAYER (MakarovPM), range=1469, listeners=3
+[20:28:52] [ENEMY] [Enemy1] Heard gunshot at (175.7864, 406.4151), intensity=0.06, distance=213
+[20:28:52] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=1
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.7177, 345.3677) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.5413, 342.9791) - skipping throw
+[20:28:52] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(198.4765, 509.8517), shooter_id=59458455195, bullet_pos=(528.8411, 349.2498)
+[20:28:52] [INFO] [Bullet] Using shooter_position, distance=367.333251953125
+[20:28:52] [INFO] [Bullet] Distance to wall: 367.333251953125 (25.0123965917775% of viewport)
+[20:28:52] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:28:52] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.3766, 340.6203) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.223, 338.2897) - skipping throw
+[20:28:52] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.0801, 335.9861) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.9476, 333.708) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.8251, 331.4541) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.7121, 329.2231) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.6084, 327.0135) - skipping throw
+[20:28:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(203.9432, 359.6682), source=PLAYER (MakarovPM), range=1469, listeners=3
+[20:28:52] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=1, self=0, below_threshold=1
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.5138, 324.824) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.4279, 322.6534) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.3495, 320.476) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.2786, 318.2812) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.2152, 316.0689) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.1595, 313.8391) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.112, 311.5915) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0725, 309.3261) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0413, 307.0429) - skipping throw
+[20:28:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(247.5994, 315.8976), source=PLAYER (MakarovPM), range=1469, listeners=3
+[20:28:52] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=2
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0188, 304.7416) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0049, 302.4221) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900, 300.0844) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0043, 297.7284) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.018, 295.3538) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0413, 292.9607) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0744, 290.5489) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.1177, 288.1183) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.1712, 285.6688) - skipping throw
+[20:28:52] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(174.1452, 458.2535), shooter_id=59458455195, bullet_pos=(747.9561, 188.6288)
+[20:28:52] [INFO] [Bullet] Using shooter_position, distance=634.000366210938
+[20:28:52] [INFO] [Bullet] Distance to wall: 634.000366210938 (43.1702507591765% of viewport)
+[20:28:52] [INFO] [Bullet] Distance-based penetration chance: 96.3013741142941%
+[20:28:52] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.2352, 283.2004) - skipping throw
+[20:28:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(296.213, 267.284), source=PLAYER (MakarovPM), range=1469, listeners=3
+[20:28:52] [ENEMY] [Enemy1] Heard gunshot at (296.213, 267.284), intensity=0.32, distance=89
+[20:28:52] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=2
+[20:28:52] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.3101, 280.7129) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.396, 278.2062) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.493, 275.6802) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.6017, 273.135) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.6212, 272.7065) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.6263, 272.5923) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.6315, 272.4789) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.6368, 272.3647) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.6501, 272.0785) - skipping throw
+[20:28:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(339.9648, 251.0651), source=PLAYER (MakarovPM), range=1469, listeners=3
+[20:28:52] [ENEMY] [Enemy1] Heard gunshot at (339.9648, 251.0651), intensity=0.60, distance=64
+[20:28:52] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=2
+[20:28:52] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.6716, 271.6181) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.7022, 270.9813) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.7422, 270.166) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.7926, 269.17) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.8544, 267.9912) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.9288, 266.6274) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.0172, 265.0765) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.1212, 263.3362) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.2427, 261.4045) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.3834, 259.2792) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.5458, 256.9584) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.7322, 254.4399) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.9454, 251.7219) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.1819, 248.8775) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.434, 246.0112) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.7019, 243.1231) - skipping throw
+[20:28:52] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.9861, 240.2131) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.287, 237.2812) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.6049, 234.3272) - skipping throw
+[20:28:53] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(432.3306, 183.0356), source=PLAYER (MakarovPM), range=1469, listeners=3
+[20:28:53] [ENEMY] [Enemy1] Heard gunshot at (432.3306, 183.0356), intensity=0.33, distance=88
+[20:28:53] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=2
+[20:28:53] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.9401, 231.3513) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.2931, 228.3533) - skipping throw
+[20:28:53] [INFO] [ReplayManager] Recording frame 600 (9,3s): player_valid=True, enemies=5
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.6641, 225.3333) - skipping throw
+[20:28:53] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(339.9648, 251.0651), shooter_id=59458455195, bullet_pos=(736.7906, 195.7206)
+[20:28:53] [INFO] [Bullet] Using shooter_position, distance=400.666656494141
+[20:28:53] [INFO] [Bullet] Distance to wall: 400.666656494141 (27.2821294017014% of viewport)
+[20:28:53] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:28:53] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (905.0535, 222.2912) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (905.4617, 219.2271) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (905.8892, 216.1409) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (906.3362, 213.0327) - skipping throw
+[20:28:53] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(432.3306, 183.0356), shooter_id=59458455195, bullet_pos=(400.895, 35.6848)
+[20:28:53] [INFO] [Bullet] Using shooter_position, distance=150.66667175293
+[20:28:53] [INFO] [Bullet] Distance to wall: 150.66667175293 (10.2591707312366% of viewport)
+[20:28:53] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:28:53] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (906.8032, 209.9026) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (907.2905, 206.7504) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (907.7986, 203.5764) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (908.3279, 200.3804) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (908.8786, 197.1626) - skipping throw
+[20:28:53] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(490.6669, 124.6993), source=PLAYER (MakarovPM), range=1469, listeners=3
+[20:28:53] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=2
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (909.4514, 193.9231) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (910.0465, 190.662) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (910.6643, 187.3792) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (911.3054, 184.075) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (911.97, 180.7493) - skipping throw
+[20:28:53] [ENEMY] [Enemy1] Hit: dmg=1, hp=1/1->0/1
+[20:28:53] [INFO] [ImpactEffects] spawn_blood_effect called at (369.0272, 165.8254), dir=(-0.890705, 0.454583), lethal=true
+[20:28:53] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[20:28:53] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[20:28:53] [INFO] [ImpactEffects] Wall found for blood splatter at (330, 185.7434) (dist=43 px)
+[20:28:53] [INFO] [BloodDecal] Blood puddle created at (331, 185.7434) (added to group)
+[20:28:53] [INFO] [ImpactEffects] Blood effect spawned at (369.0272, 165.8254) (scale=0.75)
+[20:28:53] [ENEMY] [Enemy1] Enemy died (ricochet: false, penetration: false)
+[20:28:53] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[20:28:53] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 2)
+[20:28:53] [INFO] [DeathAnim] Started - Angle: 153.0 deg, Index: 22
+[20:28:53] [ENEMY] [Enemy1] Death animation started with hit direction: (-0.890705, 0.454583)
+[20:28:53] [INFO] [FlashbangStatus] Status: STUNNED applied
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (912.6586, 177.4025) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (913.3718, 174.0345) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (913.9601, 171.325) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.5646, 168.6021) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.1854, 165.866) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.8229, 163.1167) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.477, 160.3543) - skipping throw
+[20:28:53] [INFO] [FlashbangStatus] Status: STUNNED removed
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.1482, 157.579) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.5847, 155.8044) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.7228, 155.2475) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.863, 154.6848) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.004, 154.121) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.1466, 153.5533) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.2923, 152.9757) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.4447, 152.3741) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.6068, 151.7368) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.7798, 151.0599) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.9484, 150.404) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.1121, 149.7695) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.2708, 149.1571) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.4243, 148.5674) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.5723, 148.0009) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.7147, 147.4583) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.8512, 146.94) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.9816, 146.4466) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.1057, 145.9786) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.2233, 145.5365) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.3342, 145.1208) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.4383, 144.7318) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.5353, 144.37) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.6252, 144.0357) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.7078, 143.7294) - skipping throw
+[20:28:53] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[20:28:53] [ENEMY] [Enemy1] Player reloading: false -> true
+[20:28:53] [ENEMY] [Enemy4] Player reloading: false -> true
+[20:28:53] [ENEMY] [Enemy5] Player reloading: false -> true
+[20:28:53] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(627.6898, 64.2353), source=PLAYER (Player), range=900, listeners=2
+[20:28:53] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0, below_threshold=0
+[20:28:53] [ENEMY] [Enemy4] Player vulnerable (reloading) but cannot attack: close=false (dist=1178), can_see=false
+[20:28:53] [ENEMY] [Enemy5] Player vulnerable (reloading) but cannot attack: close=false (dist=904), can_see=false
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.7828, 143.4514) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.8503, 143.2019) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.9101, 142.9812) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.9621, 142.7896) - skipping throw
+[20:28:53] [ENEMY] [Enemy1] Ragdoll activated
+[20:28:53] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.0062, 142.6273) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.0423, 142.4944) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.0704, 142.3912) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.0905, 142.3177) - skipping throw
+[20:28:53] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1024, 142.2739) - skipping throw
+[20:28:53] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[20:28:53] [ENEMY] [Enemy1] Player reloading: true -> false
+[20:28:53] [ENEMY] [Enemy4] Player reloading: true -> false
+[20:28:53] [ENEMY] [Enemy5] Player reloading: true -> false
+[20:28:53] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [BloodDecal] Blood puddle created at (275.0387, 321.7303) (added to group)
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [ReplayManager] Recording frame 660 (10,2s): player_valid=True, enemies=5
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [BloodDecal] Blood puddle created at (272.2434, 398.7058) (added to group)
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.1061, 142.26) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.0699, 142.3929) - skipping throw
+[20:28:54] [INFO] [BloodDecal] Blood puddle created at (248.6292, 432.299) (added to group)
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.9977, 142.6588) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.8894, 143.0577) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.7454, 143.59) - skipping throw
+[20:28:54] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.5659, 144.256) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.3516, 145.0559) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.1026, 145.9903) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.8196, 147.0597) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.5034, 148.2645) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.1545, 149.6056) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.7738, 151.0836) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.3622, 152.6992) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.9208, 154.4532) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.4507, 156.3467) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.9529, 158.3805) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.4288, 160.5556) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.88, 162.873) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.3077, 165.3338) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.7139, 167.9391) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.0999, 170.69) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (913.4679, 173.5877) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (912.8198, 176.6333) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (912.1576, 179.828) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (911.4837, 183.1731) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (910.8004, 186.6696) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (910.1159, 190.2879) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (909.4521, 193.9187) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (908.8094, 197.5615) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (908.1877, 201.216) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (907.5875, 204.8819) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (907.0089, 208.5587) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (906.452, 212.2462) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (905.9171, 215.9438) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (905.4043, 219.6512) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.9138, 223.3679) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.4459, 227.0937) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.0089, 230.757) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.6014, 234.3594) - skipping throw
+[20:28:54] [ENEMY] [Enemy1] Death animation completed
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.222, 237.9026) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.8697, 241.388) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.543, 244.8172) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.2409, 248.1917) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.9624, 251.5131) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.7062, 254.7827) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.4717, 258.002) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.2576, 261.1725) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.0633, 264.2956) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.8878, 267.3726) - skipping throw
+[20:28:54] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.7303, 270.4049) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.5902, 273.394) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.4667, 276.341) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.359, 279.2473) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.2667, 282.1143) - skipping throw
+[20:28:55] [INFO] [ReplayManager] Recording frame 720 (11,0s): player_valid=True, enemies=5
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.189, 284.9433) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.1229, 287.8595) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0696, 290.8618) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0305, 293.9489) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.007, 297.1193) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0001, 300.3712) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0114, 303.7029) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0422, 307.1122) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.0936, 310.5969) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.167, 314.1547) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.2635, 317.7829) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.3846, 321.4788) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.5311, 325.2395) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.7043, 329.062) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (900.905, 332.943) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.1345, 336.8792) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.3934, 340.8672) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (901.6826, 344.9032) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.0029, 348.9837) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.3505, 353.0574) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (902.7255, 357.1237) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.1275, 361.182) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (903.5565, 365.2319) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.0123, 369.2728) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.4896, 373.2621) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (904.9876, 377.2026) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (905.5059, 381.0969) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (906.0439, 384.9476) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (906.6012, 388.7573) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (907.1775, 392.5285) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (907.7726, 396.2637) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (908.3862, 399.9654) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (909.0181, 403.636) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (909.6683, 407.2778) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (910.3368, 410.8934) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (911.0237, 414.4851) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (911.7288, 418.0553) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (912.4526, 421.6063) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (913.1817, 425.077) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (913.8432, 428.1414) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (914.5234, 431.2144) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.2233, 434.2993) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (915.9436, 437.3977) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (916.6849, 440.5117) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (917.4482, 443.6436) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (918.2345, 446.7954) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.0445, 449.9692) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (919.8517, 453.062) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (920.6553, 456.0759) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (921.4544, 459.0126) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (922.2485, 461.8741) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (923.037, 464.6622) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (923.8191, 467.3785) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (924.5945, 470.0248) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (925.3624, 472.6026) - skipping throw
+[20:28:55] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (926.1226, 475.1134) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (926.8744, 477.5587) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (927.6176, 479.9396) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (928.3514, 482.2578) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (929.0757, 484.5143) - skipping throw
+[20:28:56] [INFO] [ReplayManager] Recording frame 780 (11,8s): player_valid=True, enemies=5
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (929.7902, 486.7103) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (930.4942, 488.8469) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (931.1876, 490.9252) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (931.8699, 492.9461) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (932.5409, 494.9106) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (933.2001, 496.8195) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (933.8474, 498.6736) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (934.4822, 500.4735) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (935.1044, 502.22) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (935.7136, 503.9138) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (936.3094, 505.5551) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (936.8916, 507.1447) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (937.4598, 508.6828) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (937.9779, 510.0743) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (938.4439, 511.3167) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (938.8555, 512.4071) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (939.2802, 513.5258) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (939.6124, 514.3963) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (939.8486, 515.0125) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (939.9851, 515.3679) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (940.0188, 515.4554) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (939.9466, 515.2678) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (939.766, 514.7972) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (939.4745, 514.0353) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (939.0701, 512.9733) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (938.5513, 511.6019) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (937.9169, 509.9111) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (937.1666, 507.8907) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (936.3001, 505.5294) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (935.3508, 502.907) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (934.395, 500.2273) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (933.5405, 497.7967) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (932.7864, 495.6241) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (932.674, 493.534) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (938.0456, 489.9045) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (943.5447, 486.5829) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (949.1714, 483.5693) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (954.9257, 480.8637) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (960.8076, 478.466) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (966.817, 476.3763) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (972.9539, 474.5945) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (979.2184, 473.1207) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (985.6105, 471.9549) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (992.1302, 471.097) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (998.7774, 470.5471) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1005.552, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1012.427, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1019.302, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1021.988, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.001, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.002, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:56] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [ReplayManager] Recording frame 840 (12,7s): player_valid=True, enemies=5
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.003, 470.3051) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1021.947, 470.5428) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1021.964, 471.011) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.019, 471.7034) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.138, 472.6111) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.359, 473.7222) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1022.733, 475.0294) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1023.345, 476.5895) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1024.268, 478.3499) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1025.556, 480.3056) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1027.103, 482.4717) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1028.908, 484.8481) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1028.908, 484.8481) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1030.972, 487.4348) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1030.972, 487.4348) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1033.33, 489.8637) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1033.33, 489.8637) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1035.981, 492.1347) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1035.981, 492.1347) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1038.926, 494.2478) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1038.926, 494.2478) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1042.164, 496.2031) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1042.164, 496.2031) - skipping throw
+[20:28:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1045.696, 504.0005), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:28:57] [ENEMY] [Enemy5] Heard gunshot at (1045.696, 504.0005), intensity=0.01, distance=498
+[20:28:57] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:57] [ENEMY] [Enemy5] ROT_CHANGE: none -> P2:combat_state, state=COMBAT, target=156.5°, current=0.0°, player=(1045,498), corner_timer=0.00
+[20:28:57] [INFO] [EnemyGrenade] Target (1045.696, 498.0005) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1045.696, 498.0005) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1049.522, 499.6401) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1049.522, 499.6401) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1053.641, 501.1219) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1053.641, 501.1219) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1058.054, 502.4457) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1058.054, 502.4457) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1062.76, 503.6118) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1062.76, 503.6118) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1067.76, 504.6199) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1067.76, 504.6199) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1073.054, 505.4702) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1073.054, 505.4702) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1078.641, 506.1627) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1078.641, 506.1627) - skipping throw
+[20:28:57] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1071.171, 511.9672), source=NEUTRAL (null), range=900, listeners=2
+[20:28:57] [ENEMY] [Enemy5] Heard CASING_KICK at (1071.171, 511.9672), intensity=0.01, dist=478
+[20:28:57] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:57] [INFO] [EnemyGrenade] Target (1084.522, 506.6973) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1084.522, 506.6973) - skipping throw
+[20:28:57] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1071.063, 513.7377), source=NEUTRAL (null), range=900, listeners=2
+[20:28:57] [ENEMY] [Enemy5] Heard CASING_KICK at (1071.063, 513.7377), intensity=0.01, dist=479
+[20:28:57] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1090.34, 512.9044), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:28:57] [ENEMY] [Enemy5] Heard gunshot at (1090.34, 512.9044), intensity=0.01, distance=462
+[20:28:57] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:57] [INFO] [EnemyGrenade] Target (1090.34, 506.9044) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1090.34, 506.9044) - skipping throw
+[20:28:57] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1069.919, 515.7858), source=NEUTRAL (null), range=900, listeners=2
+[20:28:57] [ENEMY] [Enemy5] Heard CASING_KICK at (1069.919, 515.7858), intensity=0.01, dist=481
+[20:28:57] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:57] [INFO] [EnemyGrenade] Target (1096.097, 506.7839) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1096.097, 506.7839) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1101.792, 506.3358) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1101.792, 506.3358) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1107.426, 505.5603) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1107.426, 505.5603) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1112.833, 504.5399) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1112.833, 504.5399) - skipping throw
+[20:28:57] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1090.34, 512.9044), shooter_id=59458455195, bullet_pos=(1199.596, 470.1215)
+[20:28:57] [INFO] [Bullet] Using shooter_position, distance=117.333557128906
+[20:28:57] [INFO] [Bullet] Distance to wall: 117.333557128906 (7.98945766229379% of viewport)
+[20:28:57] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:28:57] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:57] [INFO] [EnemyGrenade] Target (1118.014, 503.2746) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1118.014, 503.2746) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1122.968, 501.7644) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1122.968, 501.7644) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1127.697, 500.0093) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1127.697, 500.0093) - skipping throw
+[20:28:57] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1115.819, 517.2136), source=NEUTRAL (null), range=900, listeners=2
+[20:28:57] [ENEMY] [Enemy5] Heard CASING_KICK at (1115.819, 517.2136), intensity=0.01, dist=441
+[20:28:57] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:57] [INFO] [EnemyGrenade] Target (1132.109, 498.1515) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1132.109, 498.1515) - skipping throw
+[20:28:57] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1116.172, 518.9307), source=NEUTRAL (null), range=900, listeners=2
+[20:28:57] [ENEMY] [Enemy5] Heard CASING_KICK at (1116.172, 518.9307), intensity=0.01, dist=442
+[20:28:57] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1136.203, 502.191), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:28:57] [ENEMY] [Enemy5] Heard gunshot at (1136.203, 502.191), intensity=0.01, distance=416
+[20:28:57] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:57] [INFO] [EnemyGrenade] Target (1136.203, 496.191) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1136.203, 496.191) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1139.969, 494.2892) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1139.969, 494.2892) - skipping throw
+[20:28:57] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1136.203, 502.191), shooter_id=59458455195, bullet_pos=(1198.175, 475.8629)
+[20:28:57] [INFO] [Bullet] Using shooter_position, distance=67.3332672119141
+[20:28:57] [INFO] [Bullet] Distance to wall: 67.3332672119141 (4.58484597941991% of viewport)
+[20:28:57] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[20:28:57] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:57] [INFO] [EnemyGrenade] Target (1143.407, 492.446) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1143.407, 492.446) - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target (1146.517, 490.6614) not in enemy FOV - skipping throw
+[20:28:57] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1146.517, 490.6614) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1149.299, 488.9355) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1149.299, 488.9355) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1151.753, 487.2682) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1151.753, 487.2682) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1153.878, 485.6596) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1153.878, 485.6596) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1155.676, 484.1096) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1155.676, 484.1096) - skipping throw
+[20:28:58] [INFO] [ReplayManager] Recording frame 900 (13,7s): player_valid=True, enemies=5
+[20:28:58] [INFO] [EnemyGrenade] Target (1157.145, 482.6183) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1157.145, 482.6183) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1158.286, 481.1856) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1158.286, 481.1856) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1159.099, 479.8116) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1159.099, 479.8116) - skipping throw
+[20:28:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1159.584, 484.4962), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:28:58] [ENEMY] [Enemy5] Heard gunshot at (1159.584, 484.4962), intensity=0.02, distance=387
+[20:28:58] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:58] [INFO] [EnemyGrenade] Target (1159.584, 478.4962) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1159.584, 478.4962) - skipping throw
+[20:28:58] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1159.584, 484.4962), shooter_id=59458455195, bullet_pos=(1206.701, 465.8649)
+[20:28:58] [INFO] [Bullet] Using shooter_position, distance=50.6666488647461
+[20:28:58] [INFO] [Bullet] Distance to wall: 50.6666488647461 (3.4499852889525% of viewport)
+[20:28:58] [INFO] [Bullet] Point-blank shot - 100% penetration, ignoring ricochet
+[20:28:58] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:58] [INFO] [EnemyGrenade] Target (1159.741, 477.2395) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1159.741, 477.2395) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1159.569, 476.0414) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1159.569, 476.0414) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1159.07, 474.9019) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1159.07, 474.9019) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1158.242, 473.8211) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1158.242, 473.8211) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1157.086, 472.799) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1157.086, 472.799) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target (1155.603, 471.8354) not in enemy FOV - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Target not visible to enemy (in wall/unseen area) at (1155.603, 471.8354) - skipping throw
+[20:28:58] [INFO] [EnemyGrenade] Facing throw direction: (-0.896668, 0.442703) (waiting 0.3s)
+[20:28:58] [ENEMY] [Enemy5] ROT_CHANGE: P2:combat_state -> P0:grenade_throw, state=COMBAT, target=153.7°, current=106.0°, player=(1151,470), corner_timer=0.00
+[20:28:58] [ENEMY] [Enemy5] State: COMBAT -> RETREATING
+[20:28:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1143.261, 473.8975), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:28:58] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1087.234, 470.395), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:28:58] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:58] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1045.696, 504.0005), shooter_id=59458455195, bullet_pos=(1967.62, 160.0414)
+[20:28:58] [INFO] [Bullet] Using shooter_position, distance=983.997436523438
+[20:28:58] [INFO] [Bullet] Distance to wall: 983.997436523438 (67.0021948646168% of viewport)
+[20:28:58] [INFO] [Bullet] Distance-based penetration chance: 68.4974393246138%
+[20:28:58] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1078, 470.395), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:28:58] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:58] [ENEMY] [Enemy4] Memory: high confidence (0.90) - transitioning to PURSUING
+[20:28:58] [ENEMY] [Enemy4] State: IDLE -> PURSUING
+[20:28:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1078.065, 475.1277), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:28:58] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:58] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=PURSUING, target=-162.5°, current=-45.0°, player=(1078,469), corner_timer=0.00
+[20:28:58] [ENEMY] [Enemy4] PURSUING corner check: angle 130.9°
+[20:28:58] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1096.995, 483.0575), source=NEUTRAL (null), range=900, listeners=2
+[20:28:58] [ENEMY] [Enemy5] Heard CASING_KICK at (1096.995, 483.0575), intensity=0.01, dist=470
+[20:28:58] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=1
+[20:28:58] [INFO] [ScoreManager] Combo ended at 3. Max combo: 3
+[20:28:58] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[20:28:58] [INFO] [GrenadeBase] Grenade created at (1526.349, 441.6502) (frozen)
+[20:28:58] [INFO] [FragGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[20:28:58] [INFO] [GrenadeTimer] Initialized for Frag grenade, effect radius: 225
+[20:28:58] [INFO] [GrenadeTimerHelper] Attached GrenadeTimer to FragGrenade (type: Frag)
+[20:28:58] [INFO] [EnemyGrenade] Attached C# GrenadeTimer to grenade (type: Frag)
+[20:28:58] [INFO] [FragGrenade] Pin pulled - waiting for impact (no timer, impact-triggered only)
+[20:28:58] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[20:28:58] [INFO] [GrenadeBase] LEGACY throw_grenade() called! Direction: (-0.982191, 0.187886), Speed: 827.0 (unfrozen)
+[20:28:58] [INFO] [GrenadeBase] NOTE: Using DRAG-BASED system. If velocity-based is expected, ensure grenade has throw_grenade_velocity_based() method.
+[20:28:58] [INFO] [FragGrenade] Grenade thrown (legacy) - impact detection enabled
+[20:28:58] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[20:28:58] [INFO] [GrenadeTimer] Thrower set to instance ID: 58636371562
+[20:28:58] [INFO] [EnemyGrenade] Enemy grenade thrown! Target: (1153.791, 470.9305), Distance: 413
+[20:28:58] [ENEMY] [Enemy5] ROT_CHANGE: P0:grenade_throw -> P1:visible, state=RETREATING, target=173.6°, current=179.3°, player=(1069,489), corner_timer=0.00
+[20:28:58] [ENEMY] [Enemy5] State: RETREATING -> IN_COVER
+[20:28:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1066.688, 498.6744), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:28:58] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=2
+[20:28:58] [ENEMY] [Enemy5] State: IN_COVER -> SUPPRESSED
+[20:28:59] [INFO] [ReplayManager] Recording frame 960 (14,7s): player_valid=True, enemies=5
+[20:28:59] [INFO] [GrenadeBase] Collision detected with ControlRoom_WallBottom (type: StaticBody2D)
+[20:28:59] [INFO] [FragGrenade] Impact detected! Body: ControlRoom_WallBottom (type: StaticBody2D), triggering explosion
+[20:28:59] [INFO] [FragGrenade] Impact detected - exploding immediately!
+[20:28:59] [INFO] [GrenadeBase] EXPLODED at (1408.982, 459.625)!
+[20:28:59] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(1408.982, 459.625), source=NEUTRAL (FragGrenade), range=2937, listeners=2
+[20:28:59] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:28:59] [INFO] [FragGrenade] Skipping all enemies - enemy-thrown grenade (thrower ID: 58636371562)
+[20:28:59] [INFO] [FragGrenade] Spawned shrapnel #1 at angle 15.9 degrees
+[20:28:59] [INFO] [FragGrenade] Spawned shrapnel #2 at angle 77.0 degrees
+[20:28:59] [INFO] [FragGrenade] Spawned shrapnel #3 at angle 188.3 degrees
+[20:28:59] [INFO] [FragGrenade] Spawned shrapnel #4 at angle 278.8 degrees
+[20:28:59] [INFO] [GrenadeTimer] Impact detected with ControlRoom_WallBottom - EXPLODING!
+[20:28:59] [INFO] [GrenadeTimer] GDScript already handled Frag explosion - skipping C# duplicate (Issue #886)
+[20:28:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1143.261, 473.8975), shooter_id=59458455195, bullet_pos=(1977.009, 133.2153)
+[20:28:59] [INFO] [Bullet] Using shooter_position, distance=900.666259765625
+[20:28:59] [INFO] [Bullet] Distance to wall: 900.666259765625 (61.328021806655% of viewport)
+[20:28:59] [INFO] [Bullet] Distance-based penetration chance: 75.1173078922359%
+[20:28:59] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1087.234, 470.395), shooter_id=59458455195, bullet_pos=(1972.755, 81.05157)
+[20:28:59] [INFO] [Bullet] Using shooter_position, distance=967.334167480469
+[20:28:59] [INFO] [Bullet] Distance to wall: 967.334167480469 (65.8675622344311% of viewport)
+[20:28:59] [INFO] [Bullet] Distance-based penetration chance: 69.8211773931637%
+[20:28:59] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:59] [ENEMY] [Enemy5] State: SUPPRESSED -> SEEKING_COVER
+[20:28:59] [ENEMY] [Enemy5] ROT_CHANGE: P1:visible -> P4:velocity, state=SEEKING_COVER, target=-2.2°, current=-2.6°, player=(930,494), corner_timer=0.00
+[20:28:59] [ENEMY] [Enemy4] State: PURSUING -> RETREATING
+[20:28:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1066.688, 498.6744), shooter_id=59458455195, bullet_pos=(1647.247, 288.787)
+[20:28:59] [INFO] [Bullet] Using shooter_position, distance=617.333740234375
+[20:28:59] [INFO] [Bullet] Distance to wall: 617.333740234375 (42.0353895492096% of viewport)
+[20:28:59] [INFO] [Bullet] Distance-based penetration chance: 97.6253788592555%
+[20:28:59] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:59] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P3:corner, state=RETREATING, target=130.9°, current=-165.4°, player=(924,480), corner_timer=0.03
+[20:28:59] [ENEMY] [Enemy4] State: RETREATING -> IN_COVER
+[20:28:59] [ENEMY] [Enemy4] State: IN_COVER -> SUPPRESSED
+[20:28:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1078, 470.395), shooter_id=59458455195, bullet_pos=(1978.952, 118.2263)
+[20:28:59] [INFO] [Bullet] Using shooter_position, distance=967.335021972656
+[20:28:59] [INFO] [Bullet] Distance to wall: 967.335021972656 (65.8676204183754% of viewport)
+[20:28:59] [INFO] [Bullet] Distance-based penetration chance: 69.8211095118953%
+[20:28:59] [INFO] [Bullet] Penetration failed (distance roll)
+[20:28:59] [ENEMY] [Enemy5] State: SEEKING_COVER -> IN_COVER
+[20:28:59] [ENEMY] [Enemy5] State: IN_COVER -> SUPPRESSED
+[20:28:59] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[20:28:59] [ENEMY] [Enemy4] Player reloading: false -> true
+[20:28:59] [ENEMY] [Enemy5] Player reloading: false -> true
+[20:28:59] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(917.1277, 419.8034), source=PLAYER (Player), range=900, listeners=2
+[20:28:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=2
+[20:28:59] [ENEMY] [Enemy4] Player vulnerable (reloading) but cannot attack: close=false (dist=676), can_see=false
+[20:28:59] [ENEMY] [Enemy5] Player vulnerable (reloading) but cannot attack: close=false (dist=688), can_see=false
+[20:28:59] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1078.065, 475.1277), shooter_id=59458455195, bullet_pos=(1972.13, 105.833)
+[20:28:59] [INFO] [Bullet] Using shooter_position, distance=967.332214355469
+[20:28:59] [INFO] [Bullet] Distance to wall: 967.332214355469 (65.8674292425584% of viewport)
+[20:28:59] [INFO] [Bullet] Distance-based penetration chance: 69.8213325503485%
+[20:28:59] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:28:59] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[20:28:59] [ENEMY] [Enemy4] Player reloading: true -> false
+[20:28:59] [ENEMY] [Enemy5] Player reloading: true -> false
+[20:28:59] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[20:29:00] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[20:29:00] [INFO] [ReplayManager] Recording frame 1020 (15,7s): player_valid=True, enemies=5
+[20:29:00] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[20:29:00] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[20:29:00] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[20:29:00] [INFO] [Player.Grenade] G pressed - starting grab animation
+[20:29:00] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[20:29:00] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (1642.5437, 499.99155)
+[20:29:01] [INFO] [ReplayManager] Recording frame 1080 (16,7s): player_valid=True, enemies=5
+[20:29:01] [INFO] [Player.Grenade] Step 1 failed: drag not far enough right (17,834595 < 30)
+[20:29:01] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[20:29:01] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (1431.7827, 378.0541)
+[20:29:01] [ENEMY] [Enemy5] State: SUPPRESSED -> IN_COVER
+[20:29:01] [ENEMY] [Enemy5] State: IN_COVER -> PURSUING
+[20:29:01] [ENEMY] [Enemy4] State: SUPPRESSED -> IN_COVER
+[20:29:01] [ENEMY] [Enemy5] ROT_CHANGE: P4:velocity -> P2:combat_state, state=PURSUING, target=-164.9°, current=-2.2°, player=(1021,279), corner_timer=0.00
+[20:29:01] [ENEMY] [Enemy4] State: IN_COVER -> PURSUING
+[20:29:01] [ENEMY] [Enemy4] ROT_CHANGE: P3:corner -> P2:combat_state, state=PURSUING, target=-145.1°, current=130.9°, player=(1021,279), corner_timer=0.03
+[20:29:01] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[20:29:01] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[20:29:01] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[20:29:01] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[20:29:01] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[20:29:01] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[20:29:01] [INFO] [Player.Grenade] Timer started, grenade created at (1021.93317, 279.06244)
+[20:29:01] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[20:29:01] [INFO] [Player.Grenade] Step 1 complete! Drag: (230.10254, -9.370392)
+[20:29:02] [INFO] [ReplayManager] Recording frame 1140 (17,7s): player_valid=True, enemies=5
+[20:29:02] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[20:29:02] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - starting trajectory aiming
+[20:29:03] [INFO] [ReplayManager] Recording frame 1200 (18,7s): player_valid=True, enemies=5
+[20:29:03] [ENEMY] [Enemy5] PURSUING corner check: angle -123.8°
+[20:29:03] [ENEMY] [Enemy4] Warning: No valid flank position (both sides behind walls)
+[20:29:03] [ENEMY] [Enemy4] FLANKING started: target=(1203.049, 194.0854), side=left, pos=(1552.963, 648.8701)
+[20:29:03] [ENEMY] [Enemy4] State: PURSUING -> FLANKING
+[20:29:04] [INFO] [ReplayManager] Recording frame 1260 (19,7s): player_valid=True, enemies=5
+[20:29:05] [INFO] [ReplayManager] Recording frame 1320 (20,7s): player_valid=True, enemies=5
+[20:29:05] [ENEMY] [Enemy5] FLANKING started: target=(1072.335, 544.2914), side=right, pos=(1524.809, 489.4456)
+[20:29:05] [ENEMY] [Enemy5] State: PURSUING -> FLANKING
+[20:29:05] [ENEMY] [Enemy5] FLANKING corner check: angle -122.2°
+[20:29:05] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=-168.4°, current=-168.3°, player=(1021,475), corner_timer=-0.02
+[20:29:05] [ENEMY] [Enemy4] State: FLANKING -> COMBAT
+[20:29:05] [ENEMY] [Enemy5] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=-179.0°, current=-131.7°, player=(1021,494), corner_timer=0.02
+[20:29:05] [ENEMY] [Enemy5] State: FLANKING -> COMBAT
+[20:29:05] [INFO] [Player.Grenade.Simple] Throwing! Target: (1629.9325, 583.1365), Distance: 552,1, Speed: 575,5, Friction: 300,0
+[20:29:05] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,11617981
+[20:29:05] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[20:29:05] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.9932588, 0.11591863), speed=575,5, spawn=(1081.5951, 519.1426)
+[20:29:05] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.993259, 0.115919), Speed: 575.5 (clamped from 575.5, max: 1352.8)
+[20:29:05] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[20:29:05] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[20:29:05] [INFO] [Player.Grenade] State reset to IDLE
+[20:29:05] [INFO] [Player.Grenade] State reset to IDLE
+[20:29:05] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[20:29:05] [ENEMY] [Enemy4] GRENADE DANGER: Entering EVADING_GRENADE state from COMBAT
+[20:29:05] [ENEMY] [Enemy4] EVADING_GRENADE started: escaping to (1105.775, 551.2731)
+[20:29:05] [INFO] [Player.Grenade] Player rotation restored to 0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1029.047, 560.1277), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1029.047, 560.1277), intensity=0.01, dist=484
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1029.047, 560.1277), intensity=0.01, dist=495
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1029.264, 560.6963), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1029.264, 560.6963), intensity=0.01, dist=484
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1029.264, 560.6963), intensity=0.01, dist=495
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1029.693, 561.7329), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1029.693, 561.7329), intensity=0.01, dist=483
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1029.693, 561.7329), intensity=0.01, dist=495
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1030.323, 563.1429), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1030.323, 563.1429), intensity=0.01, dist=483
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1030.323, 563.1429), intensity=0.01, dist=494
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1031.137, 564.8392), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1031.137, 564.8392), intensity=0.01, dist=482
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1031.137, 564.8392), intensity=0.01, dist=493
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1032.106, 566.7437), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1032.106, 566.7437), intensity=0.01, dist=481
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1032.106, 566.7437), intensity=0.01, dist=493
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1033.196, 568.7872), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1033.196, 568.7872), intensity=0.01, dist=480
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1033.196, 568.7872), intensity=0.01, dist=492
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1034.367, 570.9083), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1034.367, 570.9083), intensity=0.01, dist=479
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1034.367, 570.9083), intensity=0.01, dist=491
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1035.578, 573.0516), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1035.578, 573.0516), intensity=0.01, dist=477
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1035.578, 573.0516), intensity=0.01, dist=490
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1520.821, 503.9998), source=ENEMY (Enemy5), range=1469, listeners=2
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1039.088, 579.1524), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1039.088, 579.1524), intensity=0.01, dist=474
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1039.088, 579.1524), intensity=0.01, dist=488
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1520.821, 503.9447), source=ENEMY (Enemy5), range=1469, listeners=2
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=1, below_threshold=0
+[20:29:05] [INFO] [LastChance] Threat detected: Bullet
+[20:29:05] [INFO] [LastChance] Not in hard mode - effect disabled
+[20:29:05] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1505.95, 490.6601), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1505.95, 490.6601), intensity=0.34, dist=86
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1505.95, 490.6601), intensity=1.00, dist=20
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [GrenadeBase] EXPLODED at (1292.882, 543.8008)!
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(1292.882, 543.8008), source=NEUTRAL (FlashbangGrenade), range=2937, listeners=2
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [FlashbangStatus] Status: BLINDED applied
+[20:29:05] [INFO] [FlashbangStatus] Status: STUNNED applied
+[20:29:05] [INFO] [FlashbangStatus] Status: BLINDED applied
+[20:29:05] [INFO] [FlashbangStatus] Status: STUNNED applied
+[20:29:05] [INFO] [FlashbangPlayer] Applying flashbang to player: distance=271, factor=0.32, duration=2.3s, intensity=0.32
+[20:29:05] [INFO] [FlashbangPlayer] Flashbang player effect started: duration=2.3s, intensity=0.32
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1111.652, 562.8243), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1111.652, 562.8243), intensity=0.02, dist=401
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1111.652, 562.8243), intensity=0.01, dist=413
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1158.063, 533.5471), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1158.063, 533.5471), intensity=0.02, dist=357
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1158.063, 533.5471), intensity=0.02, dist=364
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1194.889, 512.2958), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1194.889, 512.2958), intensity=0.02, dist=324
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1194.889, 512.2958), intensity=0.02, dist=326
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1169.236, 511.8036), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1169.236, 511.8036), intensity=0.02, dist=350
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1169.236, 511.8036), intensity=0.02, dist=352
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1129.248, 505.0726), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1129.248, 505.0726), intensity=0.02, dist=390
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1129.248, 505.0726), intensity=0.02, dist=392
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1122.691, 510.1186), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1122.691, 510.1186), intensity=0.02, dist=396
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1122.691, 510.1186), intensity=0.02, dist=398
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1115.221, 508.6138), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1115.221, 508.6138), intensity=0.02, dist=403
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1115.221, 508.6138), intensity=0.02, dist=406
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1081.92, 542.77), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1081.92, 542.77), intensity=0.01, dist=432
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1081.92, 542.77), intensity=0.01, dist=441
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1506.114, 501.025), source=NEUTRAL (null), range=900, listeners=2
+[20:29:05] [ENEMY] [Enemy4] Heard CASING_KICK at (1506.114, 501.025), intensity=0.44, dist=75
+[20:29:05] [ENEMY] [Enemy5] Heard CASING_KICK at (1506.114, 501.025), intensity=1.00, dist=15
+[20:29:05] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:05] [INFO] [GrenadeBase] Scattered 3 casings (lethal zone) + 6 casings (proximity) from explosion
+[20:29:05] [INFO] [ImpactEffects] Flashbang effect spawned at (1292.882, 543.8008) (radius=400)
+[20:29:05] [INFO] [GrenadeTimer] Timer expired for Flashbang grenade!
+[20:29:05] [INFO] [GrenadeTimer] Flashbang grenade activated at (1292.8821, 543.80084)!
+[20:29:06] [INFO] [GrenadeTimer] Applying flashbang effects (radius: 400, blindness: 12s, stun: 6s)
+[20:29:06] [INFO] [FlashbangStatus] Flashbang: blind=5.3s, stun=2.7s
+[20:29:06] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 222,4 (intensity: 0,44)
+[20:29:06] [INFO] [FlashbangStatus] Flashbang: blind=5.1s, stun=2.5s
+[20:29:06] [INFO] [GrenadeTimer] Applied flashbang to enemy at distance 231,4 (intensity: 0,42)
+[20:29:06] [INFO] [GrenadeTimer] Applied flashbang to player at distance 270,9
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(1292.882, 543.8008), source=NEUTRAL (FlashbangGrenade), range=2938, listeners=2
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [GrenadeTimer] Spawned flashbang effect at (1292.8821, 543.80084) (radius: 400)
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1045.799, 590.6832), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1045.799, 590.6832), intensity=0.01, dist=467
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1045.799, 590.6832), intensity=0.01, dist=483
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1111.652, 562.8243), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1111.652, 562.8243), intensity=0.02, dist=401
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1111.652, 562.8243), intensity=0.01, dist=413
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1158.063, 533.5471), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1158.063, 533.5471), intensity=0.02, dist=357
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1158.063, 533.5471), intensity=0.02, dist=364
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1194.889, 512.2958), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1194.889, 512.2958), intensity=0.02, dist=324
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1194.889, 512.2958), intensity=0.02, dist=326
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1169.236, 511.8036), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1169.236, 511.8036), intensity=0.02, dist=350
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1169.236, 511.8036), intensity=0.02, dist=352
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1129.248, 505.0726), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1129.248, 505.0726), intensity=0.02, dist=390
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1129.248, 505.0726), intensity=0.02, dist=392
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1122.691, 510.1186), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1122.691, 510.1186), intensity=0.02, dist=396
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1122.691, 510.1186), intensity=0.02, dist=398
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1115.221, 508.6138), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1115.221, 508.6138), intensity=0.02, dist=403
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1115.221, 508.6138), intensity=0.02, dist=406
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1081.92, 542.77), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1081.92, 542.77), intensity=0.01, dist=432
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1081.92, 542.77), intensity=0.01, dist=441
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1506.114, 501.025), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [ENEMY] [Enemy4] Heard CASING_KICK at (1506.114, 501.025), intensity=0.44, dist=75
+[20:29:06] [ENEMY] [Enemy5] Heard CASING_KICK at (1506.114, 501.025), intensity=1.00, dist=15
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:06] [INFO] [GrenadeTimer] Scattered 10 casings
+[20:29:06] [ENEMY] [Enemy5] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=175.6°, current=175.5°, player=(1021,542), corner_timer=0.02
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1005.654, 543.4216), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=2
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(982.2225, 544.0281), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=2
+[20:29:06] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(999.5839, 505.9203), source=NEUTRAL (null), range=900, listeners=2
+[20:29:06] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=2
+[20:29:06] [INFO] [ReplayManager] Recording frame 1380 (21,7s): player_valid=True, enemies=5
+[20:29:06] [INFO] [LastChance] Threat detected: @Area2D@565
+[20:29:06] [INFO] [LastChance] Not in hard mode - effect disabled
+[20:29:06] [INFO] [LastChance] Cannot trigger effect - conditions not met
+[20:29:06] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1454.3817, 518.6754), shooter_id=58636371562, bullet_pos=(45.23288, 664.433)
+[20:29:06] [INFO] [Bullet] Using shooter_position, distance=1416,6671
+[20:29:06] [INFO] [Bullet] Distance to wall: 1416,6671 (96,46347% of viewport)
+[20:29:06] [INFO] [Bullet] Distance-based penetration chance: 34,12596%
+[20:29:06] [INFO] [Bullet] Penetration failed (distance roll)
+[20:29:06] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1454.1913, 517.8987), shooter_id=58636371562, bullet_pos=(43.040768, 642.79224)
+[20:29:06] [INFO] [Bullet] Using shooter_position, distance=1416,6665
+[20:29:06] [INFO] [Bullet] Distance to wall: 1416,6665 (96,46343% of viewport)
+[20:29:06] [INFO] [Bullet] Distance-based penetration chance: 34,126003%
+[20:29:06] [INFO] [Bullet] Starting wall penetration at (43.040768, 642.79224)
+[20:29:06] [INFO] [Bullet] Raycast backward hit penetrating body at distance 19,520195
+[20:29:06] [INFO] [Bullet] Body exited signal received for penetrating body
+[20:29:06] [INFO] [Bullet] Exiting penetration at (-3.444191, 646.9064) after traveling 41,666668 pixels through wall
+[20:29:06] [INFO] [Bullet] Damage multiplier after penetration: 0,9
+[20:29:07] [INFO] [ReplayManager] Recording frame 1440 (22,7s): player_valid=True, enemies=5
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1026.619, 559.0933), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:29:07] [ENEMY] [Enemy5] Heard gunshot at (1026.619, 559.0933), intensity=0.01, distance=497
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1045.794, 573.9495), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1045.794, 573.9495), intensity=0.01, dist=467
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1045.794, 573.9495), intensity=0.01, dist=480
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1045.987, 574.6962), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1045.987, 574.6962), intensity=0.01, dist=467
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1045.987, 574.6962), intensity=0.01, dist=480
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1050.228, 603.8293), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:29:07] [ENEMY] [Enemy5] Heard gunshot at (1050.228, 603.8293), intensity=0.01, distance=481
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1045.99, 574.4199), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1045.99, 574.4199), intensity=0.01, dist=467
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1045.99, 574.4199), intensity=0.01, dist=480
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1071.234, 614.6434), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1071.234, 614.6434), intensity=0.01, dist=444
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1071.234, 614.6434), intensity=0.01, dist=463
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1070.954, 615.7111), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1070.954, 615.7111), intensity=0.01, dist=444
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1070.954, 615.7111), intensity=0.01, dist=464
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1084.117, 625.4258), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:29:07] [ENEMY] [Enemy5] Heard gunshot at (1084.117, 625.4258), intensity=0.01, distance=453
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1070.013, 616.5328), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1070.013, 616.5328), intensity=0.01, dist=445
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1070.013, 616.5328), intensity=0.01, dist=465
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1026.619, 559.0933), shooter_id=59458455195, bullet_pos=(1371.321, 494.6855)
+[20:29:07] [INFO] [Bullet] Using shooter_position, distance=350.667724609375
+[20:29:07] [INFO] [Bullet] Distance to wall: 350.667724609375 (23.877610189739% of viewport)
+[20:29:07] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:29:07] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1068.472, 617.1741), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1068.472, 617.1741), intensity=0.01, dist=447
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1068.472, 617.1741), intensity=0.01, dist=466
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1066.393, 617.6821), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1066.393, 617.6821), intensity=0.01, dist=449
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1066.393, 617.6821), intensity=0.01, dist=468
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1102.081, 638.6688), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1102.081, 638.6688), intensity=0.01, dist=416
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1102.081, 638.6688), intensity=0.01, dist=440
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1102.054, 640.6533), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1102.054, 640.6533), intensity=0.01, dist=416
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1102.054, 640.6533), intensity=0.01, dist=440
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1109.812, 621.931), source=PLAYER (MakarovPM), range=1469, listeners=2
+[20:29:07] [ENEMY] [Enemy5] Heard gunshot at (1109.812, 621.931), intensity=0.01, distance=428
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:07] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1101.868, 643.0459), source=NEUTRAL (null), range=900, listeners=2
+[20:29:07] [ENEMY] [Enemy4] Heard CASING_KICK at (1101.868, 643.0459), intensity=0.01, dist=417
+[20:29:07] [ENEMY] [Enemy5] Heard CASING_KICK at (1101.868, 643.0459), intensity=0.01, dist=441
+[20:29:07] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=0, self=0, below_threshold=0
+[20:29:08] [INFO] [ReplayManager] Recording frame 1500 (23,7s): player_valid=True, enemies=5
+[20:29:08] [ENEMY] [Enemy5] Hit: dmg=1, hp=1/1->0/1
+[20:29:08] [INFO] [ImpactEffects] spawn_blood_effect called at (1520.82, 503.9999), dir=(0.985514, -0.169597), lethal=true
+[20:29:08] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[20:29:08] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[20:29:08] [INFO] [ImpactEffects] Blood effect spawned at (1520.82, 503.9999) (scale=0.75)
+[20:29:08] [ENEMY] [Enemy5] Enemy died (ricochet: false, penetration: false)
+[20:29:08] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[20:29:08] [ENEMY] [Enemy5] [AllyDeath] Notified 1 enemies
+[20:29:08] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 1)
+[20:29:08] [INFO] [DeathAnim] Started - Angle: -9.8 deg, Index: 11
+[20:29:08] [ENEMY] [Enemy5] Death animation started with hit direction: (0.985514, -0.169597)
+[20:29:08] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1124.63, 593.7239), source=PLAYER (MakarovPM), range=1469, listeners=1
+[20:29:08] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0, below_threshold=0
+[20:29:08] [ENEMY] [Enemy4] Hit: dmg=1, hp=1/1->0/1
+[20:29:08] [INFO] [ImpactEffects] spawn_blood_effect called at (1513.171, 576.0297), dir=(0.994114, -0.108343), lethal=true
+[20:29:08] [INFO] [ImpactEffects] Blood particle effect instantiated successfully
+[20:29:08] [INFO] [ImpactEffects] Blood decals scheduled: 20 to spawn at particle landing times
+[20:29:08] [INFO] [ImpactEffects] Blood effect spawned at (1513.171, 576.0297) (scale=0.75)
+[20:29:08] [ENEMY] [Enemy4] Enemy died (ricochet: false, penetration: false)
+[20:29:08] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[20:29:08] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 0)
+[20:29:08] [INFO] [DeathAnim] Started - Angle: -6.2 deg, Index: 11
+[20:29:08] [ENEMY] [Enemy4] Death animation started with hit direction: (0.994114, -0.108343)
+[20:29:08] [INFO] [FlashbangPlayer] Flashbang player effect ended
+[20:29:08] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1128.778, 542.6489), source=PLAYER (MakarovPM), range=1469, listeners=0
+[20:29:08] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:08] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1109.812, 621.931), shooter_id=59458455195, bullet_pos=(1493.788, 617.6787)
+[20:29:08] [INFO] [Bullet] Using shooter_position, distance=384.000091552734
+[20:29:08] [INFO] [Bullet] Distance to wall: 384.000091552734 (26.1472723477305% of viewport)
+[20:29:08] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:29:08] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1601.722, 509.447) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1591.047, 499.4641) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1592.269, 511.5133) (added to group)
+[20:29:08] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1139.618, 486.6391), source=PLAYER (MakarovPM), range=1469, listeners=0
+[20:29:08] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1568.708, 507.5574) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1593.231, 512.1623) (added to group)
+[20:29:08] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1124.63, 593.7239), shooter_id=59458455195, bullet_pos=(1491.894, 600.8788)
+[20:29:08] [INFO] [Bullet] Using shooter_position, distance=367.333465576172
+[20:29:08] [INFO] [Bullet] Distance to wall: 367.333465576172 (25.0124111377636% of viewport)
+[20:29:08] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:29:08] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1559.246, 597.1872) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1570.261, 576.0753) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1617.123, 626.8741) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1588.794, 589.8973) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1560.837, 575.0154) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1566.525, 582.7304) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1596.047, 580.5149) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1610.521, 601.1334) (added to group)
+[20:29:08] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1163.27, 435.9358), source=PLAYER (MakarovPM), range=1469, listeners=0
+[20:29:08] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:08] [ENEMY] [Enemy5] Ragdoll activated
+[20:29:08] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1616.21, 498.3291) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1587.516, 596.7302) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1607.811, 507.5625) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1595.628, 637.7078) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1575.221, 627.5222) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1576.656, 598.6146) (added to group)
+[20:29:08] [ENEMY] [Enemy4] Ragdoll activated
+[20:29:08] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[20:29:08] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1163.27, 435.9358), shooter_id=59458455195, bullet_pos=(1314.154, 466.7565)
+[20:29:08] [INFO] [Bullet] Using shooter_position, distance=154.00016784668
+[20:29:08] [INFO] [Bullet] Distance to wall: 154.00016784668 (10.4861546100188% of viewport)
+[20:29:08] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1641.528, 590.8395) (added to group)
+[20:29:08] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[20:29:08] [ENEMY] [Enemy4] Player reloading: false -> true
+[20:29:08] [ENEMY] [Enemy5] Player reloading: false -> true
+[20:29:08] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(1167.409, 365.6502), source=PLAYER (Player), range=900, listeners=0
+[20:29:08] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1627.522, 674.7819) (added to group)
+[20:29:08] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1139.618, 486.6391), shooter_id=59458455195, bullet_pos=(1502.941, 540.7638)
+[20:29:08] [INFO] [Bullet] Using shooter_position, distance=367.331909179688
+[20:29:08] [INFO] [Bullet] Distance to wall: 367.331909179688 (25.012305159865% of viewport)
+[20:29:08] [INFO] [Bullet] Within ricochet range - trying ricochet first
+[20:29:08] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1658.527, 570.3021) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1658.259, 611.0322) (added to group)
+[20:29:08] [INFO] [BloodDecal] Blood puddle created at (1696.293, 494.3774) (added to group)
+[20:29:09] [INFO] [BloodDecal] Blood puddle created at (1697.881, 688.4163) (added to group)
+[20:29:09] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[20:29:09] [ENEMY] [Enemy4] Player reloading: true -> false
+[20:29:09] [ENEMY] [Enemy5] Player reloading: true -> false
+[20:29:09] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[20:29:09] [INFO] [ReplayManager] Recording frame 1560 (24,5s): player_valid=True, enemies=5
+[20:29:09] [INFO] [BloodDecal] Blood puddle created at (1673.521, 703.0221) (added to group)
+[20:29:09] [INFO] [BloodDecal] Blood puddle created at (1623.887, 719.556) (added to group)
+[20:29:09] [INFO] [BloodDecal] Blood puddle created at (1653.87, 613.2144) (added to group)
+[20:29:09] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[20:29:09] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1128.778, 542.6489), shooter_id=59458455195, bullet_pos=(1975.012, 585.816)
+[20:29:09] [INFO] [Bullet] Using shooter_position, distance=847.334533691406
+[20:29:09] [INFO] [Bullet] Distance to wall: 847.334533691406 (57.6965665098646% of viewport)
+[20:29:09] [INFO] [Bullet] Distance-based penetration chance: 79.3540057384913%
+[20:29:09] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:29:10] [ENEMY] [Enemy5] Death animation completed
+[20:29:10] [INFO] [ReplayManager] Recording frame 1620 (25,3s): player_valid=True, enemies=5
+[20:29:10] [ENEMY] [Enemy4] Death animation completed
+[20:29:10] [INFO] [Bullet] _get_distance_to_shooter: shooter_position=(1163.27, 435.9358), shooter_id=59458455195, bullet_pos=(1969.682, 381.8293)
+[20:29:10] [INFO] [Bullet] Using shooter_position, distance=808.225952148438
+[20:29:10] [INFO] [Bullet] Distance to wall: 808.225952148438 (55.0335912782637% of viewport)
+[20:29:10] [INFO] [Bullet] Distance-based penetration chance: 82.4608101753591%
+[20:29:10] [INFO] [Bullet] Caliber cannot penetrate walls
+[20:29:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1040.642, 550.9487), source=NEUTRAL (null), range=900, listeners=0
+[20:29:10] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1039.665, 551.3441), source=NEUTRAL (null), range=900, listeners=0
+[20:29:10] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1037.698, 551.9491), source=NEUTRAL (null), range=900, listeners=0
+[20:29:10] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1034.773, 552.4954), source=NEUTRAL (null), range=900, listeners=0
+[20:29:10] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1031, 552.6796), source=NEUTRAL (null), range=900, listeners=0
+[20:29:10] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:10] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1026.557, 552.2693), source=NEUTRAL (null), range=900, listeners=0
+[20:29:10] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1021.613, 551.1423), source=NEUTRAL (null), range=900, listeners=0
+[20:29:11] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1016.298, 549.251), source=NEUTRAL (null), range=900, listeners=0
+[20:29:11] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:11] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1010.705, 546.5857), source=NEUTRAL (null), range=900, listeners=0
+[20:29:11] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:11] [INFO] [ReplayManager] Recording frame 1680 (26,1s): player_valid=True, enemies=5
+[20:29:12] [INFO] [ReplayManager] Recording frame 1740 (27,1s): player_valid=True, enemies=5
+[20:29:12] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(539.0064, 561.8052), source=NEUTRAL (null), range=900, listeners=0
+[20:29:12] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:12] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(538.8388, 560.512), source=NEUTRAL (null), range=900, listeners=0
+[20:29:12] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0, below_threshold=0
+[20:29:13] [INFO] [ReplayManager] Recording frame 1800 (28,1s): player_valid=True, enemies=5
+[20:29:13] [INFO] [ScoreManager] Combo ended at 2. Max combo: 3
+[20:29:14] [INFO] [ReplayManager] Recording frame 1860 (29,1s): player_valid=True, enemies=5
+[20:29:14] [INFO] [LabyrinthLevel] Player controls disabled (level completed)
+[20:29:14] [INFO] [ReplayManager] === REPLAY RECORDING STOPPED ===
+[20:29:14] [INFO] [ReplayManager] Total frames recorded: 1861
+[20:29:14] [INFO] [ReplayManager] Total duration: 29,09s
+[20:29:14] [INFO] [ReplayManager] Blood decals at end: 70 (baseline at frame 0: 1)
+[20:29:14] [INFO] [ReplayManager] Casings at end: 37 (baseline at frame 0: 0)
+[20:29:14] [INFO] [ReplayManager] Footprints recorded: 0
+[20:29:14] [INFO] [ReplayManager] has_replay() will return: True
+[20:29:14] [INFO] [LabyrinthLevel] Replay recording stopped
+[20:29:14] [INFO] [LabyrinthLevel] Replay status: has_replay=true, duration=29.09s
+[20:29:14] [INFO] [ProgressManager] No improvement for res://scenes/levels/LabyrinthLevel.tscn on Black Metal (existing: rank=A, score=12369)
+[20:29:14] [INFO] [ScoreManager] Level completed! Final score: 11479, Rank: A
+[20:29:14] [INFO] [LabyrinthLevel] Watch Replay button not shown (replay viewing disabled in experimental settings)
+[20:29:15] [INFO] [LabyrinthLevel] Next Level button pressed: res://scenes/levels/BuildingLevel.tscn
+[20:29:15] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[20:29:15] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[20:29:15] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[20:29:15] [INFO] [LastChance] Resetting all effects (scene change detected)
+[20:29:15] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[20:29:15] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[20:29:15] [INFO] [BlackMetalEffectsManager] Scene changed to: BuildingLevel
+[20:29:15] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[20:29:15] [ENEMY] [Enemy1] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[20:29:15] [ENEMY] [Enemy2] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[20:29:15] [ENEMY] [Enemy3] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[20:29:15] [ENEMY] [Enemy4] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[20:29:15] [INFO] [EnemyGrenade] Grenade bag built (normal): [Flashbang, Flashbang, Flashbang, Offensive, Offensive, Offensive, Offensive, Offensive]
+[20:29:15] [INFO] [EnemyGrenade] Grenadier initialized: 8 grenades in bag
+[20:29:15] [ENEMY] [Grenadier] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[20:29:15] [ENEMY] [Enemy6] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[20:29:15] [ENEMY] [Enemy7] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[20:29:15] [INFO] [EnemyGrenade] Initialized: 1 grenades
+[20:29:15] [ENEMY] [Enemy8] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[20:29:15] [ENEMY] [Enemy9] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[20:29:15] [ENEMY] [Enemy10] Death animation component initialized
+[20:29:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[20:29:15] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[20:29:15] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[20:29:15] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[20:29:15] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[20:29:15] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[20:29:15] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[20:29:15] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[20:29:15] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[20:29:15] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[20:29:15] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[20:29:15] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[20:29:15] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[20:29:15] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[20:29:15] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[20:29:15] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[20:29:15] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[20:29:15] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[20:29:15] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[20:29:15] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[20:29:15] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[20:29:15] [INFO] [Player] Ready! Ammo: 9/9, Grenades: 1/3, Health: 1/3
+[20:29:15] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[20:29:15] [INFO] [BuildingLevel] Found Environment/Enemies node with 10 children
+[20:29:15] [INFO] [BuildingLevel] Child 'Enemy1': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Child 'Enemy2': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Child 'Enemy3': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Child 'Enemy4': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Child 'Grenadier': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Child 'Enemy6': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Child 'Enemy7': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Child 'Enemy8': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Child 'Enemy9': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Child 'Enemy10': script=true, has_died_signal=true
+[20:29:15] [INFO] [BuildingLevel] Enemy tracking complete: 10 enemies registered
+[20:29:15] [INFO] [BuildingLevel] Setting up weapon: makarov_pm
+[20:29:15] [INFO] [ScoreManager] Level started with 10 enemies
+[20:29:15] [INFO] [BuildingLevel] ReplayManager found as C# autoload - verified OK
+[20:29:15] [INFO] [BuildingLevel] Starting replay recording - Player: Player, Enemies count: 10
+[20:29:15] [INFO] [ReplayManager] Replay data cleared
+[20:29:15] [INFO] [BuildingLevel] Previous replay data cleared
+[20:29:15] [INFO] [ReplayManager] Detected player weapon: Makarov PM
+[20:29:15] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[20:29:15] [INFO] [ReplayManager] Level: BuildingLevel
+[20:29:15] [INFO] [ReplayManager] Player: Player (valid: True)
+[20:29:15] [INFO] [ReplayManager] Enemies count: 10
+[20:29:15] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/makarov_pm_topdown.png
+[20:29:15] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[20:29:15] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[20:29:15] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[20:29:15] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[20:29:15] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[20:29:15] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[20:29:15] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[20:29:15] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[20:29:15] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[20:29:15] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[20:29:15] [INFO] [BuildingLevel] Replay recording started successfully
+[20:29:15] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[20:29:15] [INFO] [CinemaEffects] Found player node: Player
+[20:29:15] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[20:29:15] [ENEMY] [Enemy1] Registered as sound listener
+[20:29:15] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[20:29:15] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[20:29:15] [ENEMY] [Enemy2] Registered as sound listener
+[20:29:15] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 1, behavior: GUARD
+[20:29:15] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[20:29:15] [ENEMY] [Enemy3] Registered as sound listener
+[20:29:15] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 3, behavior: GUARD
+[20:29:15] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[20:29:15] [ENEMY] [Enemy4] Registered as sound listener
+[20:29:15] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 1, behavior: GUARD
+[20:29:15] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[20:29:15] [ENEMY] [Grenadier] Registered as sound listener
+[20:29:15] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 1, behavior: GUARD
+[20:29:15] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[20:29:15] [ENEMY] [Enemy6] Registered as sound listener
+[20:29:15] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[20:29:15] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[20:29:15] [ENEMY] [Enemy7] Registered as sound listener
+[20:29:15] [ENEMY] [Enemy7] Spawned at (1600, 900), hp: 3, behavior: PATROL
+[20:29:15] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[20:29:15] [ENEMY] [Enemy8] Registered as sound listener
+[20:29:15] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 1, behavior: GUARD
+[20:29:15] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[20:29:15] [ENEMY] [Enemy9] Registered as sound listener
+[20:29:15] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 1, behavior: GUARD
+[20:29:15] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[20:29:15] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[20:29:15] [ENEMY] [Enemy10] Registered as sound listener
+[20:29:15] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 3, behavior: PATROL
+[20:29:15] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[20:29:15] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[20:29:15] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[20:29:15] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[20:29:15] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [Player] Detecting weapon pose (frame 3)...
+[20:29:15] [INFO] [Player] Detected weapon: Makarov PM (Pistol pose)
+[20:29:15] [INFO] [Player] Applied Pistol arm pose: Left=(16, 6), Right=(4, 6)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[20:29:15] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[20:29:15] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[20:29:15] [INFO] [LastChance] Found player: Player
+[20:29:15] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[20:29:15] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[20:29:15] [INFO] [LastChance] Connected to player Died signal (C#)
+[20:29:15] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [BlackMetalEffectsManager] Black Metal filter now visible (after 3 frames delay)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:15] [INFO] [EnemyGrenade] Target not visible for Flashbang at (1213.079, 700.5828) - skipping throw
+[20:29:15] [INFO] [EnemyGrenade] Throw path blocked to (1305.627, 1368.018)
+[20:29:16] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[20:29:17] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[20:29:18] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[20:29:19] [INFO] ------------------------------------------------------------
+[20:29:19] [INFO] GAME LOG ENDED: 2026-03-11T20:29:19
+[20:29:19] [INFO] ============================================================

--- a/scripts/autoload/difficulty_manager.gd
+++ b/scripts/autoload/difficulty_manager.gd
@@ -91,6 +91,13 @@ func get_difficulty_name() -> String:
 			return "Unknown"
 
 
+## Get the names of all available difficulty modes.
+## Use this as the single source of truth whenever iterating over all difficulties.
+## @return: Array of all difficulty name strings in ascending order.
+func get_all_difficulty_names() -> Array[String]:
+	return ["Easy", "Normal", "Hard", "Power Fantasy", "Black Metal"]
+
+
 ## Get the display name for a specific difficulty level.
 func get_difficulty_name_for(difficulty: Difficulty) -> String:
 	match difficulty:

--- a/scripts/autoload/progress_manager.gd
+++ b/scripts/autoload/progress_manager.gd
@@ -114,8 +114,7 @@ func is_level_completed(level_path: String, difficulty_name: String) -> bool:
 ## @param level_path: The scene file path of the level.
 ## @return: True if the level has been completed at least once on any difficulty.
 func is_level_completed_any_difficulty(level_path: String) -> bool:
-	var difficulties: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]
-	for difficulty_name in difficulties:
+	for difficulty_name in _get_all_difficulty_names():
 		if is_level_completed(level_path, difficulty_name):
 			return true
 	return false
@@ -127,12 +126,22 @@ func is_level_completed_any_difficulty(level_path: String) -> bool:
 ##          Only includes difficulties where the level has been completed.
 func get_progress_for_all_difficulties(level_path: String) -> Dictionary:
 	var result: Dictionary = {}
-	var difficulties: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]
-	for difficulty_name in difficulties:
+	for difficulty_name in _get_all_difficulty_names():
 		var rank: String = get_best_rank(level_path, difficulty_name)
 		if not rank.is_empty():
 			result[difficulty_name] = rank
 	return result
+
+
+## Get all available difficulty names from DifficultyManager (with static fallback).
+## Uses DifficultyManager as the single source of truth so new difficulties are
+## automatically picked up without needing to update this file.
+func _get_all_difficulty_names() -> Array[String]:
+	var difficulty_manager: Node = get_node_or_null("/root/DifficultyManager")
+	if difficulty_manager and difficulty_manager.has_method("get_all_difficulty_names"):
+		return difficulty_manager.get_all_difficulty_names()
+	# Static fallback — must stay in sync with DifficultyManager.Difficulty enum.
+	return ["Easy", "Normal", "Hard", "Power Fantasy", "Black Metal"]
 
 
 ## Get all progress data (for display purposes).

--- a/scripts/autoload/unlock_manager.gd
+++ b/scripts/autoload/unlock_manager.gd
@@ -81,8 +81,7 @@ func _get_best_rank_any_difficulty(level_path: String) -> String:
 		return ""
 
 	var best_rank: String = ""
-	var difficulties: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]
-	for difficulty_name in difficulties:
+	for difficulty_name in _get_all_difficulty_names():
 		var rank: String = progress_manager.get_best_rank(level_path, difficulty_name)
 		if not rank.is_empty() and _is_rank_better(rank, best_rank):
 			best_rank = rank
@@ -267,6 +266,17 @@ func _reset_condition_gated_items() -> void:
 ## the player must still hold LMB on the gold slot to permanently unlock them.
 func _reset_and_apply_all_unlocks() -> void:
 	_reset_condition_gated_items()
+
+
+## Get all available difficulty names from DifficultyManager (with static fallback).
+## Uses DifficultyManager as the single source of truth so new difficulties are
+## automatically picked up without needing to update this file.
+func _get_all_difficulty_names() -> Array[String]:
+	var difficulty_manager: Node = get_node_or_null("/root/DifficultyManager")
+	if difficulty_manager and difficulty_manager.has_method("get_all_difficulty_names"):
+		return difficulty_manager.get_all_difficulty_names()
+	# Static fallback — must stay in sync with DifficultyManager.Difficulty enum.
+	return ["Easy", "Normal", "Hard", "Power Fantasy", "Black Metal"]
 
 
 ## Log a message to the file logger if available.

--- a/scripts/ui/levels_menu.gd
+++ b/scripts/ui/levels_menu.gd
@@ -92,8 +92,8 @@ const LEVELS: Array[Dictionary] = [
 	}
 ]
 
-## Difficulty names in display order.
-const DIFFICULTY_NAMES: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]
+## Difficulty names in display order (must match DifficultyManager.get_all_difficulty_names()).
+const DIFFICULTY_NAMES: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy", "Black Metal"]
 
 ## Card dimensions.
 const CARD_WIDTH: float = 220.0

--- a/tests/unit/test_progress_manager.gd
+++ b/tests/unit/test_progress_manager.gd
@@ -47,16 +47,14 @@ class MockProgressManager:
 		return key in _progress
 
 	func is_level_completed_any_difficulty(level_path: String) -> bool:
-		var difficulties: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]
-		for difficulty_name in difficulties:
+		for difficulty_name in _get_all_difficulty_names():
 			if is_level_completed(level_path, difficulty_name):
 				return true
 		return false
 
 	func get_progress_for_all_difficulties(level_path: String) -> Dictionary:
 		var result: Dictionary = {}
-		var difficulties: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]
-		for difficulty_name in difficulties:
+		for difficulty_name in _get_all_difficulty_names():
 			var rank: String = get_best_rank(level_path, difficulty_name)
 			if not rank.is_empty():
 				result[difficulty_name] = rank
@@ -81,6 +79,9 @@ class MockProgressManager:
 
 	func _make_key(level_path: String, difficulty_name: String) -> String:
 		return "%s:%s" % [level_path, difficulty_name]
+
+	func _get_all_difficulty_names() -> Array[String]:
+		return ["Easy", "Normal", "Hard", "Power Fantasy", "Black Metal"]
 
 
 var progress: MockProgressManager
@@ -428,3 +429,41 @@ func test_is_level_completed_any_difficulty_with_f_rank_counts() -> void:
 	progress.save_level_progress("res://scenes/levels/LabyrinthLevel.tscn", "Normal", "F", 0)
 	assert_true(progress.is_level_completed_any_difficulty("res://scenes/levels/LabyrinthLevel.tscn"),
 		"An F rank completion should still count for unlocking the next level")
+
+
+# ============================================================================
+# Black Metal Difficulty Tests (Issue #984 regression — missing "Black Metal")
+# ============================================================================
+
+
+func test_is_level_completed_any_difficulty_true_after_black_metal() -> void:
+	# Bug: "Black Metal" was missing from the difficulty list, so completing a level
+	# on Black Metal mode did not count for unlocking the next level.
+	progress.save_level_progress("res://scenes/levels/LabyrinthLevel.tscn", "Black Metal", "A", 12369)
+	assert_true(progress.is_level_completed_any_difficulty("res://scenes/levels/LabyrinthLevel.tscn"),
+		"Level should be considered completed after clearing on Black Metal (regression: Issue #984)")
+
+
+func test_get_progress_for_all_difficulties_includes_black_metal() -> void:
+	# Black Metal progress should appear in the all-difficulties result
+	var level: String = "res://scenes/levels/LabyrinthLevel.tscn"
+	progress.save_level_progress(level, "Black Metal", "A", 12369)
+
+	var result: Dictionary = progress.get_progress_for_all_difficulties(level)
+	assert_true(result.has("Black Metal"), "Black Metal should appear in all-difficulties result")
+	assert_eq(result["Black Metal"], "A", "Black Metal rank should be A")
+
+
+func test_five_difficulty_modes_tracked() -> void:
+	var level: String = "res://scenes/levels/CastleLevel.tscn"
+	progress.save_level_progress(level, "Easy", "A+", 9000)
+	progress.save_level_progress(level, "Normal", "B", 6000)
+	progress.save_level_progress(level, "Hard", "D", 2000)
+	progress.save_level_progress(level, "Power Fantasy", "S", 15000)
+	progress.save_level_progress(level, "Black Metal", "A", 12000)
+
+	assert_eq(progress.get_best_rank(level, "Easy"), "A+")
+	assert_eq(progress.get_best_rank(level, "Normal"), "B")
+	assert_eq(progress.get_best_rank(level, "Hard"), "D")
+	assert_eq(progress.get_best_rank(level, "Power Fantasy"), "S")
+	assert_eq(progress.get_best_rank(level, "Black Metal"), "A")

--- a/tests/unit/test_ui_menus.gd
+++ b/tests/unit/test_ui_menus.gd
@@ -221,7 +221,7 @@ class MockLevelsMenu:
 		}
 	]
 
-	const DIFFICULTY_NAMES: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy"]
+	const DIFFICULTY_NAMES: Array[String] = ["Easy", "Normal", "Hard", "Power Fantasy", "Black Metal"]
 
 	## Number of columns in the level grid (4 cards wide).
 	const GRID_COLUMNS: int = 4
@@ -874,6 +874,38 @@ func test_completing_level_with_any_rank_unlocks_next() -> void:
 	levels_menu.set_level_progress("Labyrinth", "Normal", "F", 50)
 	assert_true(levels_menu.is_level_unlocked(1),
 		"Even an F rank completion of Labyrinth should unlock Building Level")
+
+
+# ============================================================================
+# Black Metal Difficulty Unlock Tests (Issue #984 regression)
+# ============================================================================
+# These tests cover the bug where "Black Metal" was missing from the difficulty
+# list in is_level_completed_any_difficulty, causing levels to remain locked
+# even after they were completed on Black Metal mode.
+
+
+func test_black_metal_completion_unlocks_next_level() -> void:
+	# Regression test: completing Labyrinth on Black Metal must unlock Building Level
+	levels_menu = MockLevelsMenu.new()
+	levels_menu.set_level_progress("Labyrinth", "Black Metal", "A", 12369)
+	assert_true(levels_menu.is_level_unlocked(1),
+		"Building Level should unlock after completing Labyrinth on Black Metal (regression: Issue #984)")
+
+
+func test_black_metal_completion_recognized_by_any_difficulty_check() -> void:
+	levels_menu = MockLevelsMenu.new()
+	levels_menu.set_level_progress("Labyrinth", "Black Metal", "F", 0)
+	assert_true(levels_menu.is_level_completed_any_difficulty("Labyrinth"),
+		"is_level_completed_any_difficulty should return true for Black Metal completion")
+
+
+func test_only_black_metal_progress_still_unlocks_level() -> void:
+	# Ensure we don't depend on having Easy/Normal/Hard/Power Fantasy completions
+	levels_menu = MockLevelsMenu.new()
+	levels_menu.set_level_progress("Labyrinth", "Black Metal", "S", 20000)
+	# Building Level should unlock even if only Black Metal was played
+	assert_true(levels_menu.is_level_unlocked(1),
+		"Level should unlock with only Black Metal completion — no other difficulty needed")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/godot-topdown-MVP#984

At game start only the first level **(Лабиринт / Labyrinth)** is accessible.
Each subsequent level unlocks once the player completes the immediately preceding level
on **any** difficulty mode (even an F rank counts as a completion).

## Changes

### `scripts/autoload/difficulty_manager.gd`
- Added `get_all_difficulty_names()` — canonical list of all 5 difficulty modes.
  Used as the single source of truth by progress/unlock checks.

### `scripts/autoload/progress_manager.gd`
- Added `is_level_completed_any_difficulty(level_path)` — returns `true` if a level
  was beaten on at least one difficulty mode (all 5 including Black Metal).
- Added `_get_all_difficulty_names()` — reads from DifficultyManager with a static fallback.

### `scripts/autoload/unlock_manager.gd`
- Fixed `_get_best_rank_any_difficulty()` — now checks all 5 difficulties including
  Black Metal (previously missing, breaking weapon unlock conditions).

### `scripts/ui/levels_menu.gd`
- Added `is_level_unlocked(level_index, progress_manager)` — index 0 (Labyrinth) is
  always open; all other levels require the previous one to be completed.
- `_populate_level_cards()` now passes the unlock state to each card.
- `_create_level_card()` renders locked cards with:
  - Darkened/low-contrast background and border
  - 🔒 lock icon in the preview area instead of map stats
  - Greyed-out level name
  - Description replaced by "Complete the previous level to unlock"
  - Dimmed dashes for all difficulty grades (no grade lookup)
  - No click handler; tooltip explains the lock condition
- `DIFFICULTY_NAMES` updated to include "Black Metal" (5th difficulty).

### `tests/unit/test_ui_menus.gd`
- Added 13 new tests under "Level Locking / Progression Tests"
- Added 3 regression tests for Black Metal difficulty unlocking
- Fixed pre-existing broken tests that referenced a "Tutorial" level

### `tests/unit/test_progress_manager.gd`
- Added `_get_all_difficulty_names()` to `MockProgressManager`
- Added 3 regression tests: Black Metal completion recognized, included in all-difficulties, 5 difficulty modes tracked

### `docs/case-studies/issue-984/`
- Root cause analysis with full timeline from owner's game log
- Owner's game log (`game_log_20260311_202842.txt`) archived for reference

## Bug Fix (March 11, 2026 regression)

Owner reported two issues after testing:
1. After completing Labyrinth on **Black Metal** difficulty and pressing "Next Level",
   Building Level still showed as locked.
2. Weapons unlocked by conditions stopped working.

**Root cause**: Three files had hardcoded difficulty lists `["Easy", "Normal", "Hard", "Power Fantasy"]`
that omitted **"Black Metal"** (added in a previous PR for Issue #958).

Evidence from the game log:
```
[ProgressManager] ProgressManager ready, loaded 2 entries   ← both entries are Black Metal completions
[DifficultyManager] Loaded difficulty: Black Metal
[ProgressManager] No improvement for LabyrinthLevel.tscn on Black Metal (existing: rank=A, score=12369)
```
The level WAS completed, but `is_level_completed_any_difficulty` returned `false`
because it never checked the "Black Metal" key.

## Level unlock order

| # | Level | Unlocked by |
|---|-------|------------|
| 0 | Лабиринт / Labyrinth | Always |
| 1 | Здание / Building Level | Complete Labyrinth |
| 2 | Полигон / Polygon | Complete Building Level |
| 3 | Замок / Castle | Complete Polygon |
| 4 | Город / City | Complete Castle |
| 5 | Пляж / Beach | Complete City |
| 6 | Доки / Docks | Complete Beach |
| 7 | Двойной Коридор / Double Corridor | Complete Docks |

## Test plan
- [ ] Start a new game — only Labyrinth card is clickable; all others show 🔒
- [ ] Complete Labyrinth on **any difficulty including Black Metal** — Building Level card becomes clickable
- [ ] Completing Labyrinth does **not** unlock Polygon (chain is sequential)
- [ ] Weapon unlock conditions work correctly after completing levels on Black Metal
- [ ] Run unit tests — all new and existing tests pass

---
*This PR was created automatically by the AI issue solver*