### PR TITLE
Update Sewer map enemy layout

### DIFF
--- a/scenes/levels/SewerLevel.tscn
+++ b/scenes/levels/SewerLevel.tscn
@@ -217,6 +217,13 @@ offset_right = 550.0
 offset_bottom = 450.0
 color = Color(0.12, 0.14, 0.12, 1)
 
+[node name="FloorTopRoomAlcove" type="ColorRect" parent="Environment"]
+offset_left = 288.0
+offset_top = 450.0
+offset_right = 550.0
+offset_bottom = 1362.0
+color = Color(0.12, 0.14, 0.12, 1)
+
 [node name="FloorRightBranch" type="ColorRect" parent="Environment"]
 offset_left = 288.0
 offset_top = 1362.0
@@ -1109,7 +1116,7 @@ enable_cover = true
 position = Vector2(200, 280)
 behavior_mode = 0
 patrol_offsets = Array[Vector2]([Vector2(100, 0), Vector2(-100, 0)])
-has_armored_skin = true
+has_force_field = true
 destroy_on_death = true
 enable_flanking = true
 enable_cover = true


### PR DESCRIPTION
## Summary

Addresses issue #1498: update Sewer map (Канализация) enemy layout and map fixes.

### Changes made:
- **Moved corridor enemies up**: Relocated guards near player spawn further up the corridor
- **Added shieldbearers**: Replaced two nearest enemies with shieldbearer (SWAT shield) variants; `Corridor1Guard` patrols vertically (faces along corridor), `Room1Guard` stands guard
- **Added machine gunner**: Placed `ExitRoomMachineGunner` with `weapon_type = 6` in the upper corner room above the exit
- **Added gas mask enemy**: Replaced one corridor guard with `is_gas_mask = true` variant
- **Fixed missing wall**: Added `WallTopRoom_Bottom` to close the gap in the top room exit, preventing player from going out of bounds
- **Fixed black spot**: Added `FloorTopRoomAlcove` floor tile to fill the dark void area (x=288–550, y=450–1362) right of the main corridor below the top room
- **Top room enemies**: Replaced regular guard with Force Field variant (`has_force_field = true`) and added grenadier (`is_grenadier = true`)
- **Enemy count**: Updated label to `"Enemies: 13"`

## Test plan
- [ ] Verify shieldbearers are not placed inside walls
- [ ] Verify `Corridor1Guard` (shieldbearer) faces downward toward player spawn and patrols vertically
- [ ] Verify no gap exists in top room allowing player to leave the map
- [ ] Verify the black spot area is now filled with floor color
- [ ] Verify top room has a Force Field enemy and a grenadier
- [ ] Verify machine gunner is in the upper corner room above the exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes Jhon-Crow/godot-topdown-MVP#1498