### PR TITLE
fix(#1405): synchronize sniper laser rotation with rifle in hip-fire mode

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-24T04:30:49.252Z for PR creation at branch issue-1405-63248889e0d3 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1405


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/godot-topdown-MVP#1405

- **Problem**: In hip-fire mode (not aiming through scope), the sniper rifle laser pointed directly at the mouse cursor (`GetGlobalMousePosition()`), while the rifle sprite rotated 25x slower (`NonAimingSensitivityFactor = 0.04f`). This caused the laser to jump ahead of the rifle, confusing the player.
- **Fix**: In hip-fire mode, the laser now uses `_aimDirection` (the rifle's actual rotation direction) instead of the raw mouse position. This keeps the laser synchronized with the rifle sprite at all times.
- **Scope mode unchanged**: When aiming through the scope, the laser still correctly points at the scope crosshair (screen center world position via `GetScopeAimTarget()`).

## Test plan

- [ ] Equip sniper rifle with laser sight active
- [ ] Move mouse quickly without aiming (hip-fire) — laser should rotate at the same speed as the rifle, staying aligned
- [ ] Enter scope/aim mode — laser should point at the scope crosshair (screen center)
- [ ] Exit scope — laser should resume following the rifle's slow rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)