### PR TITLE
Add orange blinking warning lights to Factory level (Issue #1436)

### DIFF
--- a/scenes/effects/OrangeBlinkingLight.tscn
+++ b/scenes/effects/OrangeBlinkingLight.tscn
@@ -18,21 +18,21 @@ script = ExtResource("1_orange_blinking_light")
 [node name="LightA" type="PointLight2D" parent="."]
 position = Vector2(40, 0)
 color = Color(1.0, 0.45, 0.05, 1.0)
-energy = 1.8
+energy = 4.0
 shadow_enabled = true
 shadow_color = Color(0, 0, 0, 0.6)
 shadow_filter = 1
 shadow_filter_smooth = 4.0
 texture = SubResource("GradientTexture2D_orange")
-texture_scale = 5.0
+texture_scale = 8.0
 
 [node name="LightB" type="PointLight2D" parent="."]
 position = Vector2(-40, 0)
 color = Color(1.0, 0.45, 0.05, 1.0)
-energy = 1.8
+energy = 4.0
 shadow_enabled = true
 shadow_color = Color(0, 0, 0, 0.6)
 shadow_filter = 1
 shadow_filter_smooth = 4.0
 texture = SubResource("GradientTexture2D_orange")
-texture_scale = 5.0
+texture_scale = 8.0

--- a/scenes/levels/FactoryLevel.tscn
+++ b/scenes/levels/FactoryLevel.tscn
@@ -1105,22 +1105,28 @@ position = Vector2(2350, 1900)
 [node name="Lighting" type="Node2D" parent="."]
 
 [node name="EntryHallLight" parent="Lighting" instance=ExtResource("6_orange_blinking_light")]
-position = Vector2(424, 384)
+position = Vector2(422, 382)
 
 [node name="WorkshopLight" parent="Lighting" instance=ExtResource("6_orange_blinking_light")]
-position = Vector2(1165, 384)
+position = Vector2(1165, 382)
 
 [node name="ControlRoomLight" parent="Lighting" instance=ExtResource("6_orange_blinking_light")]
-position = Vector2(2005, 384)
+position = Vector2(2007, 382)
 
 [node name="StorageLight" parent="Lighting" instance=ExtResource("6_orange_blinking_light")]
-position = Vector2(424, 1000)
+position = Vector2(422, 1000)
+
+[node name="CentralHallLight" parent="Lighting" instance=ExtResource("6_orange_blinking_light")]
+position = Vector2(1165, 1000)
 
 [node name="AssemblyLight" parent="Lighting" instance=ExtResource("6_orange_blinking_light")]
-position = Vector2(2005, 1000)
+position = Vector2(2007, 1000)
 
 [node name="BoilerRoomLight" parent="Lighting" instance=ExtResource("6_orange_blinking_light")]
-position = Vector2(424, 1680)
+position = Vector2(422, 1682)
+
+[node name="MaintenanceLight" parent="Lighting" instance=ExtResource("6_orange_blinking_light")]
+position = Vector2(1165, 1682)
 
 [node name="ExitHallLight" parent="Lighting" instance=ExtResource("6_orange_blinking_light")]
-position = Vector2(2005, 1680)
+position = Vector2(2007, 1682)

--- a/scripts/effects/orange_blinking_light.gd
+++ b/scripts/effects/orange_blinking_light.gd
@@ -20,7 +20,7 @@ const ROTATION_SPEED: float = PI
 const BLINK_INTERVAL: float = 0.4
 
 ## Light energy (brightness) when on.
-const LIGHT_ON_ENERGY: float = 1.8
+const LIGHT_ON_ENERGY: float = 4.0
 
 ## Orange color for industrial warning lamps.
 const LIGHT_COLOR: Color = Color(1.0, 0.45, 0.05, 1.0)

--- a/tests/unit/test_orange_blinking_light.gd
+++ b/tests/unit/test_orange_blinking_light.gd
@@ -18,7 +18,7 @@ class MockOrangeBlinkingLight:
 	const BLINK_INTERVAL: float = 0.4
 
 	## Light energy when on.
-	const LIGHT_ON_ENERGY: float = 1.8
+	const LIGHT_ON_ENERGY: float = 4.0
 
 	## Orange color for industrial warning lamps.
 	const LIGHT_COLOR: Color = Color(1.0, 0.45, 0.05, 1.0)


### PR DESCRIPTION
## Summary

- Created `scenes/effects/OrangeBlinkingLight.tscn` — an industrial emergency beacon composed of two `PointLight2D` nodes (LightA and LightB) positioned opposite each other (+40px / -40px on X), emitting orange light (`Color(1.0, 0.45, 0.05)`) via a radial `GradientTexture2D` sub-resource.
- Created `scripts/effects/orange_blinking_light.gd` — the script that:
  - Rotates the entire `Node2D` at π rad/s (one full revolution per 2 seconds) to simulate a spinning beacon.
  - Blinks both lights in sync with a 0.4 s on / 0.4 s off cycle (50% duty cycle).
  - Both lights share the same energy value so they always alternate together, giving the "light in two directions" effect required by the issue.
- **Brightness increased** (energy 1.8 → 4.0, texture_scale 5.0 → 8.0) per owner feedback.
- **Placed one `OrangeBlinkingLight` instance at the exact center of each of the 9 rooms** in `FactoryLevel.tscn` (3×3 grid): Entry Hall, Workshop, Control Room, Storage, Central Hall, Assembly, Boiler Room, Maintenance, Exit Hall.
- Added `tests/unit/test_orange_blinking_light.gd` with 8 unit tests covering: rotation, blink-on, blink-off, full-cycle reset, sync between lights, orange color correctness, rotation speed constant, and multi-cycle stability.

## Test plan

- [ ] Open `FactoryLevel` in Godot 4.3+ and verify orange beacons are visible and rotating in each of the 9 rooms.
- [ ] Confirm lights are noticeably brighter than before.
- [ ] Confirm lights blink (on/off) and rotate continuously.
- [ ] Run unit tests: `godot --headless -s addons/gut/gut_cmdln.gd -gdir=res://tests/unit -ginclude_subdirs -gexit` — all `test_orange_blinking_light` cases should pass.
- [ ] Verify no regressions in other levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes Jhon-Crow/godot-topdown-MVP#1436