### PR TITLE
fix(#1220): fix enemy patrol wall-pressing and F7 debug FPS drop

### DIFF
--- a/docs/case-studies/issue-1220/game_log_20260321_001920.txt
+++ b/docs/case-studies/issue-1220/game_log_20260321_001920.txt
@@ -1,0 +1,240 @@
+[00:19:20] [INFO] ============================================================
+[00:19:20] [INFO] GAME LOG STARTED
+[00:19:20] [INFO] ============================================================
+[00:19:20] [INFO] Timestamp: 2026-03-21T00:19:20
+[00:19:20] [INFO] Log file: I:/Загрузки/godot exe/оптимизация/game_log_20260321_001920.txt
+[00:19:20] [INFO] Executable: I:/Загрузки/godot exe/оптимизация/Godot-Top-Down-Template.exe
+[00:19:20] [INFO] OS: Windows
+[00:19:20] [INFO] Debug build: false
+[00:19:20] [INFO] Engine version: 4.3-stable (official)
+[00:19:20] [INFO] Project: Godot Top-Down Template
+[00:19:20] [INFO] Build info: not available (build_info.cfg not found)
+[00:19:20] [INFO] ------------------------------------------------------------
+[00:19:20] [INFO] [GameManager] GameManager ready
+[00:19:20] [INFO] [ScoreManager] ScoreManager ready
+[00:19:20] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[00:19:20] [INFO] [DifficultyManager] Loaded difficulty: Hard (value: 2)
+[00:19:20] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[00:19:20] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[00:19:20] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[00:19:20] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[00:19:20] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[00:19:20] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[00:19:20] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[00:19:20] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[00:19:20] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[00:19:20] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[00:19:20] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[00:19:20] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[00:19:20] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[00:19:20] [INFO] [LastChance] Resetting all effects (scene change detected)
+[00:19:20] [INFO] [LastChance] Last chance shader loaded successfully
+[00:19:20] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[00:19:20] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[00:19:20] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[00:19:20] [INFO] [LastChance]   Sepia intensity: 0.70
+[00:19:20] [INFO] [LastChance]   Brightness: 0.60
+[00:19:20] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[00:19:20] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[00:19:20] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[00:19:20] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[00:19:20] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: true, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: true, FPS drop logging: true, All weapons unlocked: true, All maps unlocked: false, Global stuck max time: 20.0s, Nav mesh visible: true
+[00:19:20] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.29, music: 1.00
+[00:19:20] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true
+[00:19:20] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[00:19:20] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[00:19:20] [INFO] [CinemaEffects] Created effects layer at layer 99
+[00:19:20] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[00:19:20] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[00:19:20] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[00:19:20] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[00:19:20] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[00:19:20] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[00:19:20] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[00:19:20] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[00:19:20] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[00:19:20] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[00:19:20] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[00:19:20] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[00:19:20] [INFO] [GrenadeTimerHelper] Autoload ready
+[00:19:20] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[00:19:20] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[00:19:20] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[00:19:20] [INFO] [PowerFantasy]   Kill effect duration: 300ms
+[00:19:20] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[00:19:20] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[00:19:20] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[00:19:20] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[00:19:20] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[00:19:20] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[00:19:20] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[00:19:20] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[00:19:20] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[00:19:20] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[00:19:20] [INFO] [ProgressManager] ProgressManager ready, loaded 45 entries
+[00:19:20] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[00:19:20] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[00:19:20] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[00:19:20] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[00:19:20] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[00:19:20] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[00:19:20] [INFO] [SceneLoader] SceneLoader initialized
+[00:19:20] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[00:19:20] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[00:19:20] [INFO] [PersistManager] Restored unlocked weapon: m16
+[00:19:20] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[00:19:20] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[00:19:20] [INFO] [PersistManager] Restored kills_without_laser_sight: 0
+[00:19:20] [INFO] [GameManager] Weapon selected: makarov_pm
+[00:19:20] [INFO] [PersistManager] Restored selected weapon: makarov_pm
+[00:19:20] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[00:19:20] [INFO] [PersistManager] Restored unlocked grenade type: 1
+[00:19:20] [INFO] [PersistManager] Restored unlocked grenade type: 2
+[00:19:20] [INFO] [PersistManager] Restored unlocked grenade type: 3
+[00:19:20] [INFO] [PersistManager] Restored selected grenade type: 0
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 0
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 2
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 4
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 5
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 6
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 7
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 8
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 10
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 11
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 12
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 13
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 14
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 15
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 16
+[00:19:20] [INFO] [PersistManager] Restored unlocked active item type: 17
+[00:19:20] [INFO] [PersistManager] Restored selected active item type: 0
+[00:19:20] [INFO] [PersistManager] Loudspeaker progress restored: level 1, levels_completed=0
+[00:19:20] [INFO] [PersistManager] State loaded successfully
+[00:19:20] [INFO] [PersistManager] PersistManager ready
+[00:19:20] [INFO] [UnlockManager] UnlockManager ready
+[00:19:20] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["m16", "makarov_pm", "ak_gl", "shotgun", "revolver", "mini_uzi", "sniper"]
+[00:19:20] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, ai: true
+[00:19:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[00:19:20] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[00:19:20] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[00:19:20] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[00:19:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[00:19:20] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[00:19:20] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[00:19:20] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[00:19:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[00:19:20] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[00:19:20] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[00:19:20] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[00:19:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[00:19:20] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[00:19:20] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[00:19:20] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[00:19:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[00:19:20] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[00:19:20] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[00:19:20] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[00:19:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[00:19:20] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[00:19:20] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[00:19:20] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[00:19:20] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[00:19:20] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[00:19:20] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[00:19:20] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[00:19:20] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[00:19:20] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[00:19:20] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[00:19:20] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[00:19:20] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[00:19:20] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[00:19:20] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[00:19:20] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[00:19:20] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[00:19:20] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[00:19:20] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[00:19:20] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[00:19:20] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[00:19:20] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[00:19:20] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[00:19:20] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[00:19:20] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[00:19:20] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[00:19:20] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[00:19:20] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[00:19:20] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[00:19:20] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[00:19:20] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[00:19:20] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[00:19:20] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[00:19:20] [INFO] [Player.Jammer] JammerHUD initialized
+[00:19:20] [INFO] [Player] Ready! Ammo: 9/9, Grenades: 1/3, Health: 3/4
+[00:19:20] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[00:19:20] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[00:19:20] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[00:19:20] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=false
+[00:19:20] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=false
+[00:19:20] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=false
+[00:19:20] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=false
+[00:19:20] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=false
+[00:19:20] [INFO] [LabyrinthLevel] Enemy tracking complete: 0 enemies registered
+[00:19:20] [INFO] [LabyrinthLevel] Setting up weapon: makarov_pm
+[00:19:20] [INFO] [ScoreManager] Level started with 0 enemies
+[00:19:20] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[00:19:21] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[00:19:21] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 0
+[00:19:21] [INFO] [LabyrinthLevel] WARNING: No enemies to track in replay
+[00:19:21] [INFO] [ReplayManager] Replay data cleared
+[00:19:21] [INFO] [LabyrinthLevel] Previous replay data cleared
+[00:19:21] [INFO] [ReplayManager] Detected player weapon: Makarov PM
+[00:19:21] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[00:19:21] [INFO] [ReplayManager] Level: LabyrinthLevel
+[00:19:21] [INFO] [ReplayManager] Player: Player (valid: True)
+[00:19:21] [INFO] [ReplayManager] Enemies count: 0
+[00:19:21] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/makarov_pm_topdown.png
+[00:19:21] [INFO] [LabyrinthLevel] Replay recording started successfully
+[00:19:21] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=0
+[00:19:21] [INFO] [CinemaEffects] Found player node: Player
+[00:19:21] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[00:19:21] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/BuildingLevel.tscn
+[00:19:21] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/BuildingLevel.tscn
+[00:19:21] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[00:19:21] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[00:19:21] [INFO] [UnlockManager] Restored saved unlock for weapon: ak_gl
+[00:19:21] [INFO] [UnlockManager] Restored saved unlock for grenade type: 1
+[00:19:21] [INFO] [UnlockManager] Restored saved unlock for grenade type: 2
+[00:19:21] [INFO] [UnlockManager] Restored saved unlock for active item type: 5
+[00:19:21] [INFO] [UnlockManager] Restored saved unlock for active item type: 2
+[00:19:21] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[00:19:21] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[00:19:21] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[00:19:21] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[00:19:21] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[00:19:21] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[00:19:21] [INFO] [Player] Detecting weapon pose (frame 3)...
+[00:19:21] [INFO] [Player] Detected weapon: Makarov PM (Pistol pose)
+[00:19:21] [INFO] [Player] Applied Pistol arm pose: Left=(16, 6), Right=(4, 6)
+[00:19:21] [INFO] [PenultimateHit] Shader warmup complete in 1055 ms
+[00:19:21] [INFO] [LastChance] Shader warmup complete in 1054 ms
+[00:19:21] [INFO] [CinemaEffects] Cinema shader warmup complete in 921 ms
+[00:19:21] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 912 ms
+[00:19:21] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[00:19:21] [INFO] [FlashbangPlayer] Shader warmup complete in 908 ms
+[00:19:21] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[00:19:21] [INFO] [SceneLoader] ERROR: Invalid resource: res://scenes/levels/BuildingLevel.tscn
+[00:19:21] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 1343 ms
+[00:19:21] [INFO] [SceneLoader] Background load started successfully
+[00:19:22] [WARN] [FPS] Drop detected: 27 fps (threshold: 30)
+[00:19:22] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=0
+[00:19:23] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=0
+[00:19:24] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=0
+[00:19:25] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=0
+[00:19:26] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=0
+[00:19:27] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=0
+[00:19:28] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=0
+[00:19:29] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=0
+[00:19:30] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=0
+[00:19:31] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=0
+[00:19:31] [INFO] ------------------------------------------------------------
+[00:19:31] [INFO] GAME LOG ENDED: 2026-03-21T00:19:31
+[00:19:31] [INFO] ============================================================

--- a/scripts/objects/enemy.gd
+++ b/scripts/objects/enemy.gd
@@ -254,6 +254,7 @@ var _global_stuck_timer: float = 0.0; var _global_stuck_last_position: Vector2 =
 const GLOBAL_STUCK_MAX_TIME: float = 4.0; const GLOBAL_STUCK_DISTANCE_THRESHOLD: float = 30.0  ## Max stuck time / min move distance  ## Issue #1173: restored 1.5→4.0; machete wall-escape is handled by MACHETE_COMBAT_STUCK_MAX_TIME
 var _machete_combat_stuck_timer: float = 0.0; var _machete_combat_stuck_last_pos: Vector2 = Vector2.ZERO  ## Issue #1107: Stuck detection for machete COMBAT state
 const MACHETE_COMBAT_STUCK_MAX_TIME: float = 0.8; const MACHETE_COMBAT_STUCK_DIST_THRESHOLD: float = 20.0  ## Reroute after 0.8s stuck within 20px
+var _debug_draw_timer: float = 0.0; const DEBUG_DRAW_INTERVAL: float = 0.1  ## Issue #1220: throttle F7 debug redraw to 10 Hz to reduce FOV raycast overhead
 var _assault_wait_timer: float = 0.0; const ASSAULT_WAIT_DURATION: float = 5.0  ## Assault wait timer / pre-assault wait (sec)
 var _assault_ready: bool = false; var _in_assault: bool = false  ## Assault wait complete / in assault flag
 var _search_center: Vector2 = Vector2.ZERO; var _search_radius: float = 100.0  ## Search center / current radius (Search State - Issue #322)
@@ -843,13 +844,16 @@ func _physics_process(delta: float) -> void:
 	if _waiting_for_grenadier:  # Issue #604: Skip AI while waiting
 		velocity = Vector2.ZERO; _update_debug_label(); _update_walk_animation(delta)
 		_apply_machete_attack_animation(); move_and_slide(); _push_casings()
-		if debug_label_enabled: queue_redraw()
+		if debug_label_enabled:
+			_debug_draw_timer += delta
+			if _debug_draw_timer >= DEBUG_DRAW_INTERVAL: _debug_draw_timer = 0.0; queue_redraw()  # Issue #1220: throttle to 10 Hz
 		return
 	_process_ai_state(delta)
 
 	_update_debug_label()
-	if debug_label_enabled:  # Request redraw for debug visualization
-		queue_redraw()
+	if debug_label_enabled:  # Issue #1220: throttle FOV cone redraws to 10 Hz (was every frame → 33 raycasts/enemy/frame at 60 fps)
+		_debug_draw_timer += delta
+		if _debug_draw_timer >= DEBUG_DRAW_INTERVAL: _debug_draw_timer = 0.0; queue_redraw()
 
 	_update_walk_animation(delta)  # Update walking animation based on movement
 	_apply_machete_attack_animation()  # Issue #595: machete swing animation
@@ -4064,12 +4068,12 @@ func _process_patrol(delta: float) -> void:
 	if _nav_agent == null:  # Fallback if nav agent unavailable
 		if global_position.distance_to(target_point) < 5.0: _is_waiting_at_patrol_point = true; velocity = Vector2.ZERO; return
 		var d := (target_point - global_position).normalized(); velocity = d * move_speed; rotation = d.angle(); return
-	_nav_agent.target_position = target_point
-	if _nav_agent.is_navigation_finished():
+	# Issue #1220: use _move_to_target_nav so patrol gets the same wall-avoidance + ORCA +
+	# slide-collision corner-escape used by PURSUING/FLANKING, preventing wall-pressing.
+	if not _move_to_target_nav(target_point, move_speed):
 		_is_waiting_at_patrol_point = true; _patrol_stuck_timer = 0.0; _patrol_stuck_last_position = global_position; velocity = Vector2.ZERO; return
-	var dir := (_nav_agent.get_next_path_position() - global_position).normalized()
-	velocity = dir * move_speed; move_and_slide(); _push_casings()
-	if dir.length() > 0.1: rotation = lerp_angle(rotation, dir.angle(), 5.0 * delta); _process_corner_check(delta, dir, "PATROL")
+	var dir := velocity.normalized()
+	if dir.length() > 0.1: _process_corner_check(delta, dir, "PATROL")
 	var moved := global_position.distance_to(_patrol_stuck_last_position)  # Stuck detection
 	if moved < PATROL_STUCK_DISTANCE_THRESHOLD:
 		_patrol_stuck_timer += delta


### PR DESCRIPTION
Fixes Jhon-Crow/godot-topdown-MVP#1220

Fresh implementation from main based on game log analysis.

---

## Fix 1: Enemy patrol wall-pressing (`scripts/objects/enemy.gd`)

**Root cause:** `_process_patrol` used raw NavigationAgent2D direction without the
slide-collision corner-escape and wall-avoidance logic present in `_move_to_target_nav`.
When nav mesh polygon edges terminated near physics walls, enemies pressed into the wall
and triggered the 1.5 s stuck-skip, then returned to the same stuck spot on the next circuit.

**Evidence from game logs (Jhon-Crow, 2026-03-20):**
```
[Enemy10] PATROL STUCK: pos=(1200, 1601.992) for 1.5s, skipping
[Enemy10] PATROL STUCK: pos=(1200, 1424.01) for 1.5s, skipping   ← same wall, next circuit
[Enemy7]  PATROL STUCK: pos=(1611.34, 898.8732) for 1.5s, skipping
```

**Fix:** Replace the manual nav block in `_process_patrol` with `_move_to_target_nav()`,
which adds ORCA avoidance + wall-avoidance + slide-collision corner-escape (same as
PURSUING/FLANKING states). Also removes the duplicate `move_and_slide()`/`_push_casings()`
calls that `_physics_process` already handles.

---

## Fix 2: F7 debug display FPS drop (`scripts/objects/enemy.gd`)

**Root cause:** `queue_redraw()` was called every physics frame when `debug_label_enabled`,
triggering `_draw_fov_cone()` which fires 33 raycasts per enemy per frame. With 10 enemies
at 60 fps that is ~20 000 debug-only raycasts/second.

**Fix:** Throttle `queue_redraw()` to 10 Hz (every 0.1 s) via `_debug_draw_timer`. FOV cone
appearance is unchanged — just updated 10× per second instead of 60×.

---

## Behaviour preservation

- Patrol waypoints, wait times, and stuck-skip logic are all unchanged.
- `_move_to_target_nav` sets `rotation = velocity.angle()` internally, so rotation is still updated.
- `_process_corner_check` is still called during patrol with the same direction.
- Debug FOV cone appearance is identical — same 33 raycasts, just throttled redraw rate.