### PR TITLE
update карта ЖД Пути: добавить врагов на карту RailwayStation

### DIFF
--- a/scenes/levels/RailwayStationLevel.tscn
+++ b/scenes/levels/RailwayStationLevel.tscn
@@ -2808,18 +2808,20 @@ color = Color(0.2, 0.7, 0.2, 1)
 [node name="Enemies" type="Node2D" parent="Environment"]
 
 ; === MACHINE GUNNERS BETWEEN NEAR TRAINS (Track 1 y=2580 and Track 2 y=2760) ===
-; Left gunner — far left side between the two nearest tracks
+; Left gunner — far left side between the two nearest tracks, facing south toward player
 [node name="NearTracks_MachineGunnerLeft" parent="Environment/Enemies" instance=ExtResource("5_enemy")]
 position = Vector2(300, 2670)
+rotation = 1.5708
 behavior_mode = 1
 weapon_type = 6
 destroy_on_death = true
 enable_flanking = true
 enable_cover = true
 
-; Right gunner — far right side between the two nearest tracks
+; Right gunner — far right side between the two nearest tracks, facing south toward player
 [node name="NearTracks_MachineGunnerRight" parent="Environment/Enemies" instance=ExtResource("5_enemy")]
 position = Vector2(3700, 2670)
+rotation = 1.5708
 behavior_mode = 1
 weapon_type = 6
 destroy_on_death = true
@@ -2827,27 +2829,29 @@ enable_flanking = true
 enable_cover = true
 
 ; === MACHINE GUNNERS BETWEEN FAR TRAINS (Track 3 y=1800 and Track 4 y=1980) ===
-; Left gunner — far left side between the two farther tracks
+; Left gunner — far left side between the two farther tracks, facing south toward player
 [node name="FarTracks_MachineGunnerLeft" parent="Environment/Enemies" instance=ExtResource("5_enemy")]
 position = Vector2(300, 1890)
+rotation = 1.5708
 behavior_mode = 1
 weapon_type = 6
 destroy_on_death = true
 enable_flanking = true
 enable_cover = true
 
-; Right gunner — far right side between the two farther tracks
+; Right gunner — far right side between the two farther tracks, facing south toward player
 [node name="FarTracks_MachineGunnerRight" parent="Environment/Enemies" instance=ExtResource("5_enemy")]
 position = Vector2(3700, 1890)
+rotation = 1.5708
 behavior_mode = 1
 weapon_type = 6
 destroy_on_death = true
 enable_flanking = true
 enable_cover = true
 
-; === DRONE OPERATORS AT MAP EXIT (top of map, above embankment y≈1000) ===
+; === DRONE OPERATORS AT MAP EXIT (embankment area y≈1100, south of exit wall gaps) ===
 [node name="Exit_DroneOperator1" parent="Environment/Enemies" instance=ExtResource("5_enemy")]
-position = Vector2(700, 700)
+position = Vector2(700, 1100)
 behavior_mode = 1
 is_drone_operator = true
 destroy_on_death = true
@@ -2855,7 +2859,7 @@ enable_flanking = true
 enable_cover = true
 
 [node name="Exit_DroneOperator2" parent="Environment/Enemies" instance=ExtResource("5_enemy")]
-position = Vector2(1600, 700)
+position = Vector2(1600, 1100)
 behavior_mode = 1
 is_drone_operator = true
 destroy_on_death = true
@@ -2863,7 +2867,7 @@ enable_flanking = true
 enable_cover = true
 
 [node name="Exit_DroneOperator3" parent="Environment/Enemies" instance=ExtResource("5_enemy")]
-position = Vector2(2500, 700)
+position = Vector2(2500, 1100)
 behavior_mode = 1
 is_drone_operator = true
 destroy_on_death = true
@@ -2871,9 +2875,18 @@ enable_flanking = true
 enable_cover = true
 
 [node name="Exit_DroneOperator4" parent="Environment/Enemies" instance=ExtResource("5_enemy")]
-position = Vector2(3300, 700)
+position = Vector2(3300, 1100)
 behavior_mode = 1
 is_drone_operator = true
+destroy_on_death = true
+enable_flanking = true
+enable_cover = true
+
+; === GAS MASK ENEMY NEAR PLAYER SPAWN (player spawn at x=2000, y=3100) ===
+[node name="Spawn_GasMaskEnemy" parent="Environment/Enemies" instance=ExtResource("5_enemy")]
+position = Vector2(2000, 2900)
+behavior_mode = 1
+is_gas_mask = true
 destroy_on_death = true
 enable_flanking = true
 enable_cover = true


### PR DESCRIPTION
## Summary

Resolves #1612

- Added 2 machine gunners (weapon_type=6) between the **nearest two trains** (Track 1 y=2580 and Track 2 y=2760): one far left (x=300, y=2670), one far right (x=3700, y=2670), both facing south (rotation=π/2) toward the player
- Added 2 machine gunners between the **farthest two trains** (Track 3 y=1800 and Track 4 y=1980): one far left (x=300, y=1890), one far right (x=3700, y=1890), both facing south toward the player
- Added 4 drone operators (`is_drone_operator = true`) at the **map exit** (embankment area, y=1100, inside the navigable map), spread across the map width
- Added 6 teleporter enemies (`is_teleporter = true`) on the **platform** (y=3100): 3 to the left of player spawn (x=600, 1000, 1400) and 3 to the right (x=2600, 3000, 3400)
- Added 1 gas mask enemy (`is_gas_mask = true`) near the **player spawn** at Vector2(2000, 2900)

## Changes

- `scenes/levels/RailwayStationLevel.tscn`: Added 13 enemy nodes in the `Environment/Enemies` node group. Machine gunners have `rotation = 1.5708` (facing south). Drone operators moved to y=1100 (inside map). Gas mask enemy added near player spawn.

## Test plan

- [ ] Open RailwayStationLevel in the Godot editor and confirm all 13 enemy nodes appear in the scene tree under `Environment/Enemies`
- [ ] Play the level and verify machine gunners appear between the train tracks (left and right sides, near and far pairs), facing south toward the player
- [ ] Verify 4 drone operators appear inside the embankment area (y≈1100), reachable and visible during gameplay
- [ ] Verify 6 teleporter enemies appear on the platform (3 left and 3 right of player spawn)
- [ ] Verify gas mask enemy appears near the player spawn (x=2000, y=2900)
- [ ] Confirm all enemies have correct behavior