### PR TITLE
fix: trajectory glasses ray blink now visible — Player.cs respects trajectory_ray_visible (Issue #1085)

### DIFF
--- a/Scripts/Characters/Player.cs
+++ b/Scripts/Characters/Player.cs
@@ -6444,6 +6444,13 @@ public partial class Player : BaseCharacter
             return;
         }
 
+        // Skip drawing during the "off" phase of the blink cycle (Issue #1085).
+        bool rayVisible = (bool)_trajectoryGlassesEffect.Get("trajectory_ray_visible");
+        if (!rayVisible)
+        {
+            return;
+        }
+
         // Read trajectory points (in local player coordinates) from the GDScript effect
         var pointsVariant = _trajectoryGlassesEffect.Get("trajectory_local_points");
         if (pointsVariant.VariantType == Variant.Type.Nil)

--- a/docs/case-studies/issue-1085/case-study.md
+++ b/docs/case-studies/issue-1085/case-study.md
@@ -1,0 +1,101 @@
+# Case Study: Issue #1085 — Trajectory Glasses Ray Blink Not Visible
+
+## Overview
+
+**Issue:** Ray blink warning for trajectory glasses was implemented in code but never visible to the player.
+**Root Cause:** `Player.cs::DrawTrajectoryGlasses()` (C#) did not check the `trajectory_ray_visible` flag computed by the GDScript controller.
+**Fix:** Added a single guard check in `DrawTrajectoryGlasses()` to return early when `trajectory_ray_visible == false`.
+
+---
+
+## Timeline / Sequence of Events
+
+| Time | Event |
+|------|-------|
+| PR #1055 | Removed the trajectory glasses progress bar (Issue #1049). Replaced with a simple single low-time blink at ≤ 2 s. |
+| Issue #1085 opened | Owner requests two-phase blink: **one-shot blink at 25% remaining** (2.5 s) and **continuous blink at 4 s remaining**. |
+| PR #1086 (commit bd0b31c7) | Blink logic added to `trajectory_glasses_effect.gd`. A `trajectory_ray_visible` boolean is computed every frame. |
+| PR #1086 (commit 9ed1bd48) | Single-blink timeline corrected (fires inside continuous blink zone). |
+| 2026-03-17 | User tests the release build (Windows) and reports blinking never appears. Attaches `game_log_20260317_063830.txt`. |
+| 2026-03-17 | AI analysis: log shows **zero blink state log entries** across two full 10-second activations. GDScript logic ran correctly, but the C# drawing code never read the flag. |
+| 2026-03-17 | Root cause confirmed and fix applied: `Player.cs::DrawTrajectoryGlasses()` now checks `trajectory_ray_visible` before drawing. |
+
+---
+
+## Root Cause Analysis
+
+The project is a hybrid C# / GDScript Godot 4 game. The trajectory glasses effect is implemented in GDScript (`trajectory_glasses_effect.gd`) but the player character and all drawing are in C# (`Player.cs`).
+
+### The Bug
+
+`trajectory_glasses_effect.gd` computes `trajectory_ray_visible` correctly each frame:
+- Normal phase (> 4 s remaining): `true`
+- Continuous blink (≤ 4 s remaining): toggled at 3 Hz
+- Single-blink at 25% (≤ 2.5 s): forced `false` for half a blink period, then `true`
+
+`Player.cs::DrawTrajectoryGlasses()` (line 6429) reads `is_active`, `trajectory_local_points`, and `trajectory_invalid_start_index` via `_trajectoryGlassesEffect.Get(...)` — but **never reads `trajectory_ray_visible`**.
+
+The GDScript `player.gd` equivalent function did have the check (line 2840):
+```gdscript
+if not _trajectory_glasses.trajectory_ray_visible:
+    return
+```
+
+But the game executable uses `Player.cs`, not `player.gd`. The GDScript player is a legacy file that is no longer active.
+
+### Evidence from Game Log
+
+`game_log_20260317_063830.txt` (attached):
+- Activation 1: `06:38:36` → Deactivation: `06:38:46` (full 10 s, no blink logs)
+- Activation 2: `06:38:49` → Deactivation: `06:38:59` (full 10 s, no blink logs)
+- **Total `[TrajectoryGlasses]` log entries: 5237 lines, zero contain "blink", "ray_visible", or "continuous"**
+
+This confirms the GDScript blink logic was never logging its state changes — the blink phase code wasn't reached in a way that produced output. After adding log statements to the blink branch, the absence of any such logs would immediately reveal the visual draw path was ignoring the flag.
+
+---
+
+## The Fix
+
+**File:** `Scripts/Characters/Player.cs`
+**Method:** `DrawTrajectoryGlasses()` (line ~6441)
+
+Added immediately after the `is_active` guard:
+```csharp
+// Skip drawing during the "off" phase of the blink cycle (Issue #1085).
+bool rayVisible = (bool)_trajectoryGlassesEffect.Get("trajectory_ray_visible");
+if (!rayVisible)
+{
+    return;
+}
+```
+
+This mirrors the existing check in `scripts/characters/player.gd:2840`.
+
+---
+
+## Additional Changes
+
+### Logging Added (`trajectory_glasses_effect.gd`)
+
+To make future regressions immediately visible in logs:
+- **Continuous blink phase start**: logged once per activation when `_effect_timer` first drops below `CONTINUOUS_BLINK_THRESHOLD`
+- **Blink state transitions**: logged whenever `trajectory_ray_visible` changes
+- **Single-blink trigger**: logged when the one-shot flash fires
+
+These use `FileLogger.info` and produce no output during the normal (solid) phase.
+
+---
+
+## Contributing Factors
+
+1. **Hybrid C#/GDScript architecture**: The GDScript `player.gd` was kept as a legacy file with correct logic, but the active code path is `Player.cs`. Changes to one don't automatically propagate to the other.
+
+2. **No log coverage for blink path**: Before this fix, zero log messages were emitted from the blink logic branch, making it impossible to diagnose via logs alone.
+
+3. **Previous PR (#1055) set the pattern**: The old `LOW_TIME_WARNING` blink was implemented in the GDScript controller only — and also would have had the same bug in the C# draw path if it was ever tested more carefully. PR #1055 happened to work because it targeted `trajectory_glasses_hud.gd` (a separate UI node) rather than the ray itself.
+
+---
+
+## Artifacts
+
+- [`game_log_20260317_063830.txt`](game_log_20260317_063830.txt) — User-provided log confirming no blink output during two activations

--- a/docs/case-studies/issue-1085/game_log_20260317_063830.txt
+++ b/docs/case-studies/issue-1085/game_log_20260317_063830.txt
@@ -1,0 +1,5248 @@
+[06:38:30] [INFO] ============================================================
+[06:38:30] [INFO] GAME LOG STARTED
+[06:38:30] [INFO] ============================================================
+[06:38:30] [INFO] Timestamp: 2026-03-17T06:38:30
+[06:38:30] [INFO] Log file: I:/Загрузки/godot exe/микро фиксы/game_log_20260317_063830.txt
+[06:38:30] [INFO] Executable: I:/Загрузки/godot exe/микро фиксы/Godot-Top-Down-Template.exe
+[06:38:30] [INFO] OS: Windows
+[06:38:30] [INFO] Debug build: false
+[06:38:30] [INFO] Engine version: 4.3-stable (official)
+[06:38:30] [INFO] Project: Godot Top-Down Template
+[06:38:30] [INFO] ------------------------------------------------------------
+[06:38:30] [INFO] [GameManager] GameManager ready
+[06:38:30] [INFO] [ScoreManager] ScoreManager ready
+[06:38:31] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[06:38:31] [INFO] [DifficultyManager] Loaded difficulty: Easy (value: 0)
+[06:38:31] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[06:38:31] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[06:38:31] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[06:38:31] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[06:38:31] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[06:38:31] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[06:38:31] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[06:38:31] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[06:38:31] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[06:38:31] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[06:38:31] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[06:38:31] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[06:38:31] [INFO] [LastChance] Resetting all effects (scene change detected)
+[06:38:31] [INFO] [LastChance] Last chance shader loaded successfully
+[06:38:31] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[06:38:31] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[06:38:31] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[06:38:31] [INFO] [LastChance]   Sepia intensity: 0.70
+[06:38:31] [INFO] [LastChance]   Brightness: 0.60
+[06:38:31] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[06:38:31] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[06:38:31] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[06:38:31] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[06:38:31] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: false, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: true, FPS drop logging: true, All weapons unlocked: false, All maps unlocked: false
+[06:38:31] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.29, music: 1.00
+[06:38:31] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[06:38:31] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[06:38:31] [INFO] [CinemaEffects] Created effects layer at layer 99
+[06:38:31] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[06:38:31] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[06:38:31] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[06:38:31] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[06:38:31] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[06:38:31] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[06:38:31] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[06:38:31] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[06:38:31] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[06:38:31] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[06:38:31] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[06:38:31] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[06:38:31] [INFO] [GrenadeTimerHelper] Autoload ready
+[06:38:31] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[06:38:31] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[06:38:31] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[06:38:31] [INFO] [PowerFantasy]   Kill effect duration: 300ms
+[06:38:31] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[06:38:31] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[06:38:31] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[06:38:31] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[06:38:31] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[06:38:31] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[06:38:31] [INFO] [ProgressManager] ProgressManager ready, loaded 6 entries
+[06:38:31] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[06:38:31] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[06:38:31] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[06:38:31] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[06:38:31] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[06:38:31] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[06:38:31] [INFO] [SceneLoader] SceneLoader initialized
+[06:38:31] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[06:38:31] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[06:38:31] [INFO] [PersistManager] Restored unlocked weapon: m16
+[06:38:31] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[06:38:31] [INFO] [GameManager] Weapon selected: ak_gl
+[06:38:31] [INFO] [PersistManager] Restored selected weapon: ak_gl
+[06:38:31] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[06:38:31] [INFO] [PersistManager] Restored unlocked grenade type: 2
+[06:38:31] [INFO] [PersistManager] Restored unlocked grenade type: 3
+[06:38:31] [INFO] [GrenadeManager] Grenade type changed from Flashbang to F-1 Grenade
+[06:38:31] [INFO] [PersistManager] Restored selected grenade type: 2
+[06:38:31] [INFO] [PersistManager] Restored unlocked active item type: 0
+[06:38:31] [INFO] [PersistManager] Restored unlocked active item type: 4
+[06:38:31] [INFO] [PersistManager] Restored unlocked active item type: 6
+[06:38:31] [INFO] [PersistManager] Restored unlocked active item type: 7
+[06:38:31] [INFO] [PersistManager] Restored unlocked active item type: 8
+[06:38:31] [INFO] [PersistManager] Restored unlocked active item type: 9
+[06:38:31] [INFO] [PersistManager] Saved active item type 2 is not unlocked, keeping default
+[06:38:31] [INFO] [PersistManager] State loaded successfully
+[06:38:31] [INFO] [PersistManager] PersistManager ready
+[06:38:31] [INFO] [UnlockManager] UnlockManager ready
+[06:38:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:31] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[06:38:31] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[06:38:31] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[06:38:31] [ENEMY] [Enemy1] Death animation component initialized
+[06:38:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:31] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[06:38:31] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[06:38:31] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[06:38:31] [ENEMY] [Enemy2] Death animation component initialized
+[06:38:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:31] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[06:38:31] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[06:38:31] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[06:38:31] [ENEMY] [Enemy3] Death animation component initialized
+[06:38:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:31] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[06:38:31] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[06:38:31] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[06:38:31] [ENEMY] [Enemy4] Death animation component initialized
+[06:38:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:31] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[06:38:31] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[06:38:31] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[06:38:31] [ENEMY] [Enemy5] Death animation component initialized
+[06:38:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:31] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[06:38:31] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[06:38:31] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[06:38:31] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[06:38:31] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[06:38:31] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[06:38:31] [INFO] [Player.Weapon] Removed default MakarovPM
+[06:38:31] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[06:38:31] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[06:38:31] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[06:38:31] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[06:38:31] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[06:38:31] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[06:38:31] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[06:38:31] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[06:38:31] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[06:38:31] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[06:38:31] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[06:38:31] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[06:38:31] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[06:38:31] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[06:38:31] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[06:38:31] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[06:38:31] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[06:38:31] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[06:38:31] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[06:38:31] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[06:38:31] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[06:38:31] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[06:38:31] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[06:38:31] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[06:38:31] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[06:38:31] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[06:38:31] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[06:38:31] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - skipping GDScript weapon swap
+[06:38:31] [INFO] [ScoreManager] Level started with 5 enemies
+[06:38:31] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[06:38:31] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[06:38:31] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[06:38:31] [INFO] [ReplayManager] Replay data cleared
+[06:38:31] [INFO] [LabyrinthLevel] Previous replay data cleared
+[06:38:31] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[06:38:31] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[06:38:31] [INFO] [ReplayManager] Level: LabyrinthLevel
+[06:38:31] [INFO] [ReplayManager] Player: Player (valid: True)
+[06:38:31] [INFO] [ReplayManager] Enemies count: 5
+[06:38:31] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[06:38:31] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[06:38:31] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[06:38:31] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[06:38:31] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[06:38:31] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[06:38:31] [INFO] [LabyrinthLevel] Replay recording started successfully
+[06:38:31] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[06:38:31] [INFO] [CinemaEffects] Found player node: Player
+[06:38:31] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[06:38:31] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/BuildingLevel.tscn
+[06:38:31] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/BuildingLevel.tscn
+[06:38:31] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[06:38:31] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[06:38:31] [INFO] [UnlockManager] Restored saved unlock for weapon: ak_gl
+[06:38:31] [INFO] [UnlockManager] Restored saved unlock for grenade type: 2
+[06:38:31] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[06:38:31] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[06:38:31] [ENEMY] [Enemy1] Registered as sound listener
+[06:38:31] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 2, behavior: GUARD
+[06:38:31] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[06:38:31] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[06:38:31] [ENEMY] [Enemy2] Registered as sound listener
+[06:38:31] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 2, behavior: GUARD
+[06:38:31] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[06:38:31] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[06:38:31] [ENEMY] [Enemy3] Registered as sound listener
+[06:38:31] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[06:38:31] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[06:38:31] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[06:38:31] [ENEMY] [Enemy4] Registered as sound listener
+[06:38:31] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 2, behavior: GUARD
+[06:38:31] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[06:38:31] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[06:38:31] [ENEMY] [Enemy5] Registered as sound listener
+[06:38:31] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 3, behavior: GUARD
+[06:38:31] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[06:38:31] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[06:38:31] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[06:38:31] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=315.0°, current=0.0°, player=(150,1000), corner_timer=0.00
+[06:38:31] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[06:38:31] [INFO] [Player] Detecting weapon pose (frame 3)...
+[06:38:31] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[06:38:31] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[06:38:31] [INFO] [PenultimateHit] Shader warmup complete in 598 ms
+[06:38:31] [INFO] [LastChance] Shader warmup complete in 596 ms
+[06:38:31] [INFO] [CinemaEffects] Cinema shader warmup complete in 515 ms
+[06:38:31] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 508 ms
+[06:38:31] [INFO] [FlashbangPlayer] Shader warmup complete in 505 ms
+[06:38:31] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[06:38:31] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[06:38:31] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[06:38:31] [INFO] [LastChance] Found player: Player
+[06:38:31] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[06:38:31] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[06:38:31] [INFO] [LastChance] Connected to player Died signal (C#)
+[06:38:31] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[06:38:31] [INFO] [SceneLoader] ERROR: Invalid resource: res://scenes/levels/BuildingLevel.tscn
+[06:38:31] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 879 ms
+[06:38:31] [INFO] [SceneLoader] Background load started successfully
+[06:38:32] [INFO] [Player] Invincibility mode: ON
+[06:38:32] [INFO] [GameManager] Invincibility mode toggled: ON
+[06:38:32] [WARN] [FPS] Drop detected: 28 fps (threshold: 30)
+[06:38:32] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[06:38:33] [INFO] [PauseMenu] Armory button pressed
+[06:38:33] [INFO] [PauseMenu] Creating new armory menu instance
+[06:38:33] [INFO] [PauseMenu] armory_menu_scene resource path: res://scenes/ui/ArmoryMenu.tscn
+[06:38:33] [INFO] [PauseMenu] Instance created, class: CanvasLayer, name: ArmoryMenu
+[06:38:33] [INFO] [PauseMenu] Script attached: res://scripts/ui/armory_menu.gd
+[06:38:33] [INFO] [PauseMenu] back_pressed signal exists on instance
+[06:38:33] [INFO] [PauseMenu] back_pressed signal connected
+[06:38:33] [INFO] [PauseMenu] Armory menu instance added as child, is_inside_tree: true
+[06:38:33] [INFO] [PauseMenu] _populate_weapon_grid method exists
+[06:38:33] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[06:38:34] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[06:38:35] [INFO] [ActiveItemManager] Active item changed from None to Trajectory Glasses
+[06:38:35] [INFO] [PersistManager] State saved to user://game_state.cfg
+[06:38:35] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[06:38:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:35] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[06:38:35] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[06:38:35] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[06:38:35] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[06:38:35] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[06:38:35] [INFO] [LastChance] Resetting all effects (scene change detected)
+[06:38:35] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[06:38:35] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[06:38:35] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[06:38:35] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[06:38:35] [ENEMY] [Enemy1] Death animation component initialized
+[06:38:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:35] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[06:38:35] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[06:38:35] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[06:38:35] [ENEMY] [Enemy2] Death animation component initialized
+[06:38:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:35] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[06:38:35] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[06:38:35] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[06:38:35] [ENEMY] [Enemy3] Death animation component initialized
+[06:38:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:35] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[06:38:35] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[06:38:35] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[06:38:35] [ENEMY] [Enemy4] Death animation component initialized
+[06:38:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:35] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[06:38:35] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[06:38:35] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[06:38:35] [ENEMY] [Enemy5] Death animation component initialized
+[06:38:35] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[06:38:35] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[06:38:35] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[06:38:35] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[06:38:35] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[06:38:35] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[06:38:35] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[06:38:35] [INFO] [Player.Weapon] Removed default MakarovPM
+[06:38:35] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[06:38:35] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[06:38:35] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[06:38:35] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[06:38:35] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[06:38:35] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[06:38:35] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[06:38:35] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[06:38:35] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[06:38:35] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[06:38:35] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[06:38:35] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[06:38:35] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[06:38:35] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[06:38:35] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[06:38:35] [INFO] [Player.TrajectoryGlasses] Trajectory glasses selected, initializing...
+[06:38:35] [INFO] [TrajectoryGlasses] Effect ready, charges: 2/2
+[06:38:35] [INFO] [TrajectoryGlasses] Initialized with player: Player, viewport diagonal: 1469
+[06:38:35] [INFO] [TrajectoryGlasses] Weapon set: AKGL
+[06:38:35] [INFO] [Player.TrajectoryGlasses] Weapon set: AKGL
+[06:38:35] [INFO] [Player.TrajectoryGlasses] Trajectory glasses equipped, charges: 2
+[06:38:35] [INFO] [Player.TrajectoryGlasses] HUD created
+[06:38:35] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[06:38:35] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[06:38:35] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[06:38:35] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[06:38:35] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[06:38:35] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[06:38:35] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[06:38:35] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[06:38:35] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[06:38:35] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[06:38:35] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - skipping GDScript weapon swap
+[06:38:35] [INFO] [ScoreManager] Level started with 5 enemies
+[06:38:35] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[06:38:35] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[06:38:35] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[06:38:35] [INFO] [ReplayManager] Replay data cleared
+[06:38:35] [INFO] [LabyrinthLevel] Previous replay data cleared
+[06:38:35] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[06:38:35] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[06:38:35] [INFO] [ReplayManager] Level: LabyrinthLevel
+[06:38:35] [INFO] [ReplayManager] Player: Player (valid: True)
+[06:38:35] [INFO] [ReplayManager] Enemies count: 5
+[06:38:35] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[06:38:35] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[06:38:35] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[06:38:35] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[06:38:35] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[06:38:35] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[06:38:35] [INFO] [LabyrinthLevel] Replay recording started successfully
+[06:38:35] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[06:38:35] [INFO] [CinemaEffects] Found player node: Player
+[06:38:35] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[06:38:35] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 6)
+[06:38:35] [ENEMY] [Enemy1] Registered as sound listener
+[06:38:35] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 2, behavior: GUARD
+[06:38:35] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[06:38:35] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 7)
+[06:38:35] [ENEMY] [Enemy2] Registered as sound listener
+[06:38:35] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 2, behavior: GUARD
+[06:38:35] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[06:38:35] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 8)
+[06:38:35] [ENEMY] [Enemy3] Registered as sound listener
+[06:38:35] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 2, behavior: PATROL
+[06:38:35] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[06:38:35] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 9)
+[06:38:35] [ENEMY] [Enemy4] Registered as sound listener
+[06:38:35] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[06:38:35] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[06:38:35] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 10)
+[06:38:35] [ENEMY] [Enemy5] Registered as sound listener
+[06:38:35] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 3, behavior: GUARD
+[06:38:35] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[06:38:35] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[06:38:35] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(150,1000), corner_timer=0.00
+[06:38:35] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[06:38:35] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[06:38:35] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[06:38:35] [INFO] [Player] Detecting weapon pose (frame 3)...
+[06:38:35] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[06:38:35] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[06:38:35] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[06:38:35] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[06:38:35] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[06:38:35] [INFO] [LastChance] Found player: Player
+[06:38:35] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[06:38:35] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[06:38:35] [INFO] [LastChance] Connected to player Died signal (C#)
+[06:38:35] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[06:38:36] [INFO] [TrajectoryGlasses] Weapon set: AKGL
+[06:38:36] [INFO] [Player.TrajectoryGlasses] Space pressed - activating (charges: 2)
+[06:38:36] [INFO] [TrajectoryGlasses] Activated! Duration: 10.0s, Charges remaining: 1/2, Player: Player
+[06:38:36] [INFO] [Player.TrajectoryGlasses] Activation result: True
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.6, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.6, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.6, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.6, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.6, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.7, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:36] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:36] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-54.4°, player=(150,1000), corner_timer=-0.02
+[06:38:37] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(150,1000), corner_timer=0.30
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:37] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:37] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:38] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:38] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=52.8°, player=(150,1000), corner_timer=-0.02
+[06:38:39] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=55.6°, player=(150,1000), corner_timer=0.30
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=1.2°, player=(150,1000), corner_timer=-0.02
+[06:38:39] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=4.1°, player=(150,1000), corner_timer=0.30
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:39] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:39] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=5
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:40] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:40] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=87.1°, player=(150,1000), corner_timer=-0.02
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=5
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=52.8°, player=(150,1000), corner_timer=0.30
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:41] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:41] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=5
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:42] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:42] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[06:38:43] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=5
+[06:38:43] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:43] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:43] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=5
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:44] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:44] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=90.0°, player=(150,1000), corner_timer=-0.02
+[06:38:45] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=92.9°, player=(150,1000), corner_timer=0.30
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=5
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=147.3°, player=(150,1000), corner_timer=-0.02
+[06:38:45] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=150.2°, player=(150,1000), corner_timer=0.30
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:45] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:45] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-155.4°, player=(150,1000), corner_timer=-0.02
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:46] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:46] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:46] [INFO] [TrajectoryGlasses] Deactivated! Charges remaining: 1/2
+[06:38:46] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=5
+[06:38:47] [INFO] [ReplayManager] Recording frame 720 (12,0s): player_valid=True, enemies=5
+[06:38:48] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:48] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[06:38:48] [INFO] [ReplayManager] Recording frame 780 (13,0s): player_valid=True, enemies=5
+[06:38:49] [INFO] [ReplayManager] Recording frame 840 (14,0s): player_valid=True, enemies=5
+[06:38:49] [INFO] [TrajectoryGlasses] Weapon set: AKGL
+[06:38:49] [INFO] [Player.TrajectoryGlasses] Space pressed - activating (charges: 1)
+[06:38:49] [INFO] [TrajectoryGlasses] Activated! Duration: 10.0s, Charges remaining: 0/2, Player: Player
+[06:38:49] [INFO] [Player.TrajectoryGlasses] Activation result: True
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[06:38:49] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:49] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:49] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:49] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [ReplayManager] Recording frame 900 (15,0s): player_valid=True, enemies=5
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:50] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:50] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [ReplayManager] Recording frame 960 (16,0s): player_valid=True, enemies=5
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=90.0°, player=(150,1000), corner_timer=-0.02
+[06:38:51] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=92.9°, player=(150,1000), corner_timer=0.30
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:51] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:51] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=147.3°, player=(150,1000), corner_timer=-0.02
+[06:38:52] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=150.2°, player=(150,1000), corner_timer=0.30
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-155.4°, player=(150,1000), corner_timer=-0.02
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [ReplayManager] Recording frame 1020 (17,0s): player_valid=True, enemies=5
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:52] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:52] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [ReplayManager] Recording frame 1080 (18,0s): player_valid=True, enemies=5
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:53] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:53] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [ReplayManager] Recording frame 1140 (19,0s): player_valid=True, enemies=5
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:54] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:54] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [ReplayManager] Recording frame 1200 (20,0s): player_valid=True, enemies=5
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:55] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:55] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[06:38:56] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [ReplayManager] Recording frame 1260 (21,0s): player_valid=True, enemies=5
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:56] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:56] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [ReplayManager] Recording frame 1320 (22,0s): player_valid=True, enemies=5
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:57] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:57] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=90.0°, player=(150,1000), corner_timer=-0.02
+[06:38:58] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=92.9°, player=(150,1000), corner_timer=0.30
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=147.3°, player=(150,1000), corner_timer=-0.02
+[06:38:58] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=150.2°, player=(150,1000), corner_timer=0.30
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [ReplayManager] Recording frame 1380 (23,0s): player_valid=True, enemies=5
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-155.4°, player=(150,1000), corner_timer=-0.02
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:58] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:58] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [ReplayManager] Recording frame 1440 (24,0s): player_valid=True, enemies=5
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochet_angle: AKGL -> max_ricochet_angle=70.0 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _get_weapon_max_ricochets: AKGL -> max_ricochets=-1 (via C# helper)
+[06:38:59] [INFO] [TrajectoryGlasses] _calculate_ricochet_trajectory: weapon_max_angle=70.0, weapon_max_ricochets=-1, bounce_limit=5
+[06:38:59] [INFO] [TrajectoryGlasses] seg 0 (bounce 0/5): impact_angle=85.8, weapon_max_angle=70.0, is_valid=false, final_seg=false
+[06:38:59] [INFO] [TrajectoryGlasses] Deactivated! Charges remaining: 0/2
+[06:39:00] [INFO] [ReplayManager] Recording frame 1500 (25,0s): player_valid=True, enemies=5
+[06:39:00] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:39:00] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[06:39:01] [INFO] [ReplayManager] Recording frame 1560 (26,0s): player_valid=True, enemies=5
+[06:39:02] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[06:39:02] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[06:39:02] [INFO] [ReplayManager] Recording frame 1620 (27,0s): player_valid=True, enemies=5
+[06:39:02] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[06:39:02] [INFO] ------------------------------------------------------------
+[06:39:02] [INFO] GAME LOG ENDED: 2026-03-17T06:39:02
+[06:39:02] [INFO] ============================================================

--- a/scripts/effects/trajectory_glasses_effect.gd
+++ b/scripts/effects/trajectory_glasses_effect.gd
@@ -80,6 +80,9 @@ var _audio_player: AudioStreamPlayer = null
 ## Warning flash timer for the trajectory ray continuous blink phase (Issue #1085).
 var _warning_flash_timer: float = 0.0
 
+## Whether the continuous-blink phase has been logged this activation (Issue #1085).
+var _continuous_blink_logged: bool = false
+
 ## Whether the single-blink at 25% has already been triggered this activation (Issue #1085).
 var _single_blink_triggered: bool = false
 
@@ -197,6 +200,7 @@ func deactivate() -> void:
 	is_active = false
 	_effect_timer = 0.0
 	_warning_flash_timer = 0.0
+	_continuous_blink_logged = false
 	_single_blink_triggered = false
 	_single_blink_timer = 0.0
 	trajectory_ray_visible = true
@@ -244,13 +248,22 @@ func _process(delta: float) -> void:
 	# Because SINGLE_BLINK_THRESHOLD (2.5 s) < CONTINUOUS_BLINK_THRESHOLD (4 s),
 	# the single blink fires while continuous blinking is already active.
 	if _effect_timer <= CONTINUOUS_BLINK_THRESHOLD:
+		if not _continuous_blink_logged:
+			_continuous_blink_logged = true
+			FileLogger.info("[TrajectoryGlasses] Continuous blink phase started at %.2fs remaining (threshold=%.2fs, freq=%.1fHz)" % [
+				_effect_timer, CONTINUOUS_BLINK_THRESHOLD, WARNING_FLASH_FREQUENCY
+			])
 		# Trigger the one-shot single blink the first time we cross 25% (Issue #1085).
 		if _effect_timer <= SINGLE_BLINK_THRESHOLD and not _single_blink_triggered:
 			_single_blink_triggered = true
 			_single_blink_timer = 0.0
+			FileLogger.info("[TrajectoryGlasses] Single-blink triggered at %.2fs remaining (threshold=%.2fs)" % [
+				_effect_timer, SINGLE_BLINK_THRESHOLD
+			])
 
 		# During the single-blink window, override with a clean off→on half-period.
 		var single_blink_period := 1.0 / WARNING_FLASH_FREQUENCY
+		var prev_visible := trajectory_ray_visible
 		if _single_blink_triggered and _single_blink_timer < single_blink_period:
 			_single_blink_timer += delta
 			if _single_blink_timer < single_blink_period * 0.5:
@@ -262,9 +275,14 @@ func _process(delta: float) -> void:
 			_warning_flash_timer += delta
 			var flash_period := 1.0 / WARNING_FLASH_FREQUENCY
 			trajectory_ray_visible = fmod(_warning_flash_timer, flash_period) < (flash_period * 0.5)
+		if trajectory_ray_visible != prev_visible:
+			FileLogger.info("[TrajectoryGlasses] Blink state changed: ray_visible=%s at %.2fs remaining" % [
+				str(trajectory_ray_visible), _effect_timer
+			])
 	else:
 		# Normal phase: ray always visible, reset timers.
 		_warning_flash_timer = 0.0
+		_continuous_blink_logged = false
 		_single_blink_triggered = false
 		_single_blink_timer = 0.0
 		trajectory_ray_visible = true

--- a/tests/unit/test_trajectory_glasses.gd
+++ b/tests/unit/test_trajectory_glasses.gd
@@ -45,6 +45,9 @@ class MockTrajectoryGlassesEffect:
 	## Continuous-blink flash timer (Issue #1085).
 	var _warning_flash_timer: float = 0.0
 
+	## Whether the continuous-blink phase has been logged this activation (Issue #1085).
+	var _continuous_blink_logged: bool = false
+
 	## Whether the single-blink at 25% has been triggered this activation (Issue #1085).
 	var _single_blink_triggered: bool = false
 
@@ -80,6 +83,7 @@ class MockTrajectoryGlassesEffect:
 		is_active = false
 		_effect_timer = 0.0
 		_warning_flash_timer = 0.0
+		_continuous_blink_logged = false
 		_single_blink_triggered = false
 		_single_blink_timer = 0.0
 		trajectory_ray_visible = true
@@ -113,6 +117,7 @@ class MockTrajectoryGlassesEffect:
 		else:
 			# Normal phase
 			_warning_flash_timer = 0.0
+			_continuous_blink_logged = false
 			_single_blink_triggered = false
 			_single_blink_timer = 0.0
 			trajectory_ray_visible = true


### PR DESCRIPTION
## 🤖 AI-Powered Solution

Fixes Jhon-Crow/godot-topdown-MVP#1085

### Problem

The trajectory glasses ray blink warning was implemented in `trajectory_glasses_effect.gd` (GDScript) but **never appeared visually**. The GDScript controller correctly computed `trajectory_ray_visible` each frame, but `Player.cs::DrawTrajectoryGlasses()` (the active C# draw path) **never read that flag** — so the ray was drawn every frame regardless of blink state.

**Root cause confirmed by `game_log_20260317_063830.txt`** (attached in case study): two full 10-second activations with zero blink-related log entries.

### Solution

Added a single guard in `Player.cs::DrawTrajectoryGlasses()`:

```csharp
// Skip drawing during the "off" phase of the blink cycle (Issue #1085).
bool rayVisible = (bool)_trajectoryGlassesEffect.Get("trajectory_ray_visible");
if (!rayVisible)
{
    return;
}
```

This mirrors the equivalent check already present in `scripts/characters/player.gd:2840` (the legacy GDScript player path).

### Blink Timeline (unchanged)

| Remaining time | Ray behaviour |
|---|---|
| 10 s → 4 s | Solid, always visible |
| 4 s → 0 s | **Continuous blink** at 3 Hz |
| First frame ≤ 2.5 s | **Extra single blink** (ray off for one half-period, then returns to continuous blink) |
| 0 s | Ray disappears |

### Changed Files

- **`Scripts/Characters/Player.cs`** — add `trajectory_ray_visible` guard in `DrawTrajectoryGlasses()` (the actual fix)
- **`scripts/effects/trajectory_glasses_effect.gd`** — add log messages for blink phase start, state transitions, and single-blink trigger so future regressions are immediately visible in logs
- **`tests/unit/test_trajectory_glasses.gd`** — sync `_continuous_blink_logged` flag into mock class
- **`docs/case-studies/issue-1085/`** — full case study with root cause analysis, timeline, and attached game log

---
*This PR was created automatically by the AI issue solver*