### PR TITLE
fix(#1275): filter search waypoints that require crossing walls

### DIFF
--- a/docs/case-studies/issue-1275/README.md
+++ b/docs/case-studies/issue-1275/README.md
@@ -132,6 +132,93 @@ on the nav mesh (so the spiral doesn't cross walls on the spiral-tracking level 
 
 ---
 
+## Follow-up: Second Root Cause Found (PR #1276 owner feedback)
+
+After PR #1276 was opened, the repository owner tested the fix and reported:
+
+> "enemies still go towards walls during searching — a zone should only be counted as
+> visited when the enemy model actually touches it."
+
+**Game log:** `game_log_20260321_143638.txt` (attached in this folder).
+
+Key excerpt from the log showing the problem:
+```
+[14:37:13] [ENEMY] [Enemy1] SEARCHING: Stuck at wp 0, skipping
+[14:37:15] [ENEMY] [Enemy1] SEARCHING: Stuck at wp 1, skipping
+...
+[14:37:18] [ENEMY] [Enemy3] SEARCHING: Expand outer ring r=175 wps=4
+```
+
+Enemies repeatedly get stuck at waypoints and skip them. Because the old code called
+`_mark_zone_visited(target_waypoint)` **even when skipping due to stuck** (Issue #354 code)
+and **even when `NavigationAgent.is_navigation_finished()` fired prematurely** (enemy not close
+to the waypoint), zones were being incorrectly marked as visited. This caused:
+
+1. Zones near walls that the nav agent couldn't reach precisely were marked visited.
+2. Those zones were excluded from future spiral ring generation.
+3. The spiral kept expanding outward without revisiting the unreachable-but-nearby zones.
+4. Enemies walked toward wall-adjacent waypoints they couldn't actually reach.
+
+### Second Root Cause
+
+In `_process_searching_state()` (`scripts/objects/enemy.gd`):
+
+```gdscript
+# OLD (broken): marks visited even when enemy never touched the waypoint
+if _nav_agent.is_navigation_finished():
+    _mark_zone_visited(target_waypoint)  # ← wrong: nav finished ≠ enemy arrived
+    _search_current_waypoint_index += 1; ...
+
+if _search_stuck_timer >= SEARCH_STUCK_MAX_TIME:
+    _mark_zone_visited(target_waypoint)  # ← wrong: stuck ≠ enemy arrived
+    _search_current_waypoint_index += 1; ...
+```
+
+### Second Fix
+
+Remove `_mark_zone_visited()` from the stuck-skip path and the nav-finished-prematurely path.
+A zone is marked visited **only** after the enemy physically arrives (distance ≤ 20 px)
+and completes the scan timer:
+
+```gdscript
+# NEW (correct): only mark visited after physical arrival + scan
+if _nav_agent.is_navigation_finished():
+    # Skip without marking visited — nav done ≠ physically touched
+    _search_current_waypoint_index += 1; ...
+
+if _search_stuck_timer >= SEARCH_STUCK_MAX_TIME:
+    # Skip without marking visited — stuck ≠ physically touched
+    _search_current_waypoint_index += 1; ...
+
+# ... later, after scan completes (enemy WAS close enough to start scanning):
+if _search_scan_timer >= SEARCH_SCAN_DURATION:
+    _mark_zone_visited(target_waypoint)  # ← correct: enemy physically scanned the zone
+```
+
+This matches the owner's stated requirement: **a point is visited only when the enemy
+model touches it.**
+
+---
+
+## Files Changed (complete)
+
+- `scripts/objects/enemy.gd`:
+  - Added `_is_path_navigable(from_pos, to_pos)` helper (beside `_is_waypoint_navigable`)
+  - Modified `_generate_search_waypoints()` to validate path connectivity per waypoint
+  - Ensured `current_pos` advance in spiral only moves to nav-mesh points
+  - Fixed `_process_searching_state()`: removed `_mark_zone_visited()` from stuck-skip
+    and nav-finished-prematurely paths (Issue #1275 owner feedback)
+
+- `tests/unit/test_search_path_wall_awareness.gd`:
+  - Unit tests for path-connectivity filtering (original fix)
+  - Unit tests for visited-zone marking logic: stuck skip, nav-finished-early, and
+    physical-arrival scenarios (second fix)
+
+- `docs/case-studies/issue-1275/game_log_20260321_143638.txt`:
+  - Game log from owner's test session showing enemies stuck during SEARCHING
+
+---
+
 ## References
 
 - Godot 4 NavigationServer2D docs: `map_get_path` returns `PackedVector2Array`

--- a/docs/case-studies/issue-1275/game_log_20260321_143638.txt
+++ b/docs/case-studies/issue-1275/game_log_20260321_143638.txt
@@ -1,0 +1,2334 @@
+[14:36:38] [INFO] ============================================================
+[14:36:38] [INFO] GAME LOG STARTED
+[14:36:38] [INFO] ============================================================
+[14:36:38] [INFO] Timestamp: 2026-03-21T14:36:38
+[14:36:38] [INFO] Log file: I:/Загрузки/godot exe/поиск/game_log_20260321_143638.txt
+[14:36:38] [INFO] Executable: I:/Загрузки/godot exe/поиск/Godot-Top-Down-Template.exe
+[14:36:38] [INFO] OS: Windows
+[14:36:38] [INFO] Debug build: false
+[14:36:38] [INFO] Engine version: 4.3-stable (official)
+[14:36:38] [INFO] Project: Godot Top-Down Template
+[14:36:38] [INFO] Build info: not available (build_info.cfg not found)
+[14:36:38] [INFO] ------------------------------------------------------------
+[14:36:38] [INFO] [GameManager] GameManager ready
+[14:36:38] [INFO] [ScoreManager] ScoreManager ready
+[14:36:38] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[14:36:38] [INFO] [DifficultyManager] Loaded difficulty: Easy (value: 0)
+[14:36:38] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[14:36:38] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[14:36:38] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[14:36:38] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[14:36:38] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[14:36:38] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[14:36:38] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[14:36:38] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[14:36:38] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[14:36:38] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[14:36:38] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[14:36:38] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[14:36:38] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[14:36:38] [INFO] [LastChance] Resetting all effects (scene change detected)
+[14:36:38] [INFO] [LastChance] Last chance shader loaded successfully
+[14:36:38] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[14:36:38] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[14:36:38] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[14:36:38] [INFO] [LastChance]   Sepia intensity: 0.70
+[14:36:38] [INFO] [LastChance]   Brightness: 0.60
+[14:36:38] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[14:36:38] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[14:36:38] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[14:36:38] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[14:36:38] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: true, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: true, FPS drop logging: true, All weapons unlocked: true, All maps unlocked: true, Global stuck max time: 3.0s, Nav mesh visible: true, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false
+[14:36:38] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[14:36:38] [INFO] [NavMeshMonitor] Overlay node created
+[14:36:38] [INFO] [NavMeshMonitor] refresh started: found 1 NavigationRegion2D node(s)
+[14:36:38] [INFO] [NavMeshMonitor] refresh: region 'NavigationRegion2D' poly_count=1 vertex_count=4 outline_count=1
+[14:36:38] [INFO] [NavMeshMonitor] refresh done: 1 region(s), 1 baked poly(s), 0 outline(s), 1 draw polys
+[14:36:38] [INFO] [NavMeshMonitor] Overlay shown with 1 polygon(s)
+[14:36:38] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.29, music: 1.00
+[14:36:38] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true
+[14:36:38] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[14:36:38] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[14:36:38] [INFO] [CinemaEffects] Created effects layer at layer 99
+[14:36:38] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[14:36:38] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[14:36:38] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[14:36:38] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[14:36:38] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[14:36:38] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[14:36:38] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[14:36:38] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[14:36:38] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[14:36:38] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[14:36:38] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[14:36:38] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[14:36:38] [INFO] [GrenadeTimerHelper] Autoload ready
+[14:36:38] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[14:36:38] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[14:36:38] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[14:36:38] [INFO] [PowerFantasy]   Kill effect duration: 300ms
+[14:36:38] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[14:36:38] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[14:36:38] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[14:36:38] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[14:36:38] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[14:36:38] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[14:36:38] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[14:36:38] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[14:36:38] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[14:36:38] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[14:36:38] [INFO] [ProgressManager] ProgressManager ready, loaded 1 entries
+[14:36:38] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[14:36:38] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[14:36:38] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[14:36:38] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[14:36:38] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[14:36:38] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[14:36:38] [INFO] [SceneLoader] SceneLoader initialized
+[14:36:38] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[14:36:38] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[14:36:38] [INFO] [PersistManager] Restored unlocked weapon: m16
+[14:36:38] [INFO] [PersistManager] Restored unlocked weapon: mini_uzi
+[14:36:38] [INFO] [PersistManager] Restored kills_without_laser_sight: 16
+[14:36:38] [INFO] [GameManager] Weapon selected: m16
+[14:36:38] [INFO] [PersistManager] Restored selected weapon: m16
+[14:36:38] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[14:36:38] [INFO] [PersistManager] Restored unlocked grenade type: 3
+[14:36:38] [INFO] [PersistManager] Restored selected grenade type: 0
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 0
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 4
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 6
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 7
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 8
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 10
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 11
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 12
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 13
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 14
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 15
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 16
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 17
+[14:36:38] [INFO] [PersistManager] Restored unlocked active item type: 18
+[14:36:38] [INFO] [ActiveItemManager] Active item changed from None to Invisibility
+[14:36:38] [INFO] [PersistManager] Restored selected active item type: 5
+[14:36:38] [INFO] [PersistManager] Loudspeaker progress restored: level 1, levels_completed=0
+[14:36:38] [INFO] [PersistManager] State loaded successfully
+[14:36:38] [INFO] [PersistManager] PersistManager ready
+[14:36:38] [INFO] [UnlockManager] UnlockManager ready
+[14:36:38] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["m16", "makarov_pm", "ak_gl", "shotgun", "mini_uzi", "sniper", "revolver"]
+[14:36:38] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, ai: true
+[14:36:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:38] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[14:36:38] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[14:36:38] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[14:36:38] [ENEMY] [Enemy1] Death animation component initialized
+[14:36:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:38] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[14:36:38] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[14:36:38] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[14:36:38] [ENEMY] [Enemy2] Death animation component initialized
+[14:36:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:38] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[14:36:38] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[14:36:38] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[14:36:38] [ENEMY] [Enemy3] Death animation component initialized
+[14:36:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:38] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[14:36:38] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[14:36:38] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[14:36:38] [ENEMY] [Enemy4] Death animation component initialized
+[14:36:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:38] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[14:36:38] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[14:36:38] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[14:36:38] [ENEMY] [Enemy5] Death animation component initialized
+[14:36:38] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:38] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[14:36:38] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[14:36:38] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[14:36:38] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[14:36:38] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[14:36:38] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[14:36:38] [INFO] [Player.Weapon] Removed default MakarovPM
+[14:36:38] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[14:36:38] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[14:36:38] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[14:36:38] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[14:36:38] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[14:36:38] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[14:36:38] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[14:36:38] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[14:36:38] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[14:36:38] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[14:36:38] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[14:36:38] [INFO] [Player.InvisibilitySuit] Invisibility suit is selected, initializing...
+[14:36:38] [INFO] [InvisibilitySuit] Shader loaded successfully
+[14:36:38] [INFO] [InvisibilitySuit] Activation sound loaded
+[14:36:38] [INFO] [InvisibilitySuit] Deactivation sound loaded
+[14:36:38] [INFO] [InvisibilitySuit] Initialized with player: Player, charges: 2/2
+[14:36:38] [INFO] [Player.InvisibilitySuit] Invisibility suit equipped, charges: 2
+[14:36:38] [INFO] [Player.InvisibilitySuit] Charge bar created
+[14:36:38] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[14:36:38] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[14:36:38] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[14:36:38] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[14:36:38] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[14:36:38] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[14:36:38] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[14:36:38] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[14:36:38] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[14:36:38] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[14:36:38] [INFO] [Player.ItemVisual] Visual applied for item type: 5
+[14:36:38] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[14:36:38] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[14:36:38] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[14:36:38] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[14:36:38] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[14:36:38] [INFO] [Player.Jammer] JammerHUD initialized
+[14:36:38] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[14:36:38] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[14:36:39] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[14:36:39] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[14:36:39] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[14:36:39] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[14:36:39] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[14:36:39] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[14:36:39] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[14:36:39] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[14:36:39] [INFO] [LabyrinthLevel] Setting up weapon: m16
+[14:36:39] [INFO] [LabyrinthLevel] AssaultRifle already equipped by C# Player - skipping GDScript weapon swap
+[14:36:39] [INFO] [ScoreManager] Level started with 5 enemies
+[14:36:39] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[14:36:39] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[14:36:39] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[14:36:39] [INFO] [ReplayManager] Replay data cleared
+[14:36:39] [INFO] [LabyrinthLevel] Previous replay data cleared
+[14:36:39] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[14:36:39] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[14:36:39] [INFO] [ReplayManager] Level: LabyrinthLevel
+[14:36:39] [INFO] [ReplayManager] Player: Player (valid: True)
+[14:36:39] [INFO] [ReplayManager] Enemies count: 5
+[14:36:39] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[14:36:39] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[14:36:39] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[14:36:39] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[14:36:39] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[14:36:39] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[14:36:39] [INFO] [LabyrinthLevel] Replay recording started successfully
+[14:36:39] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[14:36:39] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[14:36:39] [INFO] [CinemaEffects] Found player node: Player
+[14:36:39] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[14:36:39] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/BuildingLevel.tscn
+[14:36:39] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/BuildingLevel.tscn
+[14:36:39] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[14:36:39] [INFO] [UnlockManager] Restored saved unlock for weapon: mini_uzi
+[14:36:39] [INFO] [UnlockManager] Skipped restore for weapon 'silenced_pistol' (condition not met — treating as corrupt save)
+[14:36:39] [INFO] [UnlockManager] Skipped restore for weapon 'ak_gl' (condition not met — treating as corrupt save)
+[14:36:39] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[14:36:39] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[14:36:39] [ENEMY] [Enemy1] Registered as sound listener
+[14:36:39] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[14:36:39] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[14:36:39] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[14:36:39] [ENEMY] [Enemy2] Registered as sound listener
+[14:36:39] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[14:36:39] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[14:36:39] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[14:36:39] [ENEMY] [Enemy3] Registered as sound listener
+[14:36:39] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 2, behavior: PATROL
+[14:36:39] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[14:36:39] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[14:36:39] [ENEMY] [Enemy4] Registered as sound listener
+[14:36:39] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 2, behavior: GUARD
+[14:36:39] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[14:36:39] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[14:36:39] [ENEMY] [Enemy5] Registered as sound listener
+[14:36:39] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 2, behavior: GUARD
+[14:36:39] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[14:36:39] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[14:36:39] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[14:36:39] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[14:36:39] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[14:36:39] [INFO] [Player] Detecting weapon pose (frame 3)...
+[14:36:39] [INFO] [Player] Detected weapon: Rifle (default pose)
+[14:36:39] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[14:36:39] [INFO] [PenultimateHit] Shader warmup complete in 1124 ms
+[14:36:39] [INFO] [LastChance] Shader warmup complete in 1123 ms
+[14:36:39] [INFO] [CinemaEffects] Cinema shader warmup complete in 1032 ms
+[14:36:39] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1024 ms
+[14:36:39] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[14:36:39] [INFO] [FlashbangPlayer] Shader warmup complete in 1020 ms
+[14:36:39] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[14:36:39] [INFO] [SceneLoader] ERROR: Invalid resource: res://scenes/levels/BuildingLevel.tscn
+[14:36:40] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 1546 ms
+[14:36:40] [INFO] [SceneLoader] Background load started successfully
+[14:36:40] [WARN] [FPS] Drop detected: 16 fps (threshold: 30)
+[14:36:40] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[14:36:41] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[14:36:42] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[14:36:43] [INFO] [Player.Debug] Debug mode toggled: ON
+[14:36:43] [INFO] [Player] Invincibility mode: ON
+[14:36:43] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[14:36:44] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=5
+[14:36:45] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=5
+[14:36:46] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=5
+[14:36:47] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=5
+[14:36:48] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=5
+[14:36:49] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=5
+[14:36:50] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=5
+[14:36:51] [INFO] [ReplayManager] Recording frame 720 (12,0s): player_valid=True, enemies=5
+[14:36:52] [INFO] [ReplayManager] Recording frame 780 (13,0s): player_valid=True, enemies=5
+[14:36:53] [INFO] [ReplayManager] Recording frame 840 (14,0s): player_valid=True, enemies=5
+[14:36:54] [INFO] [ReplayManager] Recording frame 900 (15,0s): player_valid=True, enemies=5
+[14:36:55] [INFO] [ReplayManager] Recording frame 960 (16,0s): player_valid=True, enemies=5
+[14:36:56] [INFO] [ReplayManager] Recording frame 1020 (17,0s): player_valid=True, enemies=5
+[14:36:57] [INFO] [ReplayManager] Recording frame 1080 (18,0s): player_valid=True, enemies=5
+[14:36:58] [INFO] [ReplayManager] Recording frame 1140 (19,0s): player_valid=True, enemies=5
+[14:36:59] [INFO] [ReplayManager] Recording frame 1200 (20,0s): player_valid=True, enemies=5
+[14:37:00] [INFO] [ReplayManager] Recording frame 1260 (21,0s): player_valid=True, enemies=5
+[14:37:01] [INFO] [ReplayManager] Recording frame 1320 (22,0s): player_valid=True, enemies=5
+[14:37:02] [INFO] [ReplayManager] Recording frame 1380 (23,0s): player_valid=True, enemies=5
+[14:37:03] [INFO] [ReplayManager] Recording frame 1440 (24,0s): player_valid=True, enemies=5
+[14:37:04] [INFO] [ReplayManager] Recording frame 1500 (25,0s): player_valid=True, enemies=5
+[14:37:05] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[14:37:05] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=-0.0°, player=(150,1000), corner_timer=0.30
+[14:37:05] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(150, 1000), source=PLAYER (AssaultRifle), range=1469, listeners=5
+[14:37:05] [ENEMY] [Enemy1] Heard gunshot at (150, 1000), intensity=0.00, distance=743
+[14:37:05] [ENEMY] [Enemy2] Heard gunshot at (150, 1000), intensity=0.00, distance=752
+[14:37:05] [ENEMY] [Enemy3] Heard gunshot at (150, 1000), intensity=0.00, distance=1083
+[14:37:05] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=2, self=0
+[14:37:05] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=109.7°, current=101.3°, player=(150,1000), corner_timer=0.00
+[14:37:05] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=176.2°, current=-22.5°, player=(150,1000), corner_timer=0.00
+[14:37:05] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P2:combat_state, state=COMBAT, target=180.0°, current=-22.9°, player=(150,1000), corner_timer=0.17
+[14:37:05] [INFO] [ReplayManager] Recording frame 1560 (26,0s): player_valid=True, enemies=5
+[14:37:05] [ENEMY] [Enemy2] Hit: dmg=1, hp=1/1->0/1
+[14:37:05] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[14:37:05] [ENEMY] [Enemy2] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[14:37:05] [INFO] [GameManager] register_kill: laser sight active — kill not counted toward unlock condition
+[14:37:05] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[14:37:05] [ENEMY] [Enemy2] [AllyDeath] Notified 1 enemies
+[14:37:05] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 4)
+[14:37:05] [INFO] [DeathAnim] Started - Angle: -7.4 deg, Index: 11
+[14:37:05] [ENEMY] [Enemy2] Death animation started with hit direction: (0.991559, -0.129658)
+[14:37:06] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[14:37:06] [ENEMY] [Enemy3] State: COMBAT -> PURSUING
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (907.6504, 938.9194) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (902.8063, 943.9175) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (874.5094, 934.9974) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (918.7399, 953.8466) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (888.9153, 979.5402) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (884.6187, 938.0096) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (902.6824, 971.5297) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (873.0479, 937.8373) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (880.9701, 984.2914) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (957.5035, 968.278) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (930.7951, 963.2421) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (927.1882, 937.9129) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (915.1826, 988.9902) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (963.795, 940.5841) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (919.787, 962.1313) (added to group)
+[14:37:06] [ENEMY] [Enemy2] Ragdoll activated
+[14:37:06] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (907.4418, 941.1686) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (901.2609, 953.0439) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (986.3888, 1061.186) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (947.4752, 978.4501) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (966.6603, 1052.299) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (998.0181, 1071.346) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (912.3445, 970.9786) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (982.5051, 973.9415) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (966.1962, 956.6028) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (954.9267, 975.4969) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (991.9757, 929.1113) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (970.7971, 1093.838) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (1049.741, 1075.294) (added to group)
+[14:37:06] [INFO] [BloodDecal] Blood puddle created at (978.316, 1032.91) (added to group)
+[14:37:06] [INFO] [ReplayManager] Recording frame 1620 (26,8s): player_valid=True, enemies=5
+[14:37:07] [ENEMY] [Enemy2] Death animation completed
+[14:37:07] [INFO] [ReplayManager] Recording frame 1680 (27,6s): player_valid=True, enemies=5
+[14:37:08] [ENEMY] [Enemy1] Warning: No valid flank position (both sides behind walls)
+[14:37:08] [ENEMY] [Enemy1] FLANKING started: target=(142.5609, 888.6051), side=left, pos=(345.4688, 452.6876)
+[14:37:08] [ENEMY] [Enemy1] State: PURSUING -> FLANKING
+[14:37:08] [ENEMY] [Enemy1] FLANKING corner check: angle 25.0°
+[14:37:08] [ENEMY] [Enemy3] PURSUING corner check: angle -77.1°
+[14:37:08] [INFO] [BloodyFeet:Enemy3] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[14:37:08] [ENEMY] [Enemy1] FLANKING corner check: angle -156.8°
+[14:37:08] [ENEMY] [Enemy3] PURSUING corner check: angle 102.9°
+[14:37:08] [INFO] [ReplayManager] Recording frame 1740 (28,4s): player_valid=True, enemies=5
+[14:37:08] [ENEMY] [Enemy1] FLANKING corner check: angle -160.1°
+[14:37:09] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=81.1°, current=81.5°, player=(308,1000), corner_timer=0.13
+[14:37:09] [ENEMY] [Enemy1] State: FLANKING -> COMBAT
+[14:37:09] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(253.1827, 745.531), source=ENEMY (Enemy1), range=800, listeners=4
+[14:37:09] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=2, self=1
+[14:37:09] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[14:37:09] [INFO] [Player] Spawning blood effect at (308.66653, 1000.3333), dir=(1, 0), lethal=False (C#)
+[14:37:09] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:09] [INFO] [BloodDecal] Blood puddle created at (337, 1000.333) (added to group)
+[14:37:09] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[14:37:09] [INFO] [Player] Spawning blood effect at (308.66653, 1009.3333), dir=(1, 0), lethal=False (C#)
+[14:37:09] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:09] [INFO] [BloodDecal] Blood puddle created at (337, 1009.333) (added to group)
+[14:37:09] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[14:37:09] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(255.5945, 773.1552), source=NEUTRAL (null), range=900, listeners=4
+[14:37:09] [ENEMY] [Enemy1] Heard CASING_KICK at (255.5945, 773.1552), intensity=1.00, dist=22
+[14:37:09] [ENEMY] [Enemy3] Heard CASING_KICK at (255.5945, 773.1552), intensity=0.01, dist=658
+[14:37:09] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=0
+[14:37:10] [INFO] [ReplayManager] Recording frame 1800 (29,4s): player_valid=True, enemies=5
+[14:37:10] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P3:corner, state=RETREATING, target=-160.1°, current=83.3°, player=(308,1026), corner_timer=0.13
+[14:37:10] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=167.7°, current=168.3°, player=(308,1078), corner_timer=0.23
+[14:37:10] [ENEMY] [Enemy3] State: PURSUING -> COMBAT
+[14:37:10] [ENEMY] [Enemy1] State: RETREATING -> IN_COVER
+[14:37:10] [INFO] [ActiveItemManager.Jammer] VERBOSE: 0 jammer(s) in group, player=(333,1112)
+[14:37:10] [INFO] [InvisibilitySuit] Shader applied to 15 sprites
+[14:37:10] [INFO] [InvisibilitySuit] Activated! Duration: 4.0s, Charges remaining: 1/2
+[14:37:10] [ENEMY] [Enemy1] Memory reset: confusion=2.0s, had_target=true
+[14:37:10] [ENEMY] [Enemy1] Search mode: IN_COVER -> SEARCHING at (308.6665, 1022)
+[14:37:10] [ENEMY] [Enemy1] SEARCHING started (spiral): center=(308.6665, 1022), radius=100, waypoints=5
+[14:37:10] [ENEMY] [Enemy3] Memory reset: confusion=2.0s, had_target=true
+[14:37:10] [ENEMY] [Enemy3] Search mode: COMBAT -> SEARCHING at (329.532, 1111.925)
+[14:37:10] [ENEMY] [Enemy3] SEARCHING started (spiral): center=(329.532, 1111.925), radius=100, waypoints=4
+[14:37:10] [ENEMY] [Enemy4] Memory reset: confusion=2.0s, had_target=false
+[14:37:10] [ENEMY] [Enemy5] Memory reset: confusion=2.0s, had_target=false
+[14:37:10] [INFO] [Player] Reset memory for 4 enemies (invisibility activation - Issue #723)
+[14:37:10] [ENEMY] [Enemy1] ROT_CHANGE: P3:corner -> P2:combat_state, state=SEARCHING, target=83.4°, current=167.9°, player=(333,1111), corner_timer=0.13
+[14:37:10] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=SEARCHING, target=159.7°, current=154.2°, player=(333,1111), corner_timer=0.23
+[14:37:10] [ENEMY] [Enemy1] SEARCHING corner check: angle 176.8°
+[14:37:10] [ENEMY] [Enemy3] SEARCHING corner check: angle 70.6°
+[14:37:10] [ENEMY] [Enemy1] SEARCHING corner check: angle 177.9°
+[14:37:10] [INFO] [ReplayManager] Recording frame 1860 (30,4s): player_valid=True, enemies=5
+[14:37:10] [ENEMY] [Enemy3] SEARCHING corner check: angle -109.4°
+[14:37:11] [ENEMY] [Enemy1] SEARCHING corner check: angle 178.6°
+[14:37:11] [ENEMY] [Enemy3] SEARCHING corner check: angle -109.4°
+[14:37:11] [INFO] [BloodyFeet:Enemy3] Blood ran out - no more footprints
+[14:37:11] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.1°
+[14:37:11] [INFO] [ScoreManager] Combo ended at 1. Max combo: 1
+[14:37:11] [ENEMY] [Enemy3] SEARCHING corner check: angle -109.4°
+[14:37:11] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.4°
+[14:37:11] [INFO] [ReplayManager] Recording frame 1920 (31,4s): player_valid=True, enemies=5
+[14:37:12] [ENEMY] [Enemy3] SEARCHING corner check: angle -109.4°
+[14:37:12] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.4°
+[14:37:12] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.4°
+[14:37:12] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.4°
+[14:37:12] [INFO] [ReplayManager] Recording frame 1980 (32,4s): player_valid=True, enemies=5
+[14:37:13] [ENEMY] [Enemy1] SEARCHING: Stuck at wp 0, skipping
+[14:37:13] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.2°
+[14:37:13] [ENEMY] [Enemy3] SEARCHING corner check: angle -116.7°
+[14:37:13] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.4°
+[14:37:13] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.4°
+[14:37:13] [INFO] [ReplayManager] Recording frame 2040 (33,4s): player_valid=True, enemies=5
+[14:37:14] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.4°
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.4°
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:14] [ENEMY] [Enemy1] SEARCHING corner check: angle 179.4°
+[14:37:14] [ENEMY] [Enemy3] SEARCHING corner check: angle -81.2°
+[14:37:14] [INFO] [ReplayManager] Recording frame 2100 (34,4s): player_valid=True, enemies=5
+[14:37:15] [ENEMY] [Enemy1] SEARCHING: Stuck at wp 1, skipping
+[14:37:15] [ENEMY] [Enemy1] SEARCHING corner check: angle 157.0°
+[14:37:15] [ENEMY] [Enemy3] SEARCHING corner check: angle -87.2°
+[14:37:15] [ENEMY] [Enemy3] SEARCHING corner check: angle -89.1°
+[14:37:15] [ENEMY] [Enemy1] SEARCHING corner check: angle 165.2°
+[14:37:15] [ENEMY] [Enemy3] SEARCHING corner check: angle -89.7°
+[14:37:15] [INFO] [ReplayManager] Recording frame 2160 (35,4s): player_valid=True, enemies=5
+[14:37:15] [ENEMY] [Enemy1] SEARCHING corner check: angle 177.4°
+[14:37:16] [ENEMY] [Enemy3] SEARCHING corner check: angle -89.9°
+[14:37:16] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=SEARCHING, target=-11.4°, current=-9.7°, player=(920,863), corner_timer=0.02
+[14:37:16] [ENEMY] [Enemy1] SEARCHING: Player spotted! Transitioning to COMBAT
+[14:37:16] [ENEMY] [Enemy1] State: SEARCHING -> COMBAT
+[14:37:16] [ENEMY] [Enemy3] SEARCHING corner check: angle -90.0°
+[14:37:16] [ENEMY] [Enemy1] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-12.4°, current=-125.6°, player=(920,863), corner_timer=0.02
+[14:37:16] [ENEMY] [Enemy3] SEARCHING corner check: angle -90.0°
+[14:37:16] [INFO] [ReplayManager] Recording frame 2220 (36,4s): player_valid=True, enemies=5
+[14:37:17] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-18.2°, current=-62.8°, player=(920,863), corner_timer=0.02
+[14:37:17] [ENEMY] [Enemy3] SEARCHING: Stuck at wp 2, skipping
+[14:37:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(191.6875, 1033.112), source=NEUTRAL (null), range=900, listeners=4
+[14:37:17] [ENEMY] [Enemy1] Heard CASING_KICK at (191.6875, 1033.112), intensity=0.01, dist=508
+[14:37:17] [ENEMY] [Enemy3] Heard CASING_KICK at (191.6875, 1033.112), intensity=1.00, dist=28
+[14:37:17] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=2, self=0
+[14:37:17] [INFO] [ReplayManager] Recording frame 2280 (37,4s): player_valid=True, enemies=5
+[14:37:18] [ENEMY] [Enemy3] SEARCHING: Expand outer ring r=175 wps=4
+[14:37:18] [ENEMY] [Enemy3] SEARCHING corner check: angle 31.6°
+[14:37:18] [ENEMY] [Enemy3] SEARCHING corner check: angle -148.4°
+[14:37:18] [INFO] [ReplayManager] Recording frame 2340 (38,4s): player_valid=True, enemies=5
+[14:37:19] [INFO] [ReplayManager] Recording frame 2400 (39,4s): player_valid=True, enemies=5
+[14:37:20] [INFO] [PersistManager] State saved to user://game_state.cfg
+[14:37:20] [INFO] [PersistManager] Last level saved: res://scenes/levels/BuildingLevel.tscn
+[14:37:20] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/BuildingLevel.tscn
+[14:37:20] [INFO] [SceneLoader] Background load started successfully
+[14:37:20] [INFO] [SceneLoader] Background load complete: res://scenes/levels/BuildingLevel.tscn
+[14:37:20] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 3)
+[14:37:20] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 2)
+[14:37:20] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 1)
+[14:37:20] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[14:37:20] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:20] [INFO] [SceneLoader] Scene changed successfully
+[14:37:20] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[14:37:20] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:20] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[14:37:20] [INFO] [LastChance] Resetting all effects (scene change detected)
+[14:37:20] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[14:37:20] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[14:37:20] [INFO] [BlackMetalEffectsManager] Scene changed to: BuildingLevel
+[14:37:20] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[14:37:20] [ENEMY] [Enemy1] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[14:37:20] [ENEMY] [Enemy2] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[14:37:20] [ENEMY] [Enemy3] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[14:37:20] [ENEMY] [Enemy4] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[14:37:20] [ENEMY] [Grenadier] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[14:37:20] [ENEMY] [Enemy6] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[14:37:20] [ENEMY] [Enemy7] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[14:37:20] [ENEMY] [Enemy8] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[14:37:20] [ENEMY] [Enemy9] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[14:37:20] [ENEMY] [Enemy10] Death animation component initialized
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[14:37:20] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[14:37:20] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[14:37:20] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[14:37:20] [INFO] [Player.Weapon] Removed default MakarovPM
+[14:37:20] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[14:37:20] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[14:37:20] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[14:37:20] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[14:37:20] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[14:37:20] [INFO] [Player.Debug] Connected to GameManager, debug mode: True
+[14:37:20] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[14:37:20] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[14:37:20] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[14:37:20] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[14:37:20] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[14:37:20] [INFO] [Player.InvisibilitySuit] Invisibility suit is selected, initializing...
+[14:37:20] [INFO] [InvisibilitySuit] Shader loaded successfully
+[14:37:20] [INFO] [InvisibilitySuit] Activation sound loaded
+[14:37:20] [INFO] [InvisibilitySuit] Deactivation sound loaded
+[14:37:20] [INFO] [InvisibilitySuit] Initialized with player: Player, charges: 2/2
+[14:37:20] [INFO] [Player.InvisibilitySuit] Invisibility suit equipped, charges: 2
+[14:37:20] [INFO] [Player.InvisibilitySuit] Charge bar created
+[14:37:20] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[14:37:20] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[14:37:20] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[14:37:20] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[14:37:20] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[14:37:20] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[14:37:20] [INFO] [Player.ItemVisual] Visual applied for item type: 5
+[14:37:20] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[14:37:20] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[14:37:20] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[14:37:20] [INFO] [Player.Jammer] JammerHUD initialized
+[14:37:20] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[14:37:20] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[14:37:20] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[14:37:20] [INFO] [CinemaEffects] Found player node: Player
+[14:37:20] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[14:37:20] [ENEMY] [Enemy1] Registered as sound listener
+[14:37:20] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[14:37:20] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[14:37:20] [ENEMY] [Enemy2] Registered as sound listener
+[14:37:20] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 4, behavior: GUARD
+[14:37:20] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[14:37:20] [ENEMY] [Enemy3] Registered as sound listener
+[14:37:20] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[14:37:20] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[14:37:20] [ENEMY] [Enemy4] Registered as sound listener
+[14:37:20] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[14:37:20] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[14:37:20] [ENEMY] [Grenadier] Registered as sound listener
+[14:37:20] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[14:37:20] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[14:37:20] [ENEMY] [Enemy6] Registered as sound listener
+[14:37:20] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 4, behavior: GUARD
+[14:37:20] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[14:37:20] [ENEMY] [Enemy7] Registered as sound listener
+[14:37:20] [ENEMY] [Enemy7] Spawned at (1700, 870), hp: 4, behavior: PATROL
+[14:37:20] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[14:37:20] [ENEMY] [Enemy8] Registered as sound listener
+[14:37:20] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 3, behavior: GUARD
+[14:37:20] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[14:37:20] [ENEMY] [Enemy9] Registered as sound listener
+[14:37:20] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 3, behavior: GUARD
+[14:37:20] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[14:37:20] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[14:37:20] [ENEMY] [Enemy10] Registered as sound listener
+[14:37:20] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[14:37:20] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[14:37:20] [INFO] [LevelInitFallback] GDScript _ready() did NOT execute - performing C# fallback initialization
+[14:37:20] [INFO] [LevelInitFallback] Полигон loaded (C# fallback) - Tactical Combat Arena
+[14:37:20] [INFO] [LevelInitFallback] Found Environment/Enemies node with 10 children
+[14:37:20] [INFO] [LevelInitFallback] Child 'Enemy1': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Child 'Enemy2': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Child 'Enemy3': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Child 'Enemy4': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Child 'Grenadier': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Child 'Enemy6': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Child 'Enemy7': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Child 'Enemy8': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Child 'Enemy9': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Child 'Enemy10': has_died_signal=True
+[14:37:20] [INFO] [LevelInitFallback] Enemy tracking complete: 10 enemies registered
+[14:37:20] [INFO] [LevelInitFallback] Realistic visibility component added to player (night mode)
+[14:37:20] [INFO] [LevelInitFallback] BuildingLevel: AssaultRifle magazines reinitialized to 2 (C# fallback, Issue #1259)
+[14:37:20] [INFO] [LevelInitFallback] BuildingLevel: Re-applied auto-reload magazine reduction after ammo config for AssaultRifle
+[14:37:20] [INFO] [ScoreManager] Level started with 10 enemies
+[14:37:20] [INFO] [LevelInitFallback] ScoreManager initialized with 10 enemies
+[14:37:20] [INFO] [LevelInitFallback] Exit zone created at position (120, 1544)
+[14:37:20] [INFO] [ReplayManager] Replay data cleared
+[14:37:20] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[14:37:20] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[14:37:20] [INFO] [ReplayManager] Level: BuildingLevel
+[14:37:20] [INFO] [ReplayManager] Player: Player (valid: True)
+[14:37:20] [INFO] [ReplayManager] Enemies count: 10
+[14:37:20] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[14:37:20] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[14:37:20] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[14:37:20] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[14:37:20] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[14:37:20] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[14:37:20] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[14:37:20] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[14:37:20] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[14:37:20] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[14:37:20] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[14:37:20] [INFO] [LevelInitFallback] Replay recording started with 10 enemies
+[14:37:20] [INFO] [LevelInitFallback] GDScript properties synced
+[14:37:20] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[14:37:20] [ENEMY] [Enemy7] Patrol points snapped to navmesh (Issue #1216)
+[14:37:20] [ENEMY] [Enemy10] Patrol points snapped to navmesh (Issue #1216)
+[14:37:20] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:20] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:20] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:20] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:20] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:20] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=225.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:20] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:20] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:20] [INFO] [Player] Detecting weapon pose (frame 3)...
+[14:37:20] [INFO] [Player] Detected weapon: Rifle (default pose)
+[14:37:20] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[14:37:20] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[14:37:20] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[14:37:20] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[14:37:20] [INFO] [LastChance] Found player: Player
+[14:37:20] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[14:37:20] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[14:37:20] [INFO] [LastChance] Connected to player Died signal (C#)
+[14:37:20] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[14:37:21] [INFO] [NavMeshMonitor] refresh started: found 1 NavigationRegion2D node(s)
+[14:37:21] [INFO] [NavMeshMonitor] refresh: region 'NavigationRegion2D' poly_count=1 vertex_count=4 outline_count=1
+[14:37:21] [INFO] [NavMeshMonitor] refresh done: 1 region(s), 1 baked poly(s), 0 outline(s), 1 draw polys
+[14:37:21] [INFO] [NavMeshMonitor] Overlay shown with 1 polygon(s)
+[14:37:21] [INFO] [NavMeshMonitor] refresh started: found 1 NavigationRegion2D node(s)
+[14:37:21] [INFO] [NavMeshMonitor] refresh: region 'NavigationRegion2D' poly_count=1 vertex_count=4 outline_count=1
+[14:37:21] [INFO] [NavMeshMonitor] refresh done: 1 region(s), 1 baked poly(s), 0 outline(s), 1 draw polys
+[14:37:21] [INFO] [NavMeshMonitor] Overlay refreshed with 1 polygon(s)
+[14:37:21] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[14:37:21] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450, 990.1666), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[14:37:21] [ENEMY] [Enemy1] Heard gunshot at (450, 990.1666), intensity=0.01, distance=658
+[14:37:21] [ENEMY] [Enemy2] Heard gunshot at (450, 990.1666), intensity=0.01, distance=443
+[14:37:21] [ENEMY] [Enemy3] Heard gunshot at (450, 990.1666), intensity=0.02, distance=347
+[14:37:21] [ENEMY] [Enemy4] Heard gunshot at (450, 990.1666), intensity=0.02, distance=361
+[14:37:21] [ENEMY] [Grenadier] Heard gunshot at (450, 990.1666), intensity=0.00, distance=1404
+[14:37:21] [ENEMY] [Enemy7] Heard gunshot at (450, 990.1666), intensity=0.00, distance=1256
+[14:37:21] [ENEMY] [Enemy10] Heard gunshot at (450, 990.1666), intensity=0.00, distance=936
+[14:37:21] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=3, self=0
+[14:37:21] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=76.8°, current=168.8°, player=(450,990), corner_timer=0.00
+[14:37:21] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=83.5°, current=-67.5°, player=(450,990), corner_timer=0.00
+[14:37:21] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=136.1°, current=11.3°, player=(450,990), corner_timer=0.00
+[14:37:21] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=165.6°, current=168.8°, player=(450,990), corner_timer=0.00
+[14:37:21] [ENEMY] [Grenadier] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=152.9°, current=-101.3°, player=(450,990), corner_timer=0.00
+[14:37:21] [ENEMY] [Enemy7] ROT_CHANGE: none -> P2:combat_state, state=COMBAT, target=174.5°, current=0.0°, player=(450,990), corner_timer=0.00
+[14:37:21] [ENEMY] [Enemy10] ROT_CHANGE: none -> P2:combat_state, state=COMBAT, target=-143.3°, current=0.0°, player=(450,990), corner_timer=0.00
+[14:37:21] [ENEMY] [Enemy10] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-142.2°, current=-142.2°, player=(450,968), corner_timer=0.00
+[14:37:22] [ENEMY] [Enemy10] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-140.9°, current=-140.9°, player=(450,942), corner_timer=0.00
+[14:37:22] [INFO] [ActiveItemManager.Jammer] VERBOSE: 0 jammer(s) in group, player=(450,922)
+[14:37:22] [INFO] [InvisibilitySuit] Shader applied to 15 sprites
+[14:37:22] [INFO] [InvisibilitySuit] Activated! Duration: 4.0s, Charges remaining: 1/2
+[14:37:22] [ENEMY] [Enemy1] Memory reset: confusion=2.0s, had_target=true
+[14:37:22] [ENEMY] [Enemy1] Search mode: COMBAT -> SEARCHING at (450, 990.1666)
+[14:37:22] [ENEMY] [Enemy1] SEARCHING started (spiral): center=(450, 990.1666), radius=100, waypoints=5
+[14:37:22] [ENEMY] [Enemy2] Memory reset: confusion=2.0s, had_target=true
+[14:37:22] [ENEMY] [Enemy2] Search mode: COMBAT -> SEARCHING at (450, 990.1666)
+[14:37:22] [ENEMY] [Enemy2] SEARCHING started (spiral): center=(450, 990.1666), radius=100, waypoints=5
+[14:37:22] [ENEMY] [Enemy3] Memory reset: confusion=2.0s, had_target=true
+[14:37:22] [ENEMY] [Enemy3] Search mode: COMBAT -> SEARCHING at (450, 990.1666)
+[14:37:22] [ENEMY] [Enemy3] SEARCHING started (spiral): center=(450, 990.1666), radius=100, waypoints=5
+[14:37:22] [ENEMY] [Enemy4] Memory reset: confusion=2.0s, had_target=true
+[14:37:22] [ENEMY] [Enemy4] Search mode: COMBAT -> SEARCHING at (450, 990.1666)
+[14:37:22] [ENEMY] [Enemy4] SEARCHING started (spiral): center=(450, 990.1666), radius=100, waypoints=5
+[14:37:22] [ENEMY] [Grenadier] Memory reset: confusion=2.0s, had_target=true
+[14:37:22] [ENEMY] [Grenadier] Search mode: COMBAT -> SEARCHING at (450, 990.1666)
+[14:37:22] [ENEMY] [Grenadier] SEARCHING started (spiral): center=(450, 990.1666), radius=100, waypoints=5
+[14:37:22] [ENEMY] [Enemy6] Memory reset: confusion=2.0s, had_target=false
+[14:37:22] [ENEMY] [Enemy7] Memory reset: confusion=2.0s, had_target=true
+[14:37:22] [ENEMY] [Enemy7] Search mode: COMBAT -> SEARCHING at (450, 990.1666)
+[14:37:22] [ENEMY] [Enemy7] SEARCHING started (spiral): center=(450, 990.1666), radius=100, waypoints=5
+[14:37:22] [ENEMY] [Enemy8] Memory reset: confusion=2.0s, had_target=false
+[14:37:22] [ENEMY] [Enemy9] Memory reset: confusion=2.0s, had_target=false
+[14:37:22] [ENEMY] [Enemy10] Memory reset: confusion=2.0s, had_target=true
+[14:37:22] [ENEMY] [Enemy10] Search mode: COMBAT -> SEARCHING at (450, 946.4999)
+[14:37:22] [ENEMY] [Enemy10] SEARCHING started (spiral): center=(450, 946.4999), radius=100, waypoints=5
+[14:37:22] [INFO] [Player] Reset memory for 10 enemies (invisibility activation - Issue #723)
+[14:37:22] [ENEMY] [Enemy1] SEARCHING corner check: angle -17.3°
+[14:37:22] [ENEMY] [Enemy2] SEARCHING corner check: angle 2.1°
+[14:37:22] [ENEMY] [Enemy3] SEARCHING corner check: angle -134.9°
+[14:37:22] [ENEMY] [Grenadier] SEARCHING corner check: angle 59.8°
+[14:37:22] [ENEMY] [Enemy10] SEARCHING corner check: angle 128.8°
+[14:37:22] [ENEMY] [Enemy4] SEARCHING corner check: angle -106.3°
+[14:37:22] [ENEMY] [Enemy7] SEARCHING corner check: angle 84.4°
+[14:37:22] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[14:37:22] [ENEMY] [Enemy1] SEARCHING corner check: angle -14.7°
+[14:37:22] [ENEMY] [Enemy2] SEARCHING corner check: angle 1.5°
+[14:37:22] [ENEMY] [Enemy3] SEARCHING corner check: angle 45.1°
+[14:37:22] [ENEMY] [Grenadier] SEARCHING corner check: angle 59.8°
+[14:37:22] [ENEMY] [Enemy10] SEARCHING corner check: angle -51.2°
+[14:37:22] [ENEMY] [Enemy4] SEARCHING corner check: angle -106.3°
+[14:37:22] [ENEMY] [Enemy7] SEARCHING corner check: angle 84.5°
+[14:37:22] [ENEMY] [Enemy1] SEARCHING corner check: angle -12.5°
+[14:37:22] [ENEMY] [Enemy2] SEARCHING corner check: angle 1.1°
+[14:37:22] [ENEMY] [Enemy10] SEARCHING corner check: angle 128.8°
+[14:37:23] [ENEMY] [Enemy4] SEARCHING corner check: angle -98.8°
+[14:37:23] [ENEMY] [Enemy7] SEARCHING corner check: angle 85.1°
+[14:37:23] [ENEMY] [Enemy1] SEARCHING corner check: angle -10.6°
+[14:37:23] [ENEMY] [Enemy2] SEARCHING corner check: angle 0.8°
+[14:37:23] [ENEMY] [Enemy10] SEARCHING corner check: angle 128.8°
+[14:37:23] [ENEMY] [Enemy4] SEARCHING corner check: angle -98.2°
+[14:37:23] [ENEMY] [Enemy7] SEARCHING corner check: angle 85.6°
+[14:37:23] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[14:37:23] [ENEMY] [Enemy2] SEARCHING corner check: angle 0.6°
+[14:37:23] [ENEMY] [Enemy10] SEARCHING corner check: angle 128.8°
+[14:37:23] [ENEMY] [Enemy1] SEARCHING corner check: angle 171.4°
+[14:37:23] [ENEMY] [Enemy4] SEARCHING corner check: angle -98.2°
+[14:37:23] [ENEMY] [Enemy7] SEARCHING corner check: angle 86.0°
+[14:37:23] [ENEMY] [Enemy2] SEARCHING corner check: angle 0.6°
+[14:37:23] [ENEMY] [Enemy10] SEARCHING corner check: angle 128.8°
+[14:37:24] [ENEMY] [Enemy1] SEARCHING corner check: angle 171.4°
+[14:37:24] [ENEMY] [Enemy4] SEARCHING corner check: angle -98.2°
+[14:37:24] [ENEMY] [Enemy7] SEARCHING corner check: angle 86.4°
+[14:37:24] [ENEMY] [Enemy2] SEARCHING corner check: angle 0.6°
+[14:37:24] [ENEMY] [Enemy10] SEARCHING corner check: angle 128.8°
+[14:37:24] [ENEMY] [Enemy1] SEARCHING corner check: angle -8.4°
+[14:37:24] [ENEMY] [Enemy4] SEARCHING corner check: angle -98.2°
+[14:37:24] [ENEMY] [Enemy7] SEARCHING corner check: angle 86.8°
+[14:37:24] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[14:37:24] [ENEMY] [Enemy2] SEARCHING corner check: angle 0.6°
+[14:37:24] [ENEMY] [Enemy10] SEARCHING corner check: angle 142.3°
+[14:37:24] [ENEMY] [Enemy1] SEARCHING corner check: angle -7.8°
+[14:37:24] [ENEMY] [Enemy4] SEARCHING corner check: angle -98.2°
+[14:37:24] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(489.9102, 1019.007), source=NEUTRAL (null), range=900, listeners=10
+[14:37:24] [ENEMY] [Enemy1] Heard CASING_KICK at (489.9102, 1019.007), intensity=0.02, dist=365
+[14:37:24] [ENEMY] [Enemy1] [#910] Invisible player CASING_KICK sound — firing suppressive at (489.9102, 1019.007)
+[14:37:24] [ENEMY] [Enemy2] Heard CASING_KICK at (489.9102, 1019.007), intensity=0.02, dist=357
+[14:37:24] [ENEMY] [Enemy2] [#910] Invisible player CASING_KICK sound — firing suppressive at (489.9102, 1019.007)
+[14:37:24] [ENEMY] [Enemy3] Heard CASING_KICK at (489.9102, 1019.007), intensity=0.21, dist=108
+[14:37:24] [ENEMY] [Enemy3] [#910] Invisible player CASING_KICK sound — firing suppressive at (489.9102, 1019.007)
+[14:37:24] [ENEMY] [Enemy4] Heard CASING_KICK at (489.9102, 1019.007), intensity=0.48, dist=72
+[14:37:24] [ENEMY] [Enemy4] [#910] Invisible player CASING_KICK sound — firing suppressive at (489.9102, 1019.007)
+[14:37:24] [ENEMY] [Enemy10] Heard CASING_KICK at (489.9102, 1019.007), intensity=1.00, dist=31
+[14:37:24] [ENEMY] [Enemy10] [#910] Invisible player CASING_KICK sound — firing suppressive at (489.9102, 1019.007)
+[14:37:24] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (489.9102, 1019.007)
+[14:37:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(503.2891, 1046.489), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:24] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:24] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=5, self=0
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash triggered COMBAT from 9
+[14:37:24] [ENEMY] [Enemy7] SEARCHING corner check: angle 87.1°
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (482.6077, 1014.449)
+[14:37:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(496.063, 1042.947), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:24] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy2] SEARCHING corner check: angle 0.7°
+[14:37:24] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:24] [ENEMY] [Enemy3] SEARCHING: Stuck at wp 0, skipping
+[14:37:24] [ENEMY] [Enemy4] SEARCHING: Stuck at wp 0, skipping
+[14:37:25] [ENEMY] [Enemy10] State: COMBAT -> RETREATING
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:25] [ENEMY] [Enemy3] SEARCHING corner check: angle -82.6°
+[14:37:25] [ENEMY] [Enemy10] ROT_CHANGE: P2:combat_state -> P3:corner, state=RETREATING, target=142.3°, current=-110.8°, player=(450,921), corner_timer=0.15
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:25] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (482.6077, 1014.449)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(498.7687, 1044.201), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:25] [ENEMY] [Enemy1] SEARCHING corner check: angle -7.7°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:25] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[14:37:25] [INFO] [Player] Spawning blood effect at (450, 921.9444), dir=(1, 0), lethal=False (C#)
+[14:37:25] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:25] [INFO] [BloodDecal] Blood puddle created at (499, 921.9444) (added to group)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:25] [ENEMY] [Enemy4] SEARCHING corner check: angle -59.0°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(482.6077, 1014.449)
+[14:37:25] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (482.6077, 1014.449)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(520.2236, 1048.066), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:25] [ENEMY] [Enemy7] SEARCHING corner check: angle 87.4°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(492.5826, 1000.366)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(492.5826, 1000.366)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(492.5826, 1000.366)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(492.5826, 1000.366)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(492.5826, 1000.366)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(492.5826, 1000.366)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(492.5826, 1000.366)
+[14:37:25] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (492.5826, 1000.366)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(543.5536, 1048.066), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:25] [ENEMY] [Enemy2] SEARCHING: Stuck at wp 0, skipping
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(473.8974, 1013.914)
+[14:37:25] [ENEMY] [Enemy10] State: RETREATING -> IN_COVER
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(473.8974, 1013.914)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(473.8974, 1013.914)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(473.8974, 1013.914)
+[14:37:25] [INFO] [BloodDecal] Blood puddle created at (495.3463, 958.0135) (added to group)
+[14:37:25] [ENEMY] [Enemy2] SEARCHING corner check: angle 1.0°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(473.8974, 1013.914)
+[14:37:25] [ENEMY] [Enemy3] SEARCHING corner check: angle -87.6°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(473.8974, 1013.914)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(473.8974, 1013.914)
+[14:37:25] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (473.8974, 1013.914)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:25] [ENEMY] [Enemy1] SEARCHING corner check: angle -7.6°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(476.3725, 1038.236)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(476.3725, 1038.236)
+[14:37:25] [ENEMY] [Enemy4] SEARCHING corner check: angle -62.3°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(476.3725, 1038.236)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(476.3725, 1038.236)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(476.3725, 1038.236)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(476.3725, 1038.236)
+[14:37:25] [ENEMY] [Enemy7] SEARCHING corner check: angle 87.7°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(476.3725, 1038.236)
+[14:37:25] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (476.3725, 1038.236)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(491.9024, 1067.569)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(491.9024, 1067.569)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(491.9024, 1067.569)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(491.9024, 1067.569)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(491.9024, 1067.569)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(491.9024, 1067.569)
+[14:37:25] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[14:37:25] [ENEMY] [Enemy10] State: IN_COVER -> SUPPRESSED
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(491.9024, 1067.569)
+[14:37:25] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (491.9024, 1067.569)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(514.8883, 1067.08)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(514.8883, 1067.08)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(514.8883, 1067.08)
+[14:37:25] [ENEMY] [Enemy2] SEARCHING corner check: angle 1.1°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(514.8883, 1067.08)
+[14:37:25] [ENEMY] [Enemy3] SEARCHING corner check: angle -89.3°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(514.8883, 1067.08)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(514.8883, 1067.08)
+[14:37:25] [ENEMY] [Enemy1] SEARCHING corner check: angle -7.6°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(514.8883, 1067.08)
+[14:37:25] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (514.8883, 1067.08)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(523.4432, 1098.808)
+[14:37:25] [ENEMY] [Enemy4] SEARCHING corner check: angle -63.4°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(523.4432, 1098.808)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(523.4432, 1098.808)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(523.4432, 1098.808)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(523.4432, 1098.808)
+[14:37:25] [ENEMY] [Enemy7] SEARCHING corner check: angle 87.9°
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(523.4432, 1098.808)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(523.4432, 1098.808)
+[14:37:25] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (523.4432, 1098.808)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(529.9871, 1086.014)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(529.9871, 1086.014)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(529.9871, 1086.014)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(529.9871, 1086.014)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(529.9871, 1086.014)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(529.9871, 1086.014)
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(529.9871, 1086.014)
+[14:37:25] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (529.9871, 1086.014)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:25] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(531.5236, 1094.034)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(531.5236, 1094.034)
+[14:37:26] [ENEMY] [Enemy2] SEARCHING corner check: angle 1.1°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(531.5236, 1094.034)
+[14:37:26] [ENEMY] [Enemy3] SEARCHING corner check: angle -90.0°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(531.5236, 1094.034)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(531.5236, 1094.034)
+[14:37:26] [ENEMY] [Enemy1] SEARCHING corner check: angle -7.5°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(531.5236, 1094.034)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(531.5236, 1094.034)
+[14:37:26] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (531.5236, 1094.034)
+[14:37:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:26] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:26] [ENEMY] [Enemy4] SEARCHING corner check: angle -63.9°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(501.8181, 1065.617)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(501.8181, 1065.617)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(501.8181, 1065.617)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(501.8181, 1065.617)
+[14:37:26] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.1°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(501.8181, 1065.617)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(501.8181, 1065.617)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(501.8181, 1065.617)
+[14:37:26] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (501.8181, 1065.617)
+[14:37:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:26] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(509.4544, 1066.672)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(509.4544, 1066.672)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(509.4544, 1066.672)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(509.4544, 1066.672)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(509.4544, 1066.672)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(509.4544, 1066.672)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(509.4544, 1066.672)
+[14:37:26] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (509.4544, 1066.672)
+[14:37:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:26] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(521.7571, 1073.428)
+[14:37:26] [ENEMY] [Enemy2] SEARCHING corner check: angle 1.2°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(521.7571, 1073.428)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy1] SEARCHING: Stuck at wp 0, skipping
+[14:37:26] [ENEMY] [Enemy3] SEARCHING corner check: angle -91.9°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(521.7571, 1073.428)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(521.7571, 1073.428)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(521.7571, 1073.428)
+[14:37:26] [ENEMY] [Enemy1] SEARCHING corner check: angle -9.7°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(521.7571, 1073.428)
+[14:37:26] [ENEMY] [Enemy4] SEARCHING corner check: angle -66.9°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(521.7571, 1073.428)
+[14:37:26] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (521.7571, 1073.428)
+[14:37:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:26] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.3°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (527.7565, 1080.986)
+[14:37:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:26] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(527.7565, 1080.986)
+[14:37:26] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (527.7565, 1080.986)
+[14:37:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:26] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:26] [ENEMY] [Enemy2] SEARCHING corner check: angle 1.2°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(528.6611, 1082.739)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy3] SEARCHING corner check: angle -95.7°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(528.6611, 1082.739)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(528.6611, 1082.739)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(528.6611, 1082.739)
+[14:37:26] [ENEMY] [Enemy1] SEARCHING corner check: angle -9.7°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(528.6611, 1082.739)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy4] SEARCHING corner check: angle -69.0°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(528.6611, 1082.739)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(528.6611, 1082.739)
+[14:37:26] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (528.6611, 1082.739)
+[14:37:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:26] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(525.9344, 1078.119)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(525.9344, 1078.119)
+[14:37:26] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:26] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.5°
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(525.9344, 1078.119)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(525.9344, 1078.119)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(525.9344, 1078.119)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(525.9344, 1078.119)
+[14:37:26] [ENEMY] [Enemy10] [#910] Muzzle flash detected (invisible player): est_pos=(525.9344, 1078.119)
+[14:37:26] [ENEMY] [Enemy10] [#910] Suppressive shot toward invisible player sound at (525.9344, 1078.119)
+[14:37:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(550.2435, 1048.065), source=ENEMY (Enemy10), range=800, listeners=10
+[14:37:26] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:26] [ENEMY] [Enemy2] SEARCHING corner check: angle 1.2°
+[14:37:27] [ENEMY] [Enemy3] SEARCHING corner check: angle -96.1°
+[14:37:27] [ENEMY] [Enemy1] SEARCHING corner check: angle -9.7°
+[14:37:27] [ENEMY] [Enemy4] SEARCHING corner check: angle -69.5°
+[14:37:27] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.6°
+[14:37:27] [ENEMY] [Enemy2] SEARCHING: Stuck at wp 1, skipping
+[14:37:27] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 0, skipping
+[14:37:27] [ENEMY] [Enemy2] SEARCHING corner check: angle -14.7°
+[14:37:27] [ENEMY] [Enemy3] SEARCHING corner check: angle -96.6°
+[14:37:27] [ENEMY] [Enemy1] SEARCHING corner check: angle -8.8°
+[14:37:27] [ENEMY] [Enemy4] SEARCHING corner check: angle -69.9°
+[14:37:27] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.8°
+[14:37:27] [WARN] [FPS] Drop detected: 28 fps (threshold: 30)
+[14:37:27] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[14:37:27] [ENEMY] [Enemy2] SEARCHING corner check: angle -9.9°
+[14:37:27] [ENEMY] [Enemy3] SEARCHING corner check: angle -97.0°
+[14:37:27] [ENEMY] [Enemy1] SEARCHING corner check: angle -5.9°
+[14:37:27] [ENEMY] [Enemy4] SEARCHING corner check: angle -70.3°
+[14:37:27] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.9°
+[14:37:28] [ENEMY] [Enemy2] SEARCHING corner check: angle -6.6°
+[14:37:28] [ENEMY] [Enemy3] SEARCHING corner check: angle -97.5°
+[14:37:28] [ENEMY] [Enemy1] SEARCHING corner check: angle -3.9°
+[14:37:28] [ENEMY] [Enemy4] SEARCHING corner check: angle -70.7°
+[14:37:28] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.0°
+[14:37:28] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=SEARCHING, target=103.4°, current=103.2°, player=(450,921), corner_timer=-0.02
+[14:37:28] [ENEMY] [Enemy2] SEARCHING: Player spotted! Transitioning to COMBAT
+[14:37:28] [ENEMY] [Enemy2] State: SEARCHING -> COMBAT
+[14:37:28] [ENEMY] [Enemy3] SEARCHING corner check: angle -97.9°
+[14:37:28] [ENEMY] [Enemy1] SEARCHING corner check: angle -2.6°
+[14:37:28] [ENEMY] [Enemy4] SEARCHING corner check: angle -71.0°
+[14:37:28] [ENEMY] [Enemy2] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=101.9°, current=109.7°, player=(450,921), corner_timer=-0.02
+[14:37:28] [ENEMY] [Enemy3] SEARCHING: Stuck at wp 1, skipping
+[14:37:28] [ENEMY] [Enemy4] SEARCHING: Stuck at wp 1, skipping
+[14:37:28] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.1°
+[14:37:28] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=10
+[14:37:28] [ENEMY] [Enemy1] SEARCHING corner check: angle -1.7°
+[14:37:28] [ENEMY] [Enemy4] SEARCHING corner check: angle -29.8°
+[14:37:28] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.2°
+[14:37:28] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[14:37:29] [ENEMY] [Enemy1] SEARCHING corner check: angle -1.1°
+[14:37:29] [ENEMY] [Enemy4] SEARCHING corner check: angle -29.3°
+[14:37:29] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.3°
+[14:37:29] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 1, skipping
+[14:37:29] [ENEMY] [Enemy1] SEARCHING corner check: angle -0.8°
+[14:37:29] [ENEMY] [Enemy4] SEARCHING corner check: angle -29.3°
+[14:37:29] [ENEMY] [Enemy10] State: SUPPRESSED -> IN_COVER
+[14:37:29] [ENEMY] [Enemy10] State: IN_COVER -> PURSUING
+[14:37:29] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P2:combat_state, state=PURSUING, target=-128.5°, current=142.3°, player=(450,921), corner_timer=0.15
+[14:37:29] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.4°
+[14:37:29] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=10
+[14:37:29] [ENEMY] [Enemy1] SEARCHING corner check: angle -0.6°
+[14:37:29] [ENEMY] [Enemy4] SEARCHING corner check: angle -29.3°
+[14:37:29] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.4°
+[14:37:30] [ENEMY] [Enemy1] SEARCHING corner check: angle -0.6°
+[14:37:30] [ENEMY] [Enemy4] SEARCHING corner check: angle -29.3°
+[14:37:30] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.5°
+[14:37:30] [ENEMY] [Enemy1] SEARCHING: Stuck at wp 1, skipping
+[14:37:30] [ENEMY] [Enemy2] PURSUING corner check: angle -24.9°
+[14:37:30] [ENEMY] [Enemy1] SEARCHING corner check: angle -15.9°
+[14:37:30] [ENEMY] [Enemy4] SEARCHING corner check: angle -29.3°
+[14:37:30] [ENEMY] [Enemy3] SEARCHING: Stuck at wp 2, skipping
+[14:37:30] [ENEMY] [Enemy3] SEARCHING corner check: angle 8.2°
+[14:37:30] [ENEMY] [Enemy4] SEARCHING: Stuck at wp 2, skipping
+[14:37:30] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.5°
+[14:37:30] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=102.9°, current=74.7°, player=(450,921), corner_timer=0.17
+[14:37:30] [ENEMY] [Enemy2] State: PURSUING -> COMBAT
+[14:37:30] [ENEMY] [Enemy7] SEARCHING: Stuck at wp 0, skipping
+[14:37:30] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=10
+[14:37:30] [ENEMY] [Enemy1] SEARCHING corner check: angle -13.2°
+[14:37:30] [ENEMY] [Enemy3] SEARCHING corner check: angle 9.5°
+[14:37:30] [ENEMY] [Enemy7] SEARCHING corner check: angle 93.7°
+[14:37:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(513.52, 668.0454), source=ENEMY (Enemy2), range=800, listeners=10
+[14:37:31] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=5, self=1
+[14:37:31] [ENEMY] [Enemy1] SEARCHING corner check: angle -13.3°
+[14:37:31] [ENEMY] [Enemy10] ROT_CHANGE: P2:combat_state -> P1:visible, state=PURSUING, target=-117.0°, current=-111.4°, player=(450,921), corner_timer=0.02
+[14:37:31] [ENEMY] [Enemy10] State: PURSUING -> COMBAT
+[14:37:31] [ENEMY] [Enemy3] SEARCHING corner check: angle 9.5°
+[14:37:31] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[14:37:31] [INFO] [Player] Spawning blood effect at (450, 921.9444), dir=(1, 0), lethal=False (C#)
+[14:37:31] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:31] [INFO] [BloodDecal] Blood puddle created at (499, 921.9444) (added to group)
+[14:37:31] [ENEMY] [Enemy7] SEARCHING corner check: angle 93.3°
+[14:37:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(494.8642, 679.8209), source=NEUTRAL (null), range=900, listeners=10
+[14:37:31] [ENEMY] [Enemy1] Heard CASING_KICK at (494.8642, 679.8209), intensity=1.00, dist=33
+[14:37:31] [ENEMY] [Enemy2] Heard CASING_KICK at (494.8642, 679.8209), intensity=1.00, dist=22
+[14:37:31] [ENEMY] [Enemy3] Heard CASING_KICK at (494.8642, 679.8209), intensity=0.04, dist=254
+[14:37:31] [ENEMY] [Enemy4] Heard CASING_KICK at (494.8642, 679.8209), intensity=0.03, dist=301
+[14:37:31] [ENEMY] [Enemy10] Heard CASING_KICK at (494.8642, 679.8209), intensity=0.02, dist=369
+[14:37:31] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=5, self=0
+[14:37:31] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[14:37:31] [INFO] [Player] Spawning blood effect at (450, 921.9444), dir=(1, 0), lethal=False (C#)
+[14:37:31] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:31] [INFO] [BloodDecal] Blood puddle created at (499, 921.9444) (added to group)
+[14:37:31] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[14:37:31] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 2, skipping
+[14:37:31] [ENEMY] [Enemy1] SEARCHING corner check: angle -11.9°
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Enemy10 (remaining: 9)
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Enemy9 (remaining: 8)
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Enemy8 (remaining: 7)
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Enemy7 (remaining: 6)
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Enemy6 (remaining: 5)
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Grenadier (remaining: 4)
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[14:37:31] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[14:37:31] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:31] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[14:37:31] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:31] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[14:37:31] [INFO] [LastChance] Resetting all effects (scene change detected)
+[14:37:31] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[14:37:31] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[14:37:31] [INFO] [BlackMetalEffectsManager] Scene changed to: BuildingLevel
+[14:37:31] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[14:37:31] [ENEMY] [Enemy1] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[14:37:31] [ENEMY] [Enemy2] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[14:37:31] [ENEMY] [Enemy3] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[14:37:31] [ENEMY] [Enemy4] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[14:37:31] [ENEMY] [Grenadier] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[14:37:31] [ENEMY] [Enemy6] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[14:37:31] [ENEMY] [Enemy7] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[14:37:31] [ENEMY] [Enemy8] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[14:37:31] [ENEMY] [Enemy9] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[14:37:31] [ENEMY] [Enemy10] Death animation component initialized
+[14:37:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:31] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[14:37:31] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[14:37:31] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[14:37:31] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[14:37:31] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[14:37:31] [INFO] [Player.Weapon] GameManager weapon selection: m16 (AssaultRifle)
+[14:37:31] [INFO] [Player.Weapon] Removed default MakarovPM
+[14:37:31] [INFO] [Player.Weapon] Equipped AssaultRifle (ammo: 30/30)
+[14:37:31] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[14:37:31] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[14:37:31] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[14:37:31] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[14:37:31] [INFO] [Player.Debug] Connected to GameManager, debug mode: True
+[14:37:31] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[14:37:31] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[14:37:31] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[14:37:31] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[14:37:31] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[14:37:31] [INFO] [Player.InvisibilitySuit] Invisibility suit is selected, initializing...
+[14:37:31] [INFO] [InvisibilitySuit] Shader loaded successfully
+[14:37:31] [INFO] [InvisibilitySuit] Activation sound loaded
+[14:37:31] [INFO] [InvisibilitySuit] Deactivation sound loaded
+[14:37:31] [INFO] [InvisibilitySuit] Initialized with player: Player, charges: 2/2
+[14:37:31] [INFO] [Player.InvisibilitySuit] Invisibility suit equipped, charges: 2
+[14:37:31] [INFO] [Player.InvisibilitySuit] Charge bar created
+[14:37:31] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[14:37:31] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[14:37:31] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[14:37:31] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[14:37:31] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[14:37:31] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[14:37:31] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[14:37:31] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[14:37:31] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[14:37:31] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[14:37:31] [INFO] [Player.ItemVisual] Visual applied for item type: 5
+[14:37:31] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[14:37:31] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[14:37:31] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[14:37:31] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[14:37:31] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[14:37:31] [INFO] [Player.Jammer] JammerHUD initialized
+[14:37:31] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[14:37:31] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[14:37:31] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[14:37:31] [INFO] [CinemaEffects] Found player node: Player
+[14:37:31] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[14:37:31] [ENEMY] [Enemy1] Registered as sound listener
+[14:37:31] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 4, behavior: GUARD
+[14:37:31] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[14:37:31] [ENEMY] [Enemy2] Registered as sound listener
+[14:37:31] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[14:37:31] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[14:37:31] [ENEMY] [Enemy3] Registered as sound listener
+[14:37:31] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[14:37:31] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[14:37:31] [ENEMY] [Enemy4] Registered as sound listener
+[14:37:31] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[14:37:31] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[14:37:31] [ENEMY] [Grenadier] Registered as sound listener
+[14:37:31] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 2, behavior: GUARD
+[14:37:31] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[14:37:31] [ENEMY] [Enemy6] Registered as sound listener
+[14:37:31] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 3, behavior: GUARD
+[14:37:31] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[14:37:31] [ENEMY] [Enemy7] Registered as sound listener
+[14:37:31] [ENEMY] [Enemy7] Spawned at (1700, 870), hp: 3, behavior: PATROL
+[14:37:31] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[14:37:31] [ENEMY] [Enemy8] Registered as sound listener
+[14:37:31] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[14:37:31] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[14:37:31] [ENEMY] [Enemy9] Registered as sound listener
+[14:37:31] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 4, behavior: GUARD
+[14:37:31] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[14:37:31] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[14:37:31] [ENEMY] [Enemy10] Registered as sound listener
+[14:37:31] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 4, behavior: PATROL
+[14:37:31] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[14:37:31] [INFO] [LevelInitFallback] GDScript _ready() did NOT execute - performing C# fallback initialization
+[14:37:31] [INFO] [LevelInitFallback] Полигон loaded (C# fallback) - Tactical Combat Arena
+[14:37:31] [INFO] [LevelInitFallback] Found Environment/Enemies node with 10 children
+[14:37:31] [INFO] [LevelInitFallback] Child 'Enemy1': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Child 'Enemy2': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Child 'Enemy3': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Child 'Enemy4': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Child 'Grenadier': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Child 'Enemy6': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Child 'Enemy7': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Child 'Enemy8': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Child 'Enemy9': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Child 'Enemy10': has_died_signal=True
+[14:37:31] [INFO] [LevelInitFallback] Enemy tracking complete: 10 enemies registered
+[14:37:31] [INFO] [LevelInitFallback] Realistic visibility component added to player (night mode)
+[14:37:31] [INFO] [LevelInitFallback] BuildingLevel: AssaultRifle magazines reinitialized to 2 (C# fallback, Issue #1259)
+[14:37:31] [INFO] [LevelInitFallback] BuildingLevel: Re-applied auto-reload magazine reduction after ammo config for AssaultRifle
+[14:37:31] [INFO] [ScoreManager] Level started with 10 enemies
+[14:37:31] [INFO] [LevelInitFallback] ScoreManager initialized with 10 enemies
+[14:37:31] [INFO] [LevelInitFallback] Exit zone created at position (120, 1544)
+[14:37:31] [INFO] [ReplayManager] Replay data cleared
+[14:37:31] [INFO] [ReplayManager] Detected player weapon: Assault Rifle (M16)
+[14:37:31] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[14:37:31] [INFO] [ReplayManager] Level: BuildingLevel
+[14:37:31] [INFO] [ReplayManager] Player: Player (valid: True)
+[14:37:31] [INFO] [ReplayManager] Enemies count: 10
+[14:37:31] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/m16_rifle_topdown.png
+[14:37:31] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[14:37:31] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[14:37:31] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[14:37:31] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[14:37:31] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[14:37:31] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[14:37:31] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[14:37:31] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[14:37:31] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[14:37:31] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[14:37:31] [INFO] [LevelInitFallback] Replay recording started with 10 enemies
+[14:37:31] [INFO] [LevelInitFallback] GDScript properties synced
+[14:37:31] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[14:37:31] [ENEMY] [Enemy7] Patrol points snapped to navmesh (Issue #1216)
+[14:37:31] [ENEMY] [Enemy10] Patrol points snapped to navmesh (Issue #1216)
+[14:37:31] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:31] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:31] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:31] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:31] [ENEMY] [Grenadier] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:31] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:31] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:31] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[14:37:31] [INFO] [Player] Detecting weapon pose (frame 3)...
+[14:37:31] [INFO] [Player] Detected weapon: Rifle (default pose)
+[14:37:31] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[14:37:31] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[14:37:31] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[14:37:31] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[14:37:31] [INFO] [LastChance] Found player: Player
+[14:37:31] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[14:37:31] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[14:37:31] [INFO] [LastChance] Connected to player Died signal (C#)
+[14:37:31] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[14:37:32] [INFO] [NavMeshMonitor] refresh started: found 1 NavigationRegion2D node(s)
+[14:37:32] [INFO] [NavMeshMonitor] refresh: region 'NavigationRegion2D' poly_count=1 vertex_count=4 outline_count=1
+[14:37:32] [INFO] [NavMeshMonitor] refresh done: 1 region(s), 1 baked poly(s), 0 outline(s), 1 draw polys
+[14:37:32] [INFO] [NavMeshMonitor] Overlay shown with 1 polygon(s)
+[14:37:32] [INFO] [NavMeshMonitor] refresh started: found 1 NavigationRegion2D node(s)
+[14:37:32] [INFO] [NavMeshMonitor] refresh: region 'NavigationRegion2D' poly_count=1 vertex_count=4 outline_count=1
+[14:37:32] [INFO] [NavMeshMonitor] refresh done: 1 region(s), 1 baked poly(s), 0 outline(s), 1 draw polys
+[14:37:32] [INFO] [NavMeshMonitor] Overlay refreshed with 1 polygon(s)
+[14:37:32] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[14:37:33] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[14:37:33] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=90.0°, current=0.0°, player=(450,902), corner_timer=0.30
+[14:37:33] [ENEMY] [Enemy10] ROT_CHANGE: none -> P4:velocity, state=IDLE, target=0.0°, current=0.0°, player=(450,902), corner_timer=0.00
+[14:37:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(450.9239, 836.5493), source=PLAYER (AssaultRifle), range=1469, listeners=10
+[14:37:33] [ENEMY] [Enemy1] Heard gunshot at (450.9239, 836.5493), intensity=0.01, distance=509
+[14:37:33] [ENEMY] [Enemy2] Heard gunshot at (450.9239, 836.5493), intensity=0.03, distance=291
+[14:37:33] [ENEMY] [Enemy3] Heard gunshot at (450.9239, 836.5493), intensity=0.04, distance=264
+[14:37:33] [ENEMY] [Enemy4] Heard gunshot at (450.9239, 836.5493), intensity=0.02, distance=355
+[14:37:33] [ENEMY] [Grenadier] Heard gunshot at (450.9239, 836.5493), intensity=0.00, distance=1340
+[14:37:33] [ENEMY] [Enemy7] Heard gunshot at (450.9239, 836.5493), intensity=0.00, distance=1297
+[14:37:33] [ENEMY] [Enemy10] Heard gunshot at (450.9239, 836.5493), intensity=0.00, distance=1069
+[14:37:33] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=3, self=0
+[14:37:33] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=72.8°, current=-157.5°, player=(450,836), corner_timer=0.00
+[14:37:33] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=79.9°, current=168.8°, player=(450,836), corner_timer=0.00
+[14:37:33] [ENEMY] [Enemy3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=160.8°, current=123.7°, player=(450,836), corner_timer=0.00
+[14:37:33] [ENEMY] [Enemy4] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-169.7°, current=168.8°, player=(450,836), corner_timer=0.00
+[14:37:33] [ENEMY] [Grenadier] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=158.7°, current=-180.0°, player=(450,836), corner_timer=0.00
+[14:37:33] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P2:combat_state, state=COMBAT, target=-178.5°, current=34.4°, player=(450,836), corner_timer=0.10
+[14:37:33] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P2:combat_state, state=COMBAT, target=-138.2°, current=0.0°, player=(450,836), corner_timer=0.00
+[14:37:33] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[14:37:33] [ENEMY] [Enemy3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-166.4°, current=-119.0°, player=(544,721), corner_timer=0.00
+[14:37:33] [ENEMY] [Enemy1] State: COMBAT -> PURSUING
+[14:37:33] [ENEMY] [Enemy2] State: COMBAT -> PURSUING
+[14:37:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(684.826, 755.0727), source=ENEMY (Enemy3), range=800, listeners=10
+[14:37:33] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=1
+[14:37:33] [ENEMY] [Enemy4] State: COMBAT -> PURSUING
+[14:37:33] [ENEMY] [Grenadier] State: COMBAT -> PURSUING
+[14:37:33] [ENEMY] [Enemy7] State: COMBAT -> PURSUING
+[14:37:33] [ENEMY] [Enemy10] State: COMBAT -> PURSUING
+[14:37:33] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[14:37:33] [INFO] [Player] Spawning blood effect at (575.13745, 690), dir=(1, 0), lethal=False (C#)
+[14:37:33] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:34] [ENEMY] [Enemy3] State: COMBAT -> RETREATING
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(679.6461, 730.4693), source=NEUTRAL (null), range=900, listeners=10
+[14:37:34] [ENEMY] [Enemy1] Heard CASING_KICK at (679.6461, 730.4693), intensity=0.01, dist=521
+[14:37:34] [ENEMY] [Enemy2] Heard CASING_KICK at (679.6461, 730.4693), intensity=0.03, dist=311
+[14:37:34] [ENEMY] [Enemy3] Heard CASING_KICK at (679.6461, 730.4693), intensity=1.00, dist=28
+[14:37:34] [ENEMY] [Enemy4] Heard CASING_KICK at (679.6461, 730.4693), intensity=0.10, dist=156
+[14:37:34] [ENEMY] [Enemy10] Heard CASING_KICK at (679.6461, 730.4693), intensity=0.00, dist=838
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=5, self=0
+[14:37:34] [INFO] [ActiveItemManager.Jammer] VERBOSE: 0 jammer(s) in group, player=(633,632)
+[14:37:34] [INFO] [InvisibilitySuit] Shader applied to 15 sprites
+[14:37:34] [INFO] [InvisibilitySuit] Activated! Duration: 4.0s, Charges remaining: 1/2
+[14:37:34] [ENEMY] [Enemy1] Memory reset: confusion=2.0s, had_target=true
+[14:37:34] [ENEMY] [Enemy1] Search mode: PURSUING -> SEARCHING at (450.9239, 836.5493)
+[14:37:34] [ENEMY] [Enemy1] SEARCHING started (spiral): center=(450.9239, 836.5493), radius=100, waypoints=5
+[14:37:34] [ENEMY] [Enemy2] Memory reset: confusion=2.0s, had_target=true
+[14:37:34] [ENEMY] [Enemy2] Search mode: PURSUING -> SEARCHING at (450.9239, 836.5493)
+[14:37:34] [ENEMY] [Enemy2] SEARCHING started (spiral): center=(450.9239, 836.5493), radius=100, waypoints=5
+[14:37:34] [ENEMY] [Enemy3] Memory reset: confusion=2.0s, had_target=true
+[14:37:34] [ENEMY] [Enemy3] Search mode: RETREATING -> SEARCHING at (629.5848, 635.5526)
+[14:37:34] [ENEMY] [Enemy3] SEARCHING started (spiral): center=(629.5848, 635.5526), radius=100, waypoints=5
+[14:37:34] [ENEMY] [Enemy4] Memory reset: confusion=2.0s, had_target=true
+[14:37:34] [ENEMY] [Enemy4] Search mode: PURSUING -> SEARCHING at (625.6957, 639.4417)
+[14:37:34] [ENEMY] [Enemy4] SEARCHING started (spiral): center=(625.6957, 639.4417), radius=100, waypoints=5
+[14:37:34] [ENEMY] [Grenadier] Memory reset: confusion=2.0s, had_target=true
+[14:37:34] [ENEMY] [Grenadier] Search mode: PURSUING -> SEARCHING at (450.9239, 836.5493)
+[14:37:34] [ENEMY] [Grenadier] SEARCHING started (spiral): center=(450.9239, 836.5493), radius=100, waypoints=5
+[14:37:34] [ENEMY] [Enemy6] Memory reset: confusion=2.0s, had_target=false
+[14:37:34] [ENEMY] [Enemy7] Memory reset: confusion=2.0s, had_target=true
+[14:37:34] [ENEMY] [Enemy7] Search mode: PURSUING -> SEARCHING at (450.9239, 836.5493)
+[14:37:34] [ENEMY] [Enemy7] SEARCHING started (spiral): center=(450.9239, 836.5493), radius=100, waypoints=5
+[14:37:34] [ENEMY] [Enemy8] Memory reset: confusion=2.0s, had_target=false
+[14:37:34] [ENEMY] [Enemy9] Memory reset: confusion=2.0s, had_target=false
+[14:37:34] [ENEMY] [Enemy10] Memory reset: confusion=2.0s, had_target=true
+[14:37:34] [ENEMY] [Enemy10] Search mode: PURSUING -> SEARCHING at (450.9239, 836.5493)
+[14:37:34] [ENEMY] [Enemy10] SEARCHING started (spiral): center=(450.9239, 836.5493), radius=100, waypoints=5
+[14:37:34] [INFO] [Player] Reset memory for 10 enemies (invisibility activation - Issue #723)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (613.3078, 700.2555) (added to group)
+[14:37:34] [ENEMY] [Enemy1] SEARCHING corner check: angle -22.0°
+[14:37:34] [ENEMY] [Enemy2] SEARCHING corner check: angle 170.1°
+[14:37:34] [ENEMY] [Enemy3] ROT_CHANGE: P1:visible -> P2:combat_state, state=SEARCHING, target=-118.2°, current=-118.1°, player=(633,631), corner_timer=0.00
+[14:37:34] [ENEMY] [Enemy3] SEARCHING corner check: angle 149.9°
+[14:37:34] [ENEMY] [Enemy4] SEARCHING corner check: angle -37.4°
+[14:37:34] [ENEMY] [Grenadier] SEARCHING corner check: angle 67.1°
+[14:37:34] [ENEMY] [Enemy10] SEARCHING corner check: angle 130.4°
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (664.454, 683.6583) (added to group)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(647.0393, 739.157)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash triggered COMBAT from 9
+[14:37:34] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (647.0393, 739.157)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(410.6241, 606.6737), source=ENEMY (Enemy2), range=800, listeners=10
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash triggered COMBAT from 9
+[14:37:34] [ENEMY] [Enemy4] [#910] Suppressive shot toward invisible player sound at (653.1212, 731.4564)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0656, 826.481), source=ENEMY (Enemy4), range=800, listeners=10
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=4, self=1
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(647.0393, 739.157)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (676.8205, 666.4633) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (630.593, 741.0266) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (672.2309, 743.9077) (added to group)
+[14:37:34] [ENEMY] [Enemy3] Hit: dmg=1, hp=2/2->1/2
+[14:37:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:34] [ENEMY] [Enemy3] [#910] Hit triggered COMBAT from SEARCHING
+[14:37:34] [ENEMY] [Enemy3] [#910] Suppressive shot toward invisible player sound at (869.1194, 984.0941)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(691.5095, 742.32), source=ENEMY (Enemy3), range=800, listeners=10
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(647.0393, 739.157)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [INFO] [BloodyFeet:Enemy3] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(647.0393, 739.157)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(647.0393, 739.157)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(647.0393, 739.157)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(647.0393, 739.157)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (647.0393, 739.157)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(411.0673, 609.2018), source=ENEMY (Enemy2), range=800, listeners=10
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Suppressive shot toward invisible player sound at (653.1212, 731.4564)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(784.0667, 820.3124), source=ENEMY (Enemy4), range=800, listeners=10
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=4, self=1
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (687.5729, 781.188) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (694.9531, 744.368) (added to group)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy3] [#910] Suppressive shot toward invisible player sound at (760.3378, 796.7208)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(682.4954, 726.7781), source=ENEMY (Enemy3), range=800, listeners=10
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy3] Hit: dmg=1, hp=1/2->0/2
+[14:37:34] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[14:37:34] [ENEMY] [Enemy3] Enemy died (ricochet: false, penetration: false, player_kill: false)
+[14:37:34] [INFO] [GameManager] register_kill: laser sight active — kill not counted toward unlock condition
+[14:37:34] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[14:37:34] [ENEMY] [Enemy3] [AllyDeath] Notified 3 enemies
+[14:37:34] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 9)
+[14:37:34] [INFO] [DeathAnim] Started - Angle: -161.2 deg, Index: 1
+[14:37:34] [ENEMY] [Enemy3] Death animation started with hit direction: (-0.946594, -0.322427)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy7] SEARCHING corner check: angle 91.0°
+[14:37:34] [ENEMY] [Enemy4] Hit: dmg=1, hp=2/2->1/2
+[14:37:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (720.3643, 770.3005) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (729.7657, 783.5152) (added to group)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] State: COMBAT -> RETREATING
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(653.1212, 731.4564)
+[14:37:34] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P3:corner, state=RETREATING, target=170.1°, current=-8.6°, player=(703,561), corner_timer=0.23
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (760.3378, 796.7208)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(414.2486, 611.1556), source=ENEMY (Enemy2), range=800, listeners=9
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] ROT_CHANGE: P2:combat_state -> P3:corner, state=RETREATING, target=-37.4°, current=-124.4°, player=(703,561), corner_timer=0.23
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Suppressive shot toward invisible player sound at (760.3378, 796.7208)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(786.3332, 821.7304), source=ENEMY (Enemy4), range=800, listeners=9
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=4, self=1
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy1] SEARCHING corner check: angle -17.9°
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy10] SEARCHING corner check: angle 133.1°
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(790.8546, 824.5591), source=ENEMY (Enemy4), range=800, listeners=9
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=4, self=1
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (637.5593, 698.6998) (added to group)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (686.1101, 736.5946) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (791.1387, 716.8702) (added to group)
+[14:37:34] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(714.8149, 773.289)
+[14:37:34] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (714.8149, 773.289)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(436.5175, 624.8322), source=ENEMY (Enemy2), range=800, listeners=9
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(714.8149, 773.289)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.3378, 796.7208)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(714.8149, 773.289)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(780.2863, 770.0256)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (815.0217, 781.0461) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (736.7729, 753.3467) (added to group)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(714.8149, 773.289)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(780.2863, 770.0256)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(714.8149, 773.289)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(780.2863, 770.0256)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (609.7165, 709.7252) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (665.8036, 719.7711) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (637.4025, 714.3141) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (629.6134, 732.1351) (added to group)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(714.8149, 773.289)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(780.2863, 770.0256)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(714.8149, 773.289)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(780.2863, 770.0256)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (634.7347, 674.7682) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (832.6992, 909.5447) (added to group)
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash triggered COMBAT from 9
+[14:37:34] [ENEMY] [Enemy1] [#910] Suppressive shot toward invisible player sound at (455.746, 596.6652)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(329.9164, 401.9337), source=ENEMY (Enemy1), range=800, listeners=9
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(713.167, 749.5818)
+[14:37:34] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (713.167, 749.5818)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(459.8014, 633.9758), source=ENEMY (Enemy2), range=800, listeners=9
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(780.2863, 770.0256)
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(713.167, 749.5818)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(780.2863, 770.0256)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (618.9675, 683.043) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (609.2164, 747.6933) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (830.8802, 944.4688) (added to group)
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(713.167, 749.5818)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.4405, 793.1623)
+[14:37:34] [ENEMY] [Enemy7] SEARCHING corner check: angle 91.0°
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(713.167, 749.5818)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.4405, 793.1623)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (606.9611, 744.347) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (611.4185, 699.8455) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (603.4997, 725.3893) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (588.7847, 729.2696) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (602.6649, 688.4857) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (840.6442, 869.6785) (added to group)
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(713.167, 749.5818)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.4405, 793.1623)
+[14:37:34] [INFO] [BloodyFeet:Enemy4] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(713.167, 749.5818)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.4405, 793.1623)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (637.6759, 647.2386) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (637.1535, 739.2505) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (597.1201, 705.9215) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (628.5753, 732.0696) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (839.489, 911.4783) (added to group)
+[14:37:34] [ENEMY] [Enemy2] Hit: dmg=1, hp=2/2->1/2
+[14:37:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:34] [ENEMY] [Enemy2] [#910] Hit triggered COMBAT from RETREATING
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy2] ROT_CHANGE: P3:corner -> P2:combat_state, state=COMBAT, target=-26.6°, current=-113.6°, player=(781,484), corner_timer=0.23
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(713.167, 749.5818)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.4405, 793.1623)
+[14:37:34] [ENEMY] [Enemy1] [#910] Suppressive shot toward invisible player sound at (455.746, 596.6652)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(360.3969, 398.0896), source=ENEMY (Enemy1), range=800, listeners=9
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(408.1407, 345.8829)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (455.746, 596.6652)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(485.6429, 637.8696), source=ENEMY (Enemy2), range=800, listeners=9
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.4405, 793.1623)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (572.7651, 732.5073) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (559.5483, 702.989) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (590.8765, 763.3019) (added to group)
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(408.1407, 345.8829)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(760.4405, 793.1623)
+[14:37:34] [ENEMY] [Enemy10] SEARCHING corner check: angle -46.9°
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(408.1407, 345.8829)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(408.1407, 345.8829)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy3] Ragdoll activated
+[14:37:34] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (559.8135, 730.351) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (605.3063, 707.723) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (598.8366, 733.7393) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (840.2506, 975.5541) (added to group)
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(408.1407, 345.8829)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy1] Hit: dmg=1, hp=4/4->3/4
+[14:37:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(408.1407, 345.8829)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (626.2495, 740.1134) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (624.8521, 724.5004) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (646.1922, 705.7474) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (579.957, 691.1818) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (605.6617, 742.9557) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (536.0581, 780.6495) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (523.6334, 702.9638) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (553.1618, 751.9086) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (539.2905, 715.3616) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (874.1848, 921.5525) (added to group)
+[14:37:34] [ENEMY] [Enemy4] Hit: dmg=1, hp=1/2->0/2
+[14:37:34] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (911, 891.6431) (added to group)
+[14:37:34] [ENEMY] [Enemy4] Enemy died (ricochet: true, penetration: false, player_kill: false)
+[14:37:34] [INFO] [GameManager] register_kill: laser sight active — kill not counted toward unlock condition
+[14:37:34] [INFO] [ScoreManager] Ricochet kill registered
+[14:37:34] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[14:37:34] [ENEMY] [Enemy4] [AllyDeath] Notified 2 enemies
+[14:37:34] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 8)
+[14:37:34] [INFO] [DeathAnim] Started - Angle: 17.8 deg, Index: 13
+[14:37:34] [ENEMY] [Enemy4] Death animation started with hit direction: (0.951913, 0.306369)
+[14:37:34] [ENEMY] [Enemy1] State: COMBAT -> RETREATING
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(408.1407, 345.8829)
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(455.746, 596.6652)
+[14:37:34] [ENEMY] [Enemy1] ROT_CHANGE: P2:combat_state -> P3:corner, state=RETREATING, target=-17.9°, current=56.8°, player=(819,469), corner_timer=0.10
+[14:37:34] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(491.1225, 660.0223)
+[14:37:34] [ENEMY] [Enemy1] [#910] Suppressive shot toward invisible player sound at (491.1225, 660.0223)
+[14:37:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(402.425, 405.4265), source=ENEMY (Enemy1), range=800, listeners=8
+[14:37:34] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=1
+[14:37:34] [ENEMY] [Enemy2] State: COMBAT -> RETREATING
+[14:37:34] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(381.5934, 398.4152)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (875.4816, 950.4625) (added to group)
+[14:37:34] [INFO] [BloodDecal] Blood puddle created at (906.2201, 933.2394) (added to group)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(491.1225, 660.0223)
+[14:37:35] [ENEMY] [Enemy2] ROT_CHANGE: P2:combat_state -> P3:corner, state=RETREATING, target=170.1°, current=-87.8°, player=(824,469), corner_timer=0.23
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(381.5934, 398.4152)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(491.1225, 660.0223)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(381.5934, 398.4152)
+[14:37:35] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (381.5934, 398.4152)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(515.9934, 644.6306), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=1
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(491.1225, 660.0223)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(381.5934, 398.4152)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (638.4808, 659.7245) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (496.4049, 756.7955) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (519.585, 738.1495) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (543.8149, 741.1366) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (572.2217, 730.7935) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (856.2895, 996.951) (added to group)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(491.1225, 660.0223)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(381.5934, 398.4152)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(491.1225, 660.0223)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(381.5934, 398.4152)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(491.1225, 660.0223)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(381.5934, 398.4152)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (605.0245, 730.5366) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (570.6054, 786.8431) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (537.0162, 785.2855) (added to group)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy1] [#910] Suppressive shot toward invisible player sound at (471.1602, 602.6217)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(439.2735, 411.4238), source=ENEMY (Enemy1), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=1
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy4] [#910] Suppressive shot toward invisible player sound at (546.6407, 602.0164)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(867.0187, 877.1661), source=ENEMY (Enemy4), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=3, self=0
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy7] SEARCHING corner check: angle 90.9°
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (471.1602, 602.6217)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(531.7874, 654.5803), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=1
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (568.7289, 795.0643) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (504.2115, 751.6684) (added to group)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (465.3918, 758.3199) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (441.773, 814.173) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (346.1313, 372.7591) (added to group)
+[14:37:35] [ENEMY] [Enemy1] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(471.1602, 602.6217)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy10] SEARCHING corner check: angle 133.1°
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (377.2644, 355.4063) (added to group)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (546.6407, 602.0164)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(556.6066, 670.2156), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=1
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy1] State: RETREATING -> IN_COVER
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [INFO] [BloodyFeet:Enemy2] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (551.8017, 764.5806) (added to group)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (546.6407, 602.0164)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(588.1946, 690.115), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=1
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (573.4532, 823.788) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (347.0204, 381.0065) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (356.3362, 304.6141) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (385.3365, 350.4598) (added to group)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(546.6407, 602.0164)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (380.5694, 364.3773) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (366.0812, 289.2549) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (373.0469, 340.1563) (added to group)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(575.762, 594.3348)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy7] SEARCHING corner check: angle 90.8°
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(575.762, 594.3348)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] Ragdoll activated
+[14:37:35] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (562.1364, 794.1384) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (336.7607, 394.2384) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (293.7263, 381.8623) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (371.5422, 297.0295) (added to group)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(575.762, 594.3348)
+[14:37:35] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (575.762, 594.3348)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(617.5967, 711.6606), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=5, self=1
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(575.762, 594.3348)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (277.7191, 318.4054) (added to group)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(575.762, 594.3348)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(575.762, 594.3348)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (636.4459, 871.5173) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (344.7983, 375.4415) (added to group)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (311.3467, 420.0987) (added to group)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(575.762, 594.3348)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy10] SEARCHING corner check: angle 133.1°
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [INFO] [BloodDecal] Blood puddle created at (340.4582, 288.7219) (added to group)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy3] [#910] Muzzle flash detected (invisible player): est_pos=(828.2304, 874.7781)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (582.611, 636.7386)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(629.2386, 733.5844), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=4, self=1
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[14:37:35] [ENEMY] [Enemy1] State: IN_COVER -> SUPPRESSED
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(582.611, 636.7386)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (594.458, 645.5228)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(645.9595, 760.0774), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=4, self=1
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.458, 645.5228)
+[14:37:35] [ENEMY] [Enemy7] SEARCHING corner check: angle 90.7°
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [WARN] [FPS] Drop detected: 26 fps (threshold: 30)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy2] State: RETREATING -> IN_COVER
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (594.8327, 679.9998)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(670.9275, 786.4871), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=4, self=1
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy10] SEARCHING corner check: angle 133.1°
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(594.8327, 679.9998)
+[14:37:35] [ENEMY] [Enemy3] Death animation completed
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(689.4599, 725.8869)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(689.4599, 725.8869)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:35] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (600.8149, 761.9865)
+[14:37:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(670.9275, 786.4871), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:35] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=4, self=1
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(689.4599, 725.8869)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(689.4599, 725.8869)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(689.4599, 725.8869)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(689.4599, 725.8869)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:35] [ENEMY] [Enemy4] [#910] Muzzle flash detected (invisible player): est_pos=(689.4599, 725.8869)
+[14:37:35] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:36] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (600.8149, 761.9865)
+[14:37:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(670.9275, 786.4871), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:36] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=4, self=1
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:36] [ENEMY] [Enemy7] SEARCHING corner check: angle 90.7°
+[14:37:36] [ENEMY] [Enemy2] State: IN_COVER -> SUPPRESSED
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(600.8149, 761.9865)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(624.058, 787.8144)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(624.058, 787.8144)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(624.058, 787.8144)
+[14:37:36] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (624.058, 787.8144)
+[14:37:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(670.9275, 786.4871), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:36] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=4, self=1
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(624.058, 787.8144)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(624.058, 787.8144)
+[14:37:36] [ENEMY] [Enemy10] SEARCHING corner check: angle 133.1°
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(624.058, 787.8144)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(624.058, 787.8144)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(626.7567, 804.6196)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(626.7567, 804.6196)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(626.7567, 804.6196)
+[14:37:36] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (626.7567, 804.6196)
+[14:37:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(670.9275, 786.4871), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:36] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=4, self=1
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(626.7567, 804.6196)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(626.7567, 804.6196)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(626.7567, 804.6196)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(626.7567, 804.6196)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(628.7542, 825.0272)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(628.7542, 825.0272)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(628.7542, 825.0272)
+[14:37:36] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (628.7542, 825.0272)
+[14:37:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(670.9275, 786.4871), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:36] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=1
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(628.7542, 825.0272)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(628.7542, 825.0272)
+[14:37:36] [ENEMY] [Enemy7] SEARCHING corner check: angle 90.6°
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(628.7542, 825.0272)
+[14:37:36] [ENEMY] [Enemy4] Death animation completed
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(628.7542, 825.0272)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.999, 799.4421)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.999, 799.4421)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.999, 799.4421)
+[14:37:36] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (634.999, 799.4421)
+[14:37:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(670.9275, 786.4871), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:36] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=1
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.999, 799.4421)
+[14:37:36] [ENEMY] [Enemy10] SEARCHING corner check: angle 141.2°
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.999, 799.4421)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.999, 799.4421)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.999, 799.4421)
+[14:37:36] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.0198, 799.538)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.0198, 799.538)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.0198, 799.538)
+[14:37:36] [ENEMY] [Enemy2] [#910] Suppressive shot toward invisible player sound at (635.0198, 799.538)
+[14:37:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(670.9275, 786.4871), source=ENEMY (Enemy2), range=800, listeners=8
+[14:37:36] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=3, self=1
+[14:37:36] [ENEMY] [Enemy2] Hit: dmg=1, hp=1/2->0/2
+[14:37:36] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[14:37:36] [ENEMY] [Enemy2] Enemy died (ricochet: true, penetration: false, player_kill: false)
+[14:37:36] [INFO] [GameManager] register_kill: laser sight active — kill not counted toward unlock condition
+[14:37:36] [INFO] [ScoreManager] Ricochet kill registered
+[14:37:36] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[14:37:36] [ENEMY] [Enemy10] [AllyDeath] Witnessed at (670.9275, 786.4871), entering SEARCHING
+[14:37:36] [ENEMY] [Enemy10] SEARCHING started (spiral): center=(670.9275, 786.4871), radius=100, waypoints=5
+[14:37:36] [ENEMY] [Enemy2] [AllyDeath] Notified 2 enemies
+[14:37:36] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 7)
+[14:37:36] [INFO] [DeathAnim] Started - Angle: -53.1 deg, Index: 8
+[14:37:36] [ENEMY] [Enemy2] Death animation started with hit direction: (0.600772, -0.799421)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.0198, 799.538)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.0198, 799.538)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.0198, 799.538)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.0198, 799.538)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(616.838, 777.9911)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(616.838, 777.9911)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(616.838, 777.9911)
+[14:37:36] [ENEMY] [Enemy7] SEARCHING: Stuck at wp 0, skipping
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(616.838, 777.9911)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(616.838, 777.9911)
+[14:37:36] [ENEMY] [Enemy7] SEARCHING corner check: angle 95.0°
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(616.838, 777.9911)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(616.838, 777.9911)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.8842, 798.9373)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.8842, 798.9373)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.8842, 798.9373)
+[14:37:36] [ENEMY] [Enemy10] SEARCHING corner check: angle -168.0°
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.8842, 798.9373)
+[14:37:36] [INFO] [BloodDecal] Blood puddle created at (728.8159, 757.5334) (added to group)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.8842, 798.9373)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.8842, 798.9373)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(634.8842, 798.9373)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.4117, 801.7676)
+[14:37:36] [INFO] [BloodDecal] Blood puddle created at (746.5745, 772.1578) (added to group)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.4117, 801.7676)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.4117, 801.7676)
+[14:37:36] [INFO] [BloodDecal] Blood puddle created at (683.7794, 751.0097) (added to group)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.4117, 801.7676)
+[14:37:36] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.4117, 801.7676)
+[14:37:36] [INFO] [BloodDecal] Blood puddle created at (754.1974, 724.7175) (added to group)
+[14:37:36] [INFO] [BloodDecal] Blood puddle created at (758.3054, 726.1034) (added to group)
+[14:37:36] [INFO] [BloodDecal] Blood puddle created at (698.1266, 708.0051) (added to group)
+[14:37:37] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.4117, 801.7676)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (712.7443, 698.4506) (added to group)
+[14:37:37] [ENEMY] [Enemy2] [#910] Muzzle flash detected (invisible player): est_pos=(635.4117, 801.7676)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (738.3749, 708.8157) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (740.4886, 762.2356) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (761.7172, 730.9246) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (696.3931, 699.2843) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (793.6544, 738.2186) (added to group)
+[14:37:37] [ENEMY] [Enemy2] Ragdoll activated
+[14:37:37] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[14:37:37] [ENEMY] [Enemy7] SEARCHING corner check: angle 94.5°
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (711.1874, 709.6396) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (736.951, 786.8015) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (787.4612, 773.5604) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (712.6675, 752.1337) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (803.5973, 738.678) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (764.9774, 794.6437) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (744.0788, 732.3281) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (759.428, 803.4661) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (759.5205, 753.9447) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (756.7957, 695.585) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (691.2153, 770.9659) (added to group)
+[14:37:37] [ENEMY] [Enemy10] SEARCHING corner check: angle -171.8°
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (771.8473, 770.1454) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (801.4412, 725.1711) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (755.3726, 700.804) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (730.7087, 803.6666) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (708.5441, 706.0414) (added to group)
+[14:37:37] [INFO] [BloodDecal] Blood puddle created at (736.2418, 682.8949) (added to group)
+[14:37:37] [ENEMY] [Enemy7] SEARCHING corner check: angle 94.0°
+[14:37:37] [ENEMY] [Enemy10] SEARCHING corner check: angle -174.5°
+[14:37:37] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[14:37:37] [ENEMY] [Enemy7] SEARCHING corner check: angle 93.7°
+[14:37:37] [ENEMY] [Enemy10] SEARCHING corner check: angle -176.3°
+[14:37:38] [ENEMY] [Enemy7] SEARCHING corner check: angle 93.7°
+[14:37:38] [ENEMY] [Enemy2] Death animation completed
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [ENEMY] [Enemy10] SEARCHING corner check: angle -177.5°
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [ENEMY] [Enemy7] SEARCHING corner check: angle 93.7°
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [ENEMY] [Enemy10] SEARCHING corner check: angle -178.3°
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [INFO] [InvisibilitySuit] Deactivating (fade out)
+[14:37:38] [ENEMY] [Enemy7] SEARCHING corner check: angle 93.7°
+[14:37:38] [ENEMY] [Enemy10] SEARCHING corner check: angle -178.9°
+[14:37:39] [ENEMY] [Enemy7] SEARCHING corner check: angle 93.7°
+[14:37:39] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.2°
+[14:37:39] [ENEMY] [Enemy7] SEARCHING corner check: angle 93.7°
+[14:37:39] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.5°
+[14:37:39] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 0, skipping
+[14:37:39] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=10
+[14:37:39] [ENEMY] [Enemy7] SEARCHING: Stuck at wp 1, skipping
+[14:37:39] [ENEMY] [Enemy7] SEARCHING corner check: angle 94.0°
+[14:37:39] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.7°
+[14:37:40] [ENEMY] [Enemy7] SEARCHING corner check: angle 94.0°
+[14:37:40] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.8°
+[14:37:40] [ENEMY] [Enemy10] SEARCHING: Stuck at wp 0, skipping
+[14:37:40] [ENEMY] [Enemy7] SEARCHING corner check: angle 94.0°
+[14:37:40] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.9°
+[14:37:40] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=10
+[14:37:40] [ENEMY] [Enemy7] SEARCHING corner check: angle 94.0°
+[14:37:40] [ENEMY] [Enemy1] State: SUPPRESSED -> IN_COVER
+[14:37:40] [ENEMY] [Enemy1] State: IN_COVER -> PURSUING
+[14:37:40] [ENEMY] [Enemy1] ROT_CHANGE: P3:corner -> P2:combat_state, state=PURSUING, target=28.8°, current=-17.9°, player=(1035,728), corner_timer=0.10
+[14:37:40] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.9°
+[14:37:41] [ENEMY] [Enemy7] SEARCHING corner check: angle 94.0°
+[14:37:41] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.9°
+[14:37:41] [ENEMY] [Enemy7] SEARCHING corner check: angle 94.0°
+[14:37:41] [ENEMY] [Enemy10] SEARCHING corner check: angle -180.0°
+[14:37:41] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=10
+[14:37:41] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 1, skipping
+[14:37:41] [INFO] [ScoreManager] Combo ended at 3. Max combo: 3
+[14:37:41] [ENEMY] [Enemy7] SEARCHING: Stuck at wp 2, skipping
+[14:37:41] [ENEMY] [Enemy7] SEARCHING corner check: angle 84.6°
+[14:37:41] [ENEMY] [Enemy10] SEARCHING corner check: angle -180.0°
+[14:37:42] [ENEMY] [Enemy7] SEARCHING corner check: angle 85.2°
+[14:37:42] [ENEMY] [Enemy10] SEARCHING corner check: angle -180.0°
+[14:37:42] [ENEMY] [Enemy10] SEARCHING: Stuck at wp 1, skipping
+[14:37:42] [ENEMY] [Enemy1] PURSUING corner check: angle 162.9°
+[14:37:42] [ENEMY] [Enemy7] SEARCHING corner check: angle 85.7°
+[14:37:42] [ENEMY] [Enemy10] SEARCHING corner check: angle 11.4°
+[14:37:42] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=10
+[14:37:42] [ENEMY] [Enemy1] PURSUING corner check: angle -150.4°
+[14:37:42] [ENEMY] [Enemy7] SEARCHING corner check: angle 86.2°
+[14:37:42] [ENEMY] [Enemy10] SEARCHING corner check: angle -171.6°
+[14:37:43] [ENEMY] [Enemy1] PURSUING corner check: angle -12.5°
+[14:37:43] [ENEMY] [Enemy7] SEARCHING corner check: angle 86.6°
+[14:37:43] [ENEMY] [Enemy10] SEARCHING corner check: angle -173.8°
+[14:37:43] [INFO] [BloodyFeet:Enemy1] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[14:37:43] [ENEMY] [Enemy1] PURSUING corner check: angle -47.8°
+[14:37:43] [ENEMY] [Enemy7] SEARCHING corner check: angle 87.0°
+[14:37:43] [ENEMY] [Enemy10] SEARCHING corner check: angle -175.4°
+[14:37:43] [INFO] [ReplayManager] Recording frame 720 (12,0s): player_valid=True, enemies=10
+[14:37:43] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 2, skipping
+[14:37:43] [ENEMY] [Enemy7] SEARCHING corner check: angle 87.3°
+[14:37:43] [ENEMY] [Enemy10] SEARCHING corner check: angle -176.6°
+[14:37:44] [ENEMY] [Enemy7] SEARCHING corner check: angle 87.6°
+[14:37:44] [ENEMY] [Enemy10] SEARCHING corner check: angle -177.5°
+[14:37:44] [ENEMY] [Enemy7] SEARCHING corner check: angle 87.9°
+[14:37:44] [ENEMY] [Enemy10] SEARCHING corner check: angle -178.2°
+[14:37:44] [INFO] [ReplayManager] Recording frame 780 (13,0s): player_valid=True, enemies=10
+[14:37:44] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.1°
+[14:37:44] [ENEMY] [Enemy10] SEARCHING corner check: angle -178.6°
+[14:37:45] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.3°
+[14:37:45] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.0°
+[14:37:45] [ENEMY] [Enemy1] PURSUING corner check: angle 95.5°
+[14:37:45] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.5°
+[14:37:45] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.3°
+[14:37:45] [INFO] [ReplayManager] Recording frame 840 (14,0s): player_valid=True, enemies=10
+[14:37:45] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 3, skipping
+[14:37:45] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.7°
+[14:37:45] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.5°
+[14:37:46] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.8°
+[14:37:46] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.6°
+[14:37:46] [ENEMY] [Enemy7] SEARCHING corner check: angle 88.9°
+[14:37:46] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.7°
+[14:37:46] [INFO] [ReplayManager] Recording frame 900 (15,0s): player_valid=True, enemies=10
+[14:37:46] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.1°
+[14:37:46] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.8°
+[14:37:47] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.2°
+[14:37:47] [ENEMY] [Enemy1] PURSUING corner check: angle 101.4°
+[14:37:47] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.8°
+[14:37:47] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.2°
+[14:37:47] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.9°
+[14:37:47] [INFO] [ReplayManager] Recording frame 960 (16,0s): player_valid=True, enemies=10
+[14:37:47] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 4, skipping
+[14:37:47] [ENEMY] [Grenadier] SEARCHING: Expand outer ring r=175 wps=4
+[14:37:47] [ENEMY] [Grenadier] SEARCHING corner check: angle -96.1°
+[14:37:47] [ENEMY] [Enemy10] SEARCHING: Stuck at wp 2, skipping
+[14:37:47] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.3°
+[14:37:47] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.9°
+[14:37:47] [ENEMY] [Grenadier] SEARCHING corner check: angle -96.1°
+[14:37:48] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.4°
+[14:37:48] [ENEMY] [Enemy10] SEARCHING corner check: angle -179.9°
+[14:37:48] [ENEMY] [Grenadier] SEARCHING corner check: angle -96.1°
+[14:37:48] [ENEMY] [Enemy7] SEARCHING: Stuck at wp 3, skipping
+[14:37:48] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.5°
+[14:37:48] [ENEMY] [Enemy10] SEARCHING corner check: angle -180.0°
+[14:37:48] [INFO] [ReplayManager] Recording frame 1020 (17,0s): player_valid=True, enemies=10
+[14:37:48] [ENEMY] [Grenadier] SEARCHING corner check: angle -96.1°
+[14:37:48] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.6°
+[14:37:48] [ENEMY] [Enemy10] SEARCHING corner check: angle -180.0°
+[14:37:48] [ENEMY] [Grenadier] SEARCHING corner check: angle -96.1°
+[14:37:49] [ENEMY] [Enemy1] PURSUING corner check: angle 78.6°
+[14:37:49] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.6°
+[14:37:49] [ENEMY] [Enemy10] SEARCHING corner check: angle -180.0°
+[14:37:49] [ENEMY] [Grenadier] SEARCHING corner check: angle -96.1°
+[14:37:49] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.7°
+[14:37:49] [ENEMY] [Enemy10] SEARCHING corner check: angle -180.0°
+[14:37:49] [INFO] [ReplayManager] Recording frame 1080 (18,0s): player_valid=True, enemies=10
+[14:37:49] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 0, skipping
+[14:37:49] [ENEMY] [Grenadier] SEARCHING corner check: angle -97.8°
+[14:37:49] [ENEMY] [Enemy10] SEARCHING: Stuck at wp 3, skipping
+[14:37:49] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.7°
+[14:37:49] [ENEMY] [Enemy10] SEARCHING corner check: angle 146.7°
+[14:37:49] [ENEMY] [Grenadier] SEARCHING corner check: angle -97.8°
+[14:37:50] [ENEMY] [Enemy7] SEARCHING corner check: angle 89.7°
+[14:37:50] [ENEMY] [Enemy10] SEARCHING corner check: angle 158.1°
+[14:37:50] [ENEMY] [Grenadier] SEARCHING corner check: angle -97.8°
+[14:37:50] [ENEMY] [Enemy7] SEARCHING: Stuck at wp 4, skipping
+[14:37:50] [ENEMY] [Enemy7] SEARCHING: Expand outer ring r=175 wps=4
+[14:37:50] [ENEMY] [Enemy7] SEARCHING corner check: angle 101.9°
+[14:37:50] [INFO] [ReplayManager] Recording frame 1140 (19,0s): player_valid=True, enemies=10
+[14:37:50] [ENEMY] [Enemy10] SEARCHING corner check: angle 166.7°
+[14:37:50] [ENEMY] [Grenadier] SEARCHING corner check: angle -97.8°
+[14:37:50] [ENEMY] [Enemy7] SEARCHING corner check: angle 100.8°
+[14:37:50] [ENEMY] [Enemy10] SEARCHING corner check: angle 172.2°
+[14:37:50] [ENEMY] [Enemy1] PURSUING corner check: angle 77.3°
+[14:37:50] [ENEMY] [Grenadier] SEARCHING corner check: angle -97.8°
+[14:37:51] [ENEMY] [Enemy7] SEARCHING corner check: angle 99.8°
+[14:37:51] [ENEMY] [Enemy10] SEARCHING corner check: angle 175.5°
+[14:37:51] [ENEMY] [Enemy1] PURSUING corner check: angle 56.1°
+[14:37:51] [ENEMY] [Grenadier] SEARCHING corner check: angle -97.8°
+[14:37:51] [ENEMY] [Enemy7] SEARCHING corner check: angle 98.9°
+[14:37:51] [INFO] [ReplayManager] Recording frame 1200 (20,0s): player_valid=True, enemies=10
+[14:37:51] [ENEMY] [Enemy10] SEARCHING corner check: angle 177.4°
+[14:37:51] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 1, skipping
+[14:37:51] [ENEMY] [Enemy7] SEARCHING corner check: angle 98.1°
+[14:37:51] [ENEMY] [Enemy10] SEARCHING corner check: angle 178.5°
+[14:37:52] [ENEMY] [Enemy7] SEARCHING corner check: angle 97.6°
+[14:37:52] [ENEMY] [Enemy10] SEARCHING corner check: angle 179.2°
+[14:37:52] [ENEMY] [Enemy7] SEARCHING corner check: angle 97.6°
+[14:37:52] [INFO] [ReplayManager] Recording frame 1260 (21,0s): player_valid=True, enemies=10
+[14:37:52] [ENEMY] [Enemy10] SEARCHING corner check: angle 179.5°
+[14:37:52] [ENEMY] [Enemy7] SEARCHING corner check: angle 97.6°
+[14:37:52] [ENEMY] [Enemy10] SEARCHING corner check: angle 179.7°
+[14:37:53] [ENEMY] [Enemy1] PURSUING corner check: angle 99.0°
+[14:37:53] [ENEMY] [Enemy7] SEARCHING corner check: angle 97.6°
+[14:37:53] [ENEMY] [Enemy10] SEARCHING corner check: angle 179.8°
+[14:37:53] [ENEMY] [Enemy7] SEARCHING corner check: angle 97.6°
+[14:37:53] [INFO] [ReplayManager] Recording frame 1320 (22,0s): player_valid=True, enemies=10
+[14:37:53] [ENEMY] [Enemy10] SEARCHING: Stuck at wp 4, skipping
+[14:37:53] [ENEMY] [Enemy10] SEARCHING: Expand outer ring r=175 wps=4
+[14:37:53] [ENEMY] [Enemy10] SEARCHING corner check: angle 180.0°
+[14:37:53] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 2, skipping
+[14:37:53] [ENEMY] [Enemy7] SEARCHING corner check: angle 97.6°
+[14:37:53] [ENEMY] [Enemy7] SEARCHING: Stuck at wp 0, skipping
+[14:37:53] [ENEMY] [Enemy10] SEARCHING corner check: angle 180.0°
+[14:37:54] [ENEMY] [Enemy10] SEARCHING corner check: angle 180.0°
+[14:37:54] [INFO] [ReplayManager] Recording frame 1380 (23,0s): player_valid=True, enemies=10
+[14:37:54] [ENEMY] [Enemy10] SEARCHING corner check: angle 180.0°
+[14:37:54] [ENEMY] [Enemy10] SEARCHING corner check: angle 180.0°
+[14:37:54] [ENEMY] [Enemy1] PURSUING corner check: angle -90.7°
+[14:37:55] [ENEMY] [Enemy10] SEARCHING corner check: angle 180.0°
+[14:37:55] [INFO] [ReplayManager] Recording frame 1440 (24,0s): player_valid=True, enemies=10
+[14:37:55] [ENEMY] [Enemy10] SEARCHING: Stuck at wp 0, skipping
+[14:37:55] [ENEMY] [Enemy10] SEARCHING corner check: angle 28.7°
+[14:37:55] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 3, skipping
+[14:37:55] [ENEMY] [Grenadier] SEARCHING: Expand outer ring r=250 wps=4
+[14:37:55] [ENEMY] [Grenadier] SEARCHING corner check: angle -91.8°
+[14:37:55] [ENEMY] [Enemy7] SEARCHING: Stuck at wp 1, skipping
+[14:37:55] [ENEMY] [Enemy7] SEARCHING corner check: angle 78.7°
+[14:37:55] [ENEMY] [Enemy10] SEARCHING corner check: angle 23.6°
+[14:37:56] [ENEMY] [Grenadier] SEARCHING corner check: angle -91.8°
+[14:37:56] [ENEMY] [Enemy7] SEARCHING corner check: angle 80.0°
+[14:37:56] [ENEMY] [Enemy10] SEARCHING corner check: angle 19.1°
+[14:37:56] [ENEMY] [Grenadier] SEARCHING corner check: angle -91.8°
+[14:37:56] [ENEMY] [Enemy7] SEARCHING corner check: angle 81.1°
+[14:37:56] [INFO] [ReplayManager] Recording frame 1500 (25,0s): player_valid=True, enemies=10
+[14:37:56] [ENEMY] [Enemy10] SEARCHING corner check: angle 15.2°
+[14:37:56] [ENEMY] [Grenadier] SEARCHING corner check: angle -91.8°
+[14:37:56] [ENEMY] [Enemy1] PURSUING corner check: angle 52.1°
+[14:37:56] [ENEMY] [Enemy7] SEARCHING corner check: angle 82.2°
+[14:37:56] [ENEMY] [Enemy10] SEARCHING corner check: angle 12.0°
+[14:37:57] [ENEMY] [Grenadier] SEARCHING corner check: angle -91.8°
+[14:37:57] [ENEMY] [Enemy7] SEARCHING corner check: angle 83.1°
+[14:37:57] [ENEMY] [Enemy10] SEARCHING corner check: angle 9.5°
+[14:37:57] [ENEMY] [Grenadier] SEARCHING corner check: angle -91.8°
+[14:37:57] [ENEMY] [Enemy7] SEARCHING corner check: angle 83.9°
+[14:37:57] [INFO] [ReplayManager] Recording frame 1560 (26,0s): player_valid=True, enemies=10
+[14:37:57] [ENEMY] [Enemy10] SEARCHING corner check: angle -172.6°
+[14:37:57] [ENEMY] [Grenadier] SEARCHING: Stuck at wp 0, skipping
+[14:37:57] [ENEMY] [Grenadier] SEARCHING corner check: angle -92.8°
+[14:37:57] [ENEMY] [Enemy7] SEARCHING corner check: angle 84.6°
+[14:37:57] [ENEMY] [Enemy10] SEARCHING corner check: angle -174.2°
+[14:37:58] [ENEMY] [Grenadier] SEARCHING corner check: angle -92.8°
+[14:37:58] [ENEMY] [Enemy7] SEARCHING corner check: angle 85.3°
+[14:37:58] [ENEMY] [Enemy10] SEARCHING corner check: angle -175.5°
+[14:37:58] [ENEMY] [Grenadier] SEARCHING corner check: angle -92.8°
+[14:37:58] [INFO] ------------------------------------------------------------
+[14:37:58] [INFO] GAME LOG ENDED: 2026-03-21T14:37:58
+[14:37:58] [INFO] ============================================================

--- a/scripts/objects/enemy.gd
+++ b/scripts/objects/enemy.gd
@@ -2354,7 +2354,9 @@ func _process_searching_state(delta: float) -> void:
 		else:
 			_nav_agent.target_position = target_waypoint
 			if _nav_agent.is_navigation_finished():
-				_mark_zone_visited(target_waypoint); _search_current_waypoint_index += 1
+				# Issue #1275: Do not mark visited — enemy didn't physically touch the waypoint.
+				# Skip to next waypoint without marking as visited so future spiral rings can still include this zone.
+				_search_current_waypoint_index += 1
 				_search_moving_to_waypoint = true; _search_stuck_timer = 0.0
 			else:
 				var next_pos := _nav_agent.get_next_path_position()
@@ -2366,7 +2368,9 @@ func _process_searching_state(delta: float) -> void:
 					_search_stuck_timer += delta
 					if _search_stuck_timer >= SEARCH_STUCK_MAX_TIME:  # Stuck - skip waypoint
 						_log_to_file("SEARCHING: Stuck at wp %d, skipping" % _search_current_waypoint_index)
-						_mark_zone_visited(target_waypoint); _search_current_waypoint_index += 1
+						# Issue #1275: Do not mark visited — enemy was stuck and never touched the waypoint.
+						# Skipping without marking visited so the zone can be reconsidered later.
+						_search_current_waypoint_index += 1
 						_search_moving_to_waypoint = true; _search_stuck_timer = 0.0
 						_search_last_progress_position = global_position; return
 				else:

--- a/tests/unit/test_search_path_wall_awareness.gd
+++ b/tests/unit/test_search_path_wall_awareness.gd
@@ -234,6 +234,166 @@ func test_pre_fix_behaviour_would_have_included_cross_wall_waypoint() -> void:
 
 
 # ============================================================================
+# Visited-zone marking tests (Issue #1275 owner feedback)
+# Owner requirement: a zone is only counted as visited when the enemy physically
+# touches (reaches) the waypoint — not when it skips due to being stuck or when
+# the NavigationAgent reports navigation finished from afar.
+# ============================================================================
+
+
+class StubSearchStateProcessor:
+	## Simulates the visited-zone marking logic from _process_searching_state().
+	## Only marks a zone visited when the enemy has physically scanned it
+	## (i.e. arrived within REACHED_DISTANCE and completed the scan timer).
+
+	const REACHED_DISTANCE: float = 20.0
+	const SCAN_DURATION: float = 1.0
+	const STUCK_MAX_TIME: float = 2.0
+	const PROGRESS_THRESHOLD: float = 10.0
+
+	var visited: Dictionary = {}
+	var waypoints: Array[Vector2] = []
+	var current_index: int = 0
+	var moving: bool = true
+	var scan_timer: float = 0.0
+	var stuck_timer: float = 0.0
+	var last_progress_pos: Vector2 = Vector2.ZERO
+	var enemy_pos: Vector2 = Vector2.ZERO
+
+	## Simulate one "frame" of the searching state.
+	## nav_finished: whether NavigationAgent.is_navigation_finished() would return true.
+	## progress: distance the enemy "moved" this frame.
+	## delta: frame time.
+	func process_frame(delta: float, nav_finished: bool, progress: float) -> void:
+		if current_index >= waypoints.size():
+			return
+		var wp := waypoints[current_index]
+		var dist := enemy_pos.distance_to(wp)
+		if moving:
+			if dist <= REACHED_DISTANCE:
+				# Physically arrived — start scanning
+				moving = false; scan_timer = 0.0; stuck_timer = 0.0
+			elif nav_finished:
+				# Nav agent says done but enemy is not close — Issue #1275 fix:
+				# do NOT mark visited, just skip to next waypoint.
+				current_index += 1; moving = true; stuck_timer = 0.0
+			else:
+				# Moving toward waypoint
+				if progress < PROGRESS_THRESHOLD:
+					stuck_timer += delta
+					if stuck_timer >= STUCK_MAX_TIME:
+						# Stuck — Issue #1275 fix: do NOT mark visited, just skip.
+						current_index += 1; moving = true; stuck_timer = 0.0
+				else:
+					stuck_timer = 0.0
+		else:
+			# Scanning at waypoint
+			scan_timer += delta
+			if scan_timer >= SCAN_DURATION:
+				# Scan complete — enemy physically touched and scanned this zone.
+				_mark_visited(wp); current_index += 1; moving = true
+
+	func _mark_visited(pos: Vector2) -> void:
+		var k := "%d,%d" % [int(pos.x / 50.0) * 50, int(pos.y / 50.0) * 50]
+		visited[k] = true
+
+	func is_visited(pos: Vector2) -> bool:
+		var k := "%d,%d" % [int(pos.x / 50.0) * 50, int(pos.y / 50.0) * 50]
+		return visited.has(k)
+
+
+func _make_processor(wp: Vector2, enemy_at: Vector2) -> StubSearchStateProcessor:
+	var p := StubSearchStateProcessor.new()
+	p.waypoints = [wp]
+	p.enemy_pos = enemy_at
+	p.last_progress_pos = enemy_at
+	return p
+
+
+func test_stuck_waypoint_not_marked_visited() -> void:
+	## When the enemy is stuck and skips a waypoint, the zone must NOT be marked visited
+	## so future spiral rings can still include that position.
+	var wp := Vector2(200, 0)
+	var p := _make_processor(wp, Vector2(0, 0))
+	# Enemy is far from waypoint and making no progress (stuck)
+	p.enemy_pos = Vector2(0, 0)  # far from wp
+
+	# Simulate stuck: no progress for STUCK_MAX_TIME + 1 extra frame
+	var frames := int(StubSearchStateProcessor.STUCK_MAX_TIME / 0.1) + 1
+	for _i in range(frames):
+		p.process_frame(0.1, false, 0.0)  # progress=0 → stuck
+
+	assert_false(p.is_visited(wp),
+		"Stuck-skipped waypoint must NOT be marked visited (Issue #1275)")
+	assert_eq(p.current_index, 1, "Index should advance past the stuck waypoint")
+
+
+func test_nav_finished_early_not_marked_visited() -> void:
+	## When NavigationAgent.is_navigation_finished() fires before the enemy is close,
+	## the zone must NOT be marked visited.
+	var wp := Vector2(300, 0)
+	var p := _make_processor(wp, Vector2(0, 0))
+	p.enemy_pos = Vector2(0, 0)  # far from wp
+
+	# One frame where nav says finished but enemy is not close
+	p.process_frame(0.1, true, 100.0)
+
+	assert_false(p.is_visited(wp),
+		"Nav-finished-early waypoint must NOT be marked visited (Issue #1275)")
+	assert_eq(p.current_index, 1, "Index should advance past the waypoint")
+
+
+func test_physically_reached_and_scanned_marked_visited() -> void:
+	## When the enemy physically arrives (dist ≤ REACHED_DISTANCE) and completes
+	## the scan timer, the zone IS marked visited.
+	var wp := Vector2(10, 0)  # within REACHED_DISTANCE of origin
+	var p := _make_processor(wp, Vector2(0, 0))
+	p.enemy_pos = Vector2(5, 0)  # within 20px of wp → "touches" it
+
+	# First frame: arrives (moving → scanning)
+	p.process_frame(0.1, false, 0.0)
+	assert_false(p.is_visited(wp), "Not yet visited — still scanning")
+
+	# Scan frames until SCAN_DURATION is exceeded
+	var scan_frames := int(StubSearchStateProcessor.SCAN_DURATION / 0.1) + 1
+	for _i in range(scan_frames):
+		p.process_frame(0.1, false, 0.0)
+
+	assert_true(p.is_visited(wp),
+		"Zone must be visited after enemy physically touches and scans it (Issue #1275)")
+
+
+func test_stuck_then_reached_on_retry_marks_visited() -> void:
+	## Validates the full intended flow: enemy skips a stuck wp without marking it
+	## visited, so the zone remains available for future spiral regeneration.
+	## Here we verify that if the enemy later physically reaches the same position,
+	## it IS then marked visited.
+	var wp_stuck := Vector2(200, 0)
+	var wp_close := Vector2(10, 0)
+	var p := StubSearchStateProcessor.new()
+	p.waypoints = [wp_stuck, wp_close]
+	p.enemy_pos = Vector2(0, 0)
+
+	# Get stuck on first wp
+	var stuck_frames := int(StubSearchStateProcessor.STUCK_MAX_TIME / 0.1) + 1
+	for _i in range(stuck_frames):
+		p.process_frame(0.1, false, 0.0)
+
+	assert_false(p.is_visited(wp_stuck), "Stuck wp should not be marked visited")
+	assert_eq(p.current_index, 1, "Should advance to second waypoint")
+
+	# Now physically reach the close wp
+	p.enemy_pos = Vector2(5, 0)  # within 20px of wp_close
+	p.process_frame(0.1, false, 0.0)  # arrive at wp_close
+	var scan_frames := int(StubSearchStateProcessor.SCAN_DURATION / 0.1) + 1
+	for _i in range(scan_frames):
+		p.process_frame(0.1, false, 0.0)
+
+	assert_true(p.is_visited(wp_close), "Physically reached wp should be marked visited")
+	assert_false(p.is_visited(wp_stuck), "First stuck wp still must NOT be marked visited")
+
+
+# ============================================================================
 # Constants validation
 # ============================================================================
 


### PR DESCRIPTION
## Problem

When an enemy enters the \`SEARCHING\` state it generates a spiral search pattern via
\`_generate_search_waypoints()\`. Two bugs caused enemies to navigate into walls:

**Bug 1** — Path-crossing walls during waypoint generation:
The spiral used \`_is_waypoint_navigable()\` which only checks whether the **destination
point** is on the navigation mesh (≤ 50 px from the nearest nav-mesh point). It did **not**
verify that a navigable path exists from the enemy's current position to that point. Waypoints
in adjacent rooms separated by walls were added to the list, and enemies tried to walk through walls.

**Bug 2** — Zones marked visited without enemy touching them (owner feedback, game log: \`docs/case-studies/issue-1275/game_log_20260321_143638.txt\`):
\`_process_searching_state()\` called \`_mark_zone_visited()\` in two wrong places:
1. When \`NavigationAgent.is_navigation_finished()\` fired but the enemy was still far away.
2. When the stuck timer expired and the waypoint was skipped.

Both caused zones near walls to be incorrectly excluded from future spiral rings, leaving the
enemy cycling through unreachable waypoints forever.

Screenshot from issue:

![search paths crossing walls](https://github.com/user-attachments/assets/e341444b-322e-4612-95b1-3d8725179b2c)

## Root Causes

### Bug 1 — \`_generate_search_waypoints()\` (point-only check)

\`\`\`gdscript
# Before fix — point-only check; ignores walls between rooms
if _is_waypoint_navigable(next_pos) and not _is_zone_visited(next_pos):
    _search_waypoints.append(next_pos)
\`\`\`

Also: \`current_pos\` advanced unconditionally even when \`next_pos\` was off-mesh.

### Bug 2 — \`_process_searching_state()\` (premature visited marking)

\`\`\`gdscript
# Before fix — marks visited even when enemy never touched the waypoint
if _nav_agent.is_navigation_finished():
    _mark_zone_visited(target_waypoint)  # wrong: nav done ≠ physically arrived
    ...
if _search_stuck_timer >= SEARCH_STUCK_MAX_TIME:
    _mark_zone_visited(target_waypoint)  # wrong: stuck ≠ physically touched
    ...
\`\`\`

## Fix

### Fix 1 — New helper \`_is_path_navigable(from, to)\`

Calls \`NavigationServer2D.map_get_path()\` which returns an empty array when walls block
the route. Added to \`_generate_search_waypoints()\` as a third condition:

\`\`\`gdscript
# After fix — path-connectivity check added (Issue #1275)
if _is_waypoint_navigable(next_pos) and not _is_zone_visited(next_pos) \
        and _is_path_navigable(global_position, next_pos):
    _search_waypoints.append(next_pos)
if _is_waypoint_navigable(next_pos):
    current_pos = next_pos  # only advance when step is on the mesh
\`\`\`

### Fix 2 — Mark visited only when enemy physically touches the waypoint

Removed \`_mark_zone_visited()\` from the stuck-skip and nav-finished-early paths.
A zone is now only marked visited after the enemy physically arrives and scans:

\`\`\`gdscript
# After fix — zone only marked visited after physical arrival + scan
if _nav_agent.is_navigation_finished():
    _search_current_waypoint_index += 1  # skip, but do NOT mark visited
    ...
if _search_stuck_timer >= SEARCH_STUCK_MAX_TIME:
    _search_current_waypoint_index += 1  # skip, but do NOT mark visited
    ...
# After scan timer completes (enemy WAS physically close enough to start scanning):
if _search_scan_timer >= SEARCH_SCAN_DURATION:
    _mark_zone_visited(target_waypoint)  # correct: enemy touched and scanned it
\`\`\`

## Tests

\`tests/unit/test_search_path_wall_awareness.gd\` covers:

**Wall filtering (Bug 1):**
- All positions reachable → waypoints generated normally
- Wall blocks north → no waypoints with y < threshold
- Wall blocks east room → no cross-wall waypoints
- All directions blocked → only center waypoint
- Partial wall → only reachable quadrant included
- Tracking position doesn't advance into off-mesh points
- Regression: old code without path check would include cross-wall waypoints

**Visited-zone marking (Bug 2):**
- Stuck-skipped waypoint NOT marked as visited
- Nav-finished-early waypoint NOT marked as visited
- Physically reached + scanned waypoint IS marked as visited
- Stuck then physically reached on retry: only the reached one is marked

## Case Study

\`docs/case-studies/issue-1275/README.md\` — full analysis with both root causes,
game log reference, solution evaluation table, and fix descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes Jhon-Crow/godot-topdown-MVP#1275