### PR TITLE
fix: remove gold highlight from armory button when all items unlocked (Issue #1050)

### DIFF
--- a/scripts/levels/beach_level.gd
+++ b/scripts/levels/beach_level.gd
@@ -980,15 +980,29 @@ func _on_armory_button_pressed() -> void:
 		get_tree().root.add_child(armory_menu)
 		armory_menu.back_pressed.connect(func():
 			armory_menu.queue_free()
-			# Issue #1050: Remove gold armory button if all available items have been opened
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
 			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
 			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
-				var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
-				if armory_btn:
-					armory_btn.queue_free()
+				_remove_armory_button_gold_style()
+		)
+		armory_menu.apply_pressed_from_score_screen.connect(func():
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
+			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
+			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
+				_remove_armory_button_gold_style()
 		)
 	else:
 		_log_to_file("ERROR: Could not load armory menu scene")
+
+
+## Issue #1050: Remove gold highlight from the ArmoryButton when no items remain to unlock.
+## The button stays visible but loses its gold styling and reverts to plain "Armory" text.
+func _remove_armory_button_gold_style() -> void:
+	var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
+	if armory_btn:
+		armory_btn.text = "Armory"
+		armory_btn.remove_theme_color_override("font_color")
+		armory_btn.remove_theme_stylebox_override("normal")
 
 
 ## Setup the weapon based on GameManager's selected weapon.

--- a/scripts/levels/building_level.gd
+++ b/scripts/levels/building_level.gd
@@ -1734,15 +1734,29 @@ func _on_armory_button_pressed() -> void:
 		# Connect back button to close the overlay
 		armory_menu.back_pressed.connect(func():
 			armory_menu.queue_free()
-			# Issue #1050: Remove gold armory button if all available items have been opened
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
 			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
 			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
-				var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
-				if armory_btn:
-					armory_btn.queue_free()
+				_remove_armory_button_gold_style()
+		)
+		armory_menu.apply_pressed_from_score_screen.connect(func():
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
+			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
+			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
+				_remove_armory_button_gold_style()
 		)
 	else:
 		_log_to_file("ERROR: Could not load armory menu scene")
+
+
+## Issue #1050: Remove gold highlight from the ArmoryButton when no items remain to unlock.
+## The button stays visible but loses its gold styling and reverts to plain "Armory" text.
+func _remove_armory_button_gold_style() -> void:
+	var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
+	if armory_btn:
+		armory_btn.text = "Armory"
+		armory_btn.remove_theme_color_override("font_color")
+		armory_btn.remove_theme_stylebox_override("normal")
 
 
 ## Get the next level path based on the level ordering from LevelsMenu (Issue #568).

--- a/scripts/levels/castle_level.gd
+++ b/scripts/levels/castle_level.gd
@@ -1084,15 +1084,29 @@ func _on_armory_button_pressed() -> void:
 		get_tree().root.add_child(armory_menu)
 		armory_menu.back_pressed.connect(func():
 			armory_menu.queue_free()
-			# Issue #1050: Remove gold armory button if all available items have been opened
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
 			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
 			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
-				var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
-				if armory_btn:
-					armory_btn.queue_free()
+				_remove_armory_button_gold_style()
+		)
+		armory_menu.apply_pressed_from_score_screen.connect(func():
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
+			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
+			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
+				_remove_armory_button_gold_style()
 		)
 	else:
 		_log_to_file("ERROR: Could not load armory menu scene")
+
+
+## Issue #1050: Remove gold highlight from the ArmoryButton when no items remain to unlock.
+## The button stays visible but loses its gold styling and reverts to plain "Armory" text.
+func _remove_armory_button_gold_style() -> void:
+	var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
+	if armory_btn:
+		armory_btn.text = "Armory"
+		armory_btn.remove_theme_color_override("font_color")
+		armory_btn.remove_theme_stylebox_override("normal")
 
 
 ## Get the next level path based on the level ordering from LevelsMenu (Issue #568, Issue #762).

--- a/scripts/levels/city_level.gd
+++ b/scripts/levels/city_level.gd
@@ -907,13 +907,27 @@ func _on_armory_button_pressed() -> void:
 		get_tree().root.add_child(armory_menu)
 		armory_menu.back_pressed.connect(func():
 			armory_menu.queue_free()
-			# Issue #1050: Remove gold armory button if all available items have been opened
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
 			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
 			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
-				var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
-				if armory_btn:
-					armory_btn.queue_free()
+				_remove_armory_button_gold_style()
 		)
+		armory_menu.apply_pressed_from_score_screen.connect(func():
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
+			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
+			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
+				_remove_armory_button_gold_style()
+		)
+
+
+## Issue #1050: Remove gold highlight from the ArmoryButton when no items remain to unlock.
+## The button stays visible but loses its gold styling and reverts to plain "Armory" text.
+func _remove_armory_button_gold_style() -> void:
+	var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
+	if armory_btn:
+		armory_btn.text = "Armory"
+		armory_btn.remove_theme_color_override("font_color")
+		armory_btn.remove_theme_stylebox_override("normal")
 
 
 func _get_next_level_path() -> String:

--- a/scripts/levels/docks_level.gd
+++ b/scripts/levels/docks_level.gd
@@ -963,15 +963,29 @@ func _on_armory_button_pressed() -> void:
 		get_tree().root.add_child(armory_menu)
 		armory_menu.back_pressed.connect(func():
 			armory_menu.queue_free()
-			# Issue #1050: Remove gold armory button if all available items have been opened
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
 			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
 			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
-				var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
-				if armory_btn:
-					armory_btn.queue_free()
+				_remove_armory_button_gold_style()
+		)
+		armory_menu.apply_pressed_from_score_screen.connect(func():
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
+			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
+			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
+				_remove_armory_button_gold_style()
 		)
 	else:
 		_log_to_file("ERROR: Could not load armory menu scene")
+
+
+## Issue #1050: Remove gold highlight from the ArmoryButton when no items remain to unlock.
+## The button stays visible but loses its gold styling and reverts to plain "Armory" text.
+func _remove_armory_button_gold_style() -> void:
+	var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
+	if armory_btn:
+		armory_btn.text = "Armory"
+		armory_btn.remove_theme_color_override("font_color")
+		armory_btn.remove_theme_stylebox_override("normal")
 
 
 func _setup_selected_weapon() -> void:

--- a/scripts/levels/labyrinth_level.gd
+++ b/scripts/levels/labyrinth_level.gd
@@ -1657,15 +1657,29 @@ func _on_armory_button_pressed() -> void:
 		get_tree().root.add_child(armory_menu)
 		armory_menu.back_pressed.connect(func():
 			armory_menu.queue_free()
-			# Issue #1050: Remove gold armory button if all available items have been opened
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
 			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
 			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
-				var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
-				if armory_btn:
-					armory_btn.queue_free()
+				_remove_armory_button_gold_style()
+		)
+		armory_menu.apply_pressed_from_score_screen.connect(func():
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
+			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
+			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
+				_remove_armory_button_gold_style()
 		)
 	else:
 		_log_to_file("ERROR: Could not load armory menu scene")
+
+
+## Issue #1050: Remove gold highlight from the ArmoryButton when no items remain to unlock.
+## The button stays visible but loses its gold styling and reverts to plain "Armory" text.
+func _remove_armory_button_gold_style() -> void:
+	var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
+	if armory_btn:
+		armory_btn.text = "Armory"
+		armory_btn.remove_theme_color_override("font_color")
+		armory_btn.remove_theme_stylebox_override("normal")
 
 
 ## Get the next level path based on the level ordering from LevelsMenu.

--- a/scripts/levels/revolver_level.gd
+++ b/scripts/levels/revolver_level.gd
@@ -1025,15 +1025,29 @@ func _on_armory_button_pressed() -> void:
 		get_tree().root.add_child(armory_menu)
 		armory_menu.back_pressed.connect(func():
 			armory_menu.queue_free()
-			# Issue #1050: Remove gold armory button if all available items have been opened
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
 			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
 			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
-				var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
-				if armory_btn:
-					armory_btn.queue_free()
+				_remove_armory_button_gold_style()
+		)
+		armory_menu.apply_pressed_from_score_screen.connect(func():
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
+			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
+			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
+				_remove_armory_button_gold_style()
 		)
 	else:
 		_log_to_file("ERROR: Could not load armory menu scene")
+
+
+## Issue #1050: Remove gold highlight from the ArmoryButton when no items remain to unlock.
+## The button stays visible but loses its gold styling and reverts to plain "Armory" text.
+func _remove_armory_button_gold_style() -> void:
+	var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
+	if armory_btn:
+		armory_btn.text = "Armory"
+		armory_btn.remove_theme_color_override("font_color")
+		armory_btn.remove_theme_stylebox_override("normal")
 
 
 ## Get the next level path based on the level ordering.

--- a/scripts/levels/test_tier.gd
+++ b/scripts/levels/test_tier.gd
@@ -1232,15 +1232,29 @@ func _on_armory_button_pressed() -> void:
 		get_tree().root.add_child(armory_menu)
 		armory_menu.back_pressed.connect(func():
 			armory_menu.queue_free()
-			# Issue #1050: Remove gold armory button if all available items have been opened
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
 			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
 			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
-				var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
-				if armory_btn:
-					armory_btn.queue_free()
+				_remove_armory_button_gold_style()
+		)
+		armory_menu.apply_pressed_from_score_screen.connect(func():
+			# Issue #1050: Remove gold highlight from armory button if all available items have been opened
+			var unlock_manager: Node = get_node_or_null("/root/UnlockManager")
+			if unlock_manager == null or not unlock_manager.has_method("has_any_available_unlock") or not unlock_manager.has_any_available_unlock():
+				_remove_armory_button_gold_style()
 		)
 	else:
 		print("[TestTier] ERROR: Could not load armory menu scene")
+
+
+## Issue #1050: Remove gold highlight from the ArmoryButton when no items remain to unlock.
+## The button stays visible but loses its gold styling and reverts to plain "Armory" text.
+func _remove_armory_button_gold_style() -> void:
+	var armory_btn := get_tree().current_scene.find_child("ArmoryButton", true, false)
+	if armory_btn:
+		armory_btn.text = "Armory"
+		armory_btn.remove_theme_color_override("font_color")
+		armory_btn.remove_theme_stylebox_override("normal")
 
 
 ## Get the next level path based on the level ordering from LevelsMenu (Issue #568).


### PR DESCRIPTION
## Summary

Fixes #1050: The gold highlighting on the Armory button disappears after the player unlocks all available items — the button itself remains visible and accessible.

**Root cause:** The original fix incorrectly deleted the entire ArmoryButton node instead of just removing its gold styling. It also only handled the Back button path, not Apply.

**Fix:**
1. Replace `armory_btn.queue_free()` with `_remove_armory_button_gold_style()` — removes only the gold font color and gold border stylebox, resets text from "★ Armory — Items Available!" to "Armory"
2. Connect `apply_pressed_from_score_screen` signal so the same degolding happens when player presses Apply after unlocking all items (not only Back)
3. Add `_remove_armory_button_gold_style()` helper function to all 8 level files

Applies to: Labyrinth, Building, TestTier, Castle, RevolverLevel, Beach, DocksLevel, CityLevel.

## Test plan

- [ ] Complete a level to get a score screen with the gold "★ Armory — Items Available!" button
- [ ] Click the Armory button — the armory opens
- [ ] Unlock all available items (hold LMB on gold slots)
- [ ] Press **Back** — the gold Armory button should lose its gold styling and show plain "Armory" (not disappear)
- [ ] Press **Apply** (with items remaining to unlock) — close armory — the gold Armory button should lose its gold styling and show plain "Armory"
- [ ] If some items are still unlockable (not all opened), pressing Back/Apply should NOT remove the gold styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)