### PR TITLE
fix(#1613): update Docks map enemies in central and loading dock areas

### DIFF
--- a/scenes/levels/DocksLevel.tscn
+++ b/scenes/levels/DocksLevel.tscn
@@ -916,43 +916,13 @@ destroy_on_death = true
 enable_flanking = true
 enable_cover = true
 
-[node name="LoadingDock_Rifle1" parent="Environment/Enemies" instance=ExtResource("4_enemy")]
-position = Vector2(3650, 1550)
-behavior_mode = 0
-weapon_type = 0
-patrol_offsets = Array[Vector2]([Vector2(0, 100), Vector2(0, -100)])
-destroy_on_death = true
-enable_flanking = true
-enable_cover = true
-
-[node name="LoadingDock_Rifle2" parent="Environment/Enemies" instance=ExtResource("4_enemy")]
-position = Vector2(4050, 1600)
+[node name="LoadingDock_ArmoredSkin" parent="Environment/Enemies" instance=ExtResource("4_enemy")]
+position = Vector2(3950, 1650)
 behavior_mode = 1
-weapon_type = 0
 destroy_on_death = true
 enable_flanking = true
 enable_cover = true
-
-[node name="LoadingDock_UZI" parent="Environment/Enemies" instance=ExtResource("4_enemy")]
-position = Vector2(4350, 1700)
-behavior_mode = 0
-weapon_type = 2
-patrol_offsets = Array[Vector2]([Vector2(100, 0), Vector2(-100, 0)])
-destroy_on_death = true
-enable_flanking = true
-enable_cover = true
-
-[node name="LoadingDock_Machete" parent="Environment/Enemies" instance=ExtResource("4_enemy")]
-position = Vector2(3850, 1800)
-behavior_mode = 1
-weapon_type = 3
-move_speed = 250.0
-combat_move_speed = 380.0
-destroy_on_death = true
-enable_flanking = true
-enable_cover = true
-min_health = 3
-max_health = 5
+has_armored_skin = true
 
 [node name="ContainerYardB_Rifle" parent="Environment/Enemies" instance=ExtResource("4_enemy")]
 position = Vector2(350, 2850)
@@ -1057,7 +1027,7 @@ offset_top = 45.0
 offset_right = -10.0
 offset_bottom = 75.0
 grow_horizontal = 0
-text = "Enemies: 18"
+text = "Enemies: 15"
 horizontal_alignment = 2
 
 [node name="AmmoLabel" type="Label" parent="CanvasLayer/UI"]

--- a/scripts/levels/docks_level.gd
+++ b/scripts/levels/docks_level.gd
@@ -2,7 +2,7 @@ extends Node2D
 ## Docks level scene (Issue #753).
 ##
 ## Large industrial docks environment with shipping containers, warehouses,
-## and open spaces. Features 18 enemies with varied weapons for tactical gameplay.
+## and open spaces. Features 15 enemies with varied weapons for tactical gameplay.
 ## Map layout: ~5000x4000 pixels with water boundaries.
 
 var _enemy_count_label: Label = null

--- a/tests/unit/test_docks_level.gd
+++ b/tests/unit/test_docks_level.gd
@@ -2,7 +2,7 @@ extends GutTest
 ## Unit tests for docks_level.gd level script.
 ##
 ## Tests saturation constants, exit zone configuration, and level initialization
-## for the large industrial docks environment with 18 enemies.
+## for the large industrial docks environment with 15 enemies.
 
 
 # ============================================================================
@@ -40,7 +40,7 @@ class MockDocksLevel:
 	var map_height: int = 4000
 
 	## Default enemy count for docks level.
-	var default_enemy_count: int = 18
+	var default_enemy_count: int = 15
 
 	## Initialize with default enemies.
 	func initialize() -> void:
@@ -113,8 +113,8 @@ func test_exit_zone_dimensions() -> void:
 
 
 func test_default_enemy_count() -> void:
-	assert_eq(level.default_enemy_count, 18,
-		"Docks level should have 18 enemies by default")
+	assert_eq(level.default_enemy_count, 15,
+		"Docks level should have 15 enemies by default")
 
 
 func test_level_starts_not_cleared() -> void:
@@ -125,25 +125,25 @@ func test_level_starts_not_cleared() -> void:
 
 func test_enemy_count_initialized_correctly() -> void:
 	level.initialize()
-	assert_eq(level._initial_enemy_count, 18,
-		"Initial enemy count should be 18")
-	assert_eq(level._current_enemy_count, 18,
-		"Current enemy count should be 18 at start")
+	assert_eq(level._initial_enemy_count, 15,
+		"Initial enemy count should be 15")
+	assert_eq(level._current_enemy_count, 15,
+		"Current enemy count should be 15 at start")
 
 
 func test_level_cleared_when_all_enemies_dead() -> void:
 	level.initialize()
-	for i in range(17):
+	for i in range(14):
 		level.on_enemy_died()
 	assert_false(level._level_cleared, "Not cleared with 1 enemy remaining")
 	level.on_enemy_died()
-	assert_true(level._level_cleared, "Level should be cleared when all 18 enemies dead")
+	assert_true(level._level_cleared, "Level should be cleared when all 15 enemies dead")
 	assert_true(level.exit_zone_activated, "Exit zone should activate on clear")
 
 
 func test_player_exit_completes_level() -> void:
 	level.initialize()
-	for i in range(18):
+	for i in range(15):
 		level.on_enemy_died()
 	level.on_player_reached_exit()
 	assert_true(level._level_completed,


### PR DESCRIPTION
## Problem

Issue #1613 requested removing enemies from the central open area of the Docks map, and the repo owner additionally requested replacing the Loading Dock enemies with a single armored skin enemy.

## Solution

**Change 1:** Removed both open-area patrol enemies from the central empty space:
- `OpenArea_Patrol1` — position (1800, 700), M16 rifle patrol
- `OpenArea_Patrol2` — position (2200, 2700), M16 rifle patrol

**Change 2:** Replaced 4 Loading Dock enemies with 1 armored skin enemy (as requested in PR comment):
- Removed: `LoadingDock_Rifle1`, `LoadingDock_Rifle2`, `LoadingDock_UZI`, `LoadingDock_Machete`
- Added: `LoadingDock_ArmoredSkin` at position (3950, 1650) with `has_armored_skin = true`

Total enemy count reduced from **20 to 15**.

## Files Changed

- `scenes/levels/DocksLevel.tscn` — removed open area patrol + loading dock enemies, added armored skin enemy, updated `EnemyCountLabel` to "Enemies: 15"
- `scripts/levels/docks_level.gd` — updated comment from 18 to 15 enemies
- `tests/unit/test_docks_level.gd` — updated all enemy count assertions from 18 to 15

## Test plan

- [ ] Open Docks level in Godot — verify no enemies patrol the central open space
- [ ] Verify only one armored skin enemy is in the Loading Dock area
- [ ] UI shows "Enemies: 15" at level start
- [ ] All 15 enemies eliminated → level clears and exit zone activates
- [ ] Unit tests pass with new enemy count of 15

Fixes Jhon-Crow/godot-topdown-MVP#1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)