### PR TITLE
fix: restore bullet spread for M16 assault rifle (Issue #1117)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-17T22:07:41.385Z for PR creation at branch issue-1117-ae4cb7d0a9c0 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1117


### PR DESCRIPTION
## Root Cause

In a prior commit (`4ddcca42` — "Make laser sight follow recoil pattern"), the `ApplySpread` method in `AssaultRifle.cs` was rewritten to sync the laser sight with the actual bullet trajectory. However, this accidentally removed the **per-bullet random spread** that made the M16 shoot with visible dispersion.

The old code:
```csharp
float randomSpread = (float)GD.RandRange(-spreadRadians / 2, spreadRadians / 2);
return direction.Rotated(randomSpread);
```

The new (broken) code only updated the recoil accumulator `_recoilOffset` without applying any random angle to the current bullet. Since `_recoilOffset` is clamped to ±5° and recovers quickly, the recoil drift was visually subtle — bullets appeared to fly without spread.

## Fix

Restore random spread per bullet while keeping the laser-recoil sync:

```csharp
// Apply random spread for this bullet so each shot has visible dispersion
float randomSpread = (float)GD.RandRange(-spreadRadians, spreadRadians);
result = result.Rotated(randomSpread * 0.5f);

// Also update recoil accumulator for the next shot (affects laser sight)
float recoilDirection = (float)GD.RandRange(-1.0, 1.0);
float recoilAmount = spreadRadians * Mathf.Abs(recoilDirection);
_recoilOffset += recoilDirection * recoilAmount * 0.5f;
_recoilOffset = Mathf.Clamp(_recoilOffset, -MaxRecoilOffset, MaxRecoilOffset);
```

This matches the pattern used by all other weapons with laser sights (Revolver, MakarovPM, SilencedPistol, AKGL) — all apply both recoil offset and random spread together.

## Behavior After Fix

- Each bullet gets a random angular deviation within `SpreadAngle` (2° for M16)
- The laser sight continues to show the accumulated recoil direction
- Laser and bullets remain reasonably aligned (laser shows where the recoil is drifting)
- Power Fantasy recoil multiplier still applies to reduce spread in that mode

Fixes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)