### PR TITLE
fix: set special items to 7 columns per row in armory menu

### DIFF
--- a/scripts/ui/armory_menu.gd
+++ b/scripts/ui/armory_menu.gd
@@ -98,7 +98,7 @@ const MAX_GRENADE_ROWS_COLLAPSED: int = 1
 const GRID_COLUMNS: int = 4
 
 ## Number of columns in the special items grid.
-const SPECIAL_GRID_COLUMNS: int = 8
+const SPECIAL_GRID_COLUMNS: int = 7
 
 ## Maximum number of visible active item rows before accordion hides the rest.
 const MAX_ACTIVE_ITEM_ROWS_COLLAPSED: int = 1


### PR DESCRIPTION
## Summary

Fixes #1147

The SPECIAL items section in the armory menu was displaying items with too many columns (originally 4, then 8), leaving empty space on the right side of the panel.

## Changes

- Set `SPECIAL_GRID_COLUMNS: int = 7` constant in `scripts/ui/armory_menu.gd` (reduced from 8 per owner feedback)
- `_active_item_grid.columns` uses `SPECIAL_GRID_COLUMNS`
- `max_visible_active_items` calculation uses `SPECIAL_GRID_COLUMNS` so the accordion collapse threshold scales correctly

## Before / After

**Before:** Special items with excess empty space to the right  
**After:** 7 special items per row, reducing empty space on the right side

## Test plan

- [ ] Open the armory menu in-game and navigate to the SPECIAL section
- [ ] Verify items are displayed 7 per row
- [ ] Verify the accordion collapse/expand still works correctly
- [ ] Verify weapons and grenades grids are unaffected (still 4 columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)