### PR TITLE
fix(#1679): block outer left void and gap in SewerLevel

### DIFF
--- a/scenes/levels/SewerLevel.tscn
+++ b/scenes/levels/SewerLevel.tscn
@@ -257,22 +257,22 @@ size = Vector2(112, 450)
 polygon = PackedVector2Array(-56, -225, 56, -225, 56, 225, -56, 225)
 
 [sub_resource type="RectangleShape2D" id="S_niche_gap_top"]
-size = Vector2(176, 312)
+size = Vector2(200, 312)
 
 [sub_resource type="OccluderPolygon2D" id="O_niche_gap_top"]
-polygon = PackedVector2Array(-88, -156, 88, -156, 88, 156, -88, 156)
+polygon = PackedVector2Array(-100, -156, 100, -156, 100, 156, -100, 156)
 
 [sub_resource type="RectangleShape2D" id="S_niche_gap_med"]
-size = Vector2(176, 300)
+size = Vector2(200, 300)
 
 [sub_resource type="OccluderPolygon2D" id="O_niche_gap_med"]
-polygon = PackedVector2Array(-88, -150, 88, -150, 88, 150, -88, 150)
+polygon = PackedVector2Array(-100, -150, 100, -150, 100, 150, -100, 150)
 
 [sub_resource type="RectangleShape2D" id="S_niche_gap_bot"]
-size = Vector2(176, 338)
+size = Vector2(200, 338)
 
 [sub_resource type="OccluderPolygon2D" id="O_niche_gap_bot"]
-polygon = PackedVector2Array(-88, -169, 88, -169, 88, 169, -88, 169)
+polygon = PackedVector2Array(-100, -169, 100, -169, 100, 169, -100, 169)
 
 [node name="SewerLevel" type="Node2D"]
 script = ExtResource("1_sewer_level")
@@ -1016,14 +1016,14 @@ shape = SubResource("S_lower_void5")
 occluder = SubResource("O_lower_void5")
 
 [node name="WallNicheGap1" type="StaticBody2D" parent="Environment/Walls"]
-position = Vector2(400, 1694)
+position = Vector2(388, 1694)
 collision_layer = 4
 collision_mask = 0
 
 [node name="ColorRect" type="ColorRect" parent="Environment/Walls/WallNicheGap1"]
-offset_left = -88.0
+offset_left = -100.0
 offset_top = -156.0
-offset_right = 88.0
+offset_right = 100.0
 offset_bottom = 156.0
 color = Color(0.04, 0.06, 0.05, 1)
 
@@ -1034,14 +1034,14 @@ shape = SubResource("S_niche_gap_top")
 occluder = SubResource("O_niche_gap_top")
 
 [node name="WallNicheGap2" type="StaticBody2D" parent="Environment/Walls"]
-position = Vector2(400, 2100)
+position = Vector2(388, 2100)
 collision_layer = 4
 collision_mask = 0
 
 [node name="ColorRect" type="ColorRect" parent="Environment/Walls/WallNicheGap2"]
-offset_left = -88.0
+offset_left = -100.0
 offset_top = -150.0
-offset_right = 88.0
+offset_right = 100.0
 offset_bottom = 150.0
 color = Color(0.04, 0.06, 0.05, 1)
 
@@ -1052,14 +1052,14 @@ shape = SubResource("S_niche_gap_med")
 occluder = SubResource("O_niche_gap_med")
 
 [node name="WallNicheGap3" type="StaticBody2D" parent="Environment/Walls"]
-position = Vector2(400, 2500)
+position = Vector2(388, 2500)
 collision_layer = 4
 collision_mask = 0
 
 [node name="ColorRect" type="ColorRect" parent="Environment/Walls/WallNicheGap3"]
-offset_left = -88.0
+offset_left = -100.0
 offset_top = -150.0
-offset_right = 88.0
+offset_right = 100.0
 offset_bottom = 150.0
 color = Color(0.04, 0.06, 0.05, 1)
 
@@ -1070,14 +1070,14 @@ shape = SubResource("S_niche_gap_med")
 occluder = SubResource("O_niche_gap_med")
 
 [node name="WallNicheGap4" type="StaticBody2D" parent="Environment/Walls"]
-position = Vector2(400, 2919)
+position = Vector2(388, 2919)
 collision_layer = 4
 collision_mask = 0
 
 [node name="ColorRect" type="ColorRect" parent="Environment/Walls/WallNicheGap4"]
-offset_left = -88.0
+offset_left = -100.0
 offset_top = -169.0
-offset_right = 88.0
+offset_right = 100.0
 offset_bottom = 169.0
 color = Color(0.04, 0.06, 0.05, 1)
 


### PR DESCRIPTION
## Summary

Fixes #1679 — the outer dark area to the left of the corridor (and surrounding void regions) were physically passable, allowing the player and enemies to roam outside the level boundaries. Additionally, enemies could get stuck inside the right corridor wall segments adjacent to niche void areas.

### Root Cause

Five separate issues allowed the player/enemies to access restricted areas:

1. **Gap between top room walls (x=62..88, y=112..450)** — The top room's left wall segment (`WallTopRoom_Left` at x=38..62) and the main left wall (`WallLeft` at x=88..112) had a 26px gap between them, creating an entry point into the void area.

2. **Outer left void (x=0..88, y=450..3088) had no collision** — The dark background area to the left of the main corridor was not physically blocked.

3. **Top-left void (x=0..88, y=0..450) had no collision** — The dark area in the top-left corner was also unblocked.

4. **Adjacent left gray walls were too thin** — Enemies could get stuck in `WallLeft` (x=88..112) and `WallTopRoom_Left` (x=38..62) because the void collision only covered up to their edge, not under them.

5. **Adjacent right gray walls were too thin** — Enemies could enter `WallRightSeg1-4` (x=288..312) from the niche side because `WallNicheGap1-4` started at x=312 and didn't extend under the gray wall segments.

### Fix: Five walls + nav polygon update

#### WallLeftGap (inner gap fix)
Fills the 26px gap between `WallTopRoom_Left` and `WallLeft` in the top room section:

| Property | Value |
|---|---|
| Position | Vector2(75, 281) |
| Size | 26×338 px |
| Covers | x=62..88, y=112..450 |

#### WallLeftOuterVoid (outer corridor void fix — expanded)
Blocks the entire outer left void for the corridor section, extended to cover the adjacent `WallLeft` gray wall:

| Property | Value |
|---|---|
| Position | Vector2(56, 1769) |
| Size | 112×2638 px |
| Covers | x=0..112, y=450..3088 |

#### WallTopLeftVoid (top-left corner void fix — expanded)
Blocks the top-left corner void, extended to cover the adjacent gray walls:

| Property | Value |
|---|---|
| Position | Vector2(56, 225) |
| Size | 112×450 px |
| Covers | x=0..112, y=0..450 |

#### WallNicheGap1-4 (right corridor niche gap fix — expanded)
Extended from x=312..488 to x=288..488 (200px wide, centered at x=388) to also cover the adjacent `WallRightSeg1-4` gray walls:

| Gap | Position | Size | Covers |
|---|---|---|---|
| WallNicheGap1 | Vector2(388, 1694) | 200×312 px | x=288..488, y=1538..1850 |
| WallNicheGap2 | Vector2(388, 2100) | 200×300 px | x=288..488, y=1950..2250 |
| WallNicheGap3 | Vector2(388, 2500) | 200×300 px | x=288..488, y=2350..2650 |
| WallNicheGap4 | Vector2(388, 2919) | 200×338 px | x=288..488, y=2750..3088 |

#### NavigationPolygon update
The top room's left boundary in the navigation mesh was updated from x=50 to x=112, matching the new void wall coverage.

Together, these changes fully prevent the player and enemies from accessing or getting stuck in any wall or void area on either side of the level, while keeping the visual appearance unchanged (the gray walls are drawn on top of the void walls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)