### PR TITLE
fix(#1616): remove enemies from start room and recess door transitions

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-28T16:56:49.793Z for PR creation at branch issue-1616-c2453ab14574 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1616

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-28T16:56:49.793Z for PR creation at branch issue-1616-c2453ab14574 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1616

--- a/scripts/levels/roguelike_level.gd
+++ b/scripts/levels/roguelike_level.gd
@@ -437,6 +437,9 @@ func _start_new_run() -> void:
 	GameManager.roguelike_current_map_room = 0  # Start room
 	GameManager.roguelike_visited_rooms = [0]
 	GameManager.roguelike_room_map[0]["visited"] = true
+	# Issue #1616: Mark the start room as cleared so it is always treated as
+	# an enemy-free room — both on the first entry and on any revisit.
+	GameManager.roguelike_room_map[0]["cleared"] = true
 	GameManager.roguelike_target_room = -1
 
 	var names: Array = []
@@ -1709,27 +1712,52 @@ func _create_door_zone(direction: int, target_room_idx: int) -> void:
 	var door_color: Color = _get_door_color(target_room_idx)
 	var door_label_text: String = _get_door_label(target_room_idx)
 
+	# Issue #1616: Door transitions must be recessed into the wall so they are
+	# visually embedded in the doorway gap rather than floating at the room edge.
+	# Wall thickness = 24 px (matching _build_room_boundary_closed).
+	# The collision zone is centred on the room-side edge of the wall (y/x = t)
+	# so it triggers as soon as the player steps through the opening.
+	# The visual is sized to fill the wall thickness exactly (vis_depth = t).
+	var t_wall: float = 24.0          ## Must match _build_room_boundary_closed
+	var vis_depth: float = t_wall     ## Visual fits exactly inside the wall
+
 	# Calculate door position at the wall gap
 	var door_pos := Vector2.ZERO
-	var door_w: float = 80.0
-	var door_h: float = 80.0
+	## Horizontal span of the doorway gap (used for N/S doors)
+	var door_w: float = DOOR_GAP - 20.0
+	## Vertical span of the doorway gap (used for E/W doors)
+	var door_h: float = DOOR_GAP - 20.0
+	## Visual dimensions — recessed flush with the wall
+	var vis_w: float = door_w
+	var vis_h: float = door_h
 	match direction:
 		DIR_NORTH:
-			door_pos = Vector2(_room_w * 0.5, 12.0)
-			door_w = DOOR_GAP - 20.0
-			door_h = 40.0
+			# Place at the inner (room-side) edge of the top wall
+			door_pos = Vector2(_room_w * 0.5, t_wall)
+			vis_h = vis_depth
 		DIR_SOUTH:
-			door_pos = Vector2(_room_w * 0.5, _room_h - 12.0)
-			door_w = DOOR_GAP - 20.0
-			door_h = 40.0
+			# Place at the inner (room-side) edge of the bottom wall
+			door_pos = Vector2(_room_w * 0.5, _room_h - t_wall)
+			vis_h = vis_depth
 		DIR_EAST:
-			door_pos = Vector2(_room_w - 12.0, _room_h * 0.5)
-			door_w = 40.0
-			door_h = DOOR_GAP - 20.0
+			# Place at the inner (room-side) edge of the right wall
+			door_pos = Vector2(_room_w - t_wall, _room_h * 0.5)
+			vis_w = vis_depth
 		DIR_WEST:
-			door_pos = Vector2(12.0, _room_h * 0.5)
-			door_w = 40.0
-			door_h = DOOR_GAP - 20.0
+			# Place at the inner (room-side) edge of the left wall
+			door_pos = Vector2(t_wall, _room_h * 0.5)
+			vis_w = vis_depth
+
+	## Collision depth extends slightly into the room so the trigger fires
+	## as the player steps through the gap rather than requiring them to
+	## walk fully into the wall.
+	var coll_w: float = door_w
+	var coll_h: float = door_h
+	match direction:
+		DIR_NORTH, DIR_SOUTH:
+			coll_h = t_wall + 16.0
+		DIR_EAST, DIR_WEST:
+			coll_w = t_wall + 16.0
 
 	var door_zone := Area2D.new()
 	door_zone.name = "DoorZone_%d_%d" % [direction, target_room_idx]
@@ -1737,28 +1765,28 @@ func _create_door_zone(direction: int, target_room_idx: int) -> void:
 	door_zone.collision_layer = 0
 	door_zone.collision_mask = 1  # Detect player
 
-	# Collision shape
+	# Collision shape (slightly wider than the visual so it triggers early)
 	var coll := CollisionShape2D.new()
 	var shape := RectangleShape2D.new()
-	shape.size = Vector2(door_w, door_h)
+	shape.size = Vector2(coll_w, coll_h)
 	coll.shape = shape
 	door_zone.add_child(coll)
 
-	# Visual: colored glow rect
+	# Visual: colored glow rect — recessed inside the wall
 	var glow := ColorRect.new()
 	glow.color = Color(door_color.r, door_color.g, door_color.b, 0.3)
-	glow.size = Vector2(door_w + 12, door_h + 12)
-	glow.position = -Vector2(door_w * 0.5 + 6, door_h * 0.5 + 6)
+	glow.size = Vector2(vis_w + 8, vis_h + 8)
+	glow.position = -Vector2(vis_w * 0.5 + 4, vis_h * 0.5 + 4)
 	door_zone.add_child(glow)
 
-	# Visual: inner solid rect
+	# Visual: inner solid rect — fits flush inside the wall thickness
 	var inner := ColorRect.new()
 	inner.color = door_color
-	inner.size = Vector2(door_w, door_h)
-	inner.position = -Vector2(door_w * 0.5, door_h * 0.5)
+	inner.size = Vector2(vis_w, vis_h)
+	inner.position = -Vector2(vis_w * 0.5, vis_h * 0.5)
 	door_zone.add_child(inner)
 
-	# Door label
+	# Door label — placed just inside the room, adjacent to the door
 	var lbl := Label.new()
 	lbl.text = door_label_text
 	lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
@@ -1768,17 +1796,16 @@ func _create_door_zone(direction: int, target_room_idx: int) -> void:
 	lbl.add_theme_color_override("font_shadow_color", Color(0, 0, 0, 0.9))
 	lbl.add_theme_constant_override("shadow_offset_x", 1)
 	lbl.add_theme_constant_override("shadow_offset_y", 1)
-	lbl.size = Vector2(door_w + 20, 24)
-	# Position label above/below/beside the door
+	lbl.size = Vector2(vis_w + 20, 24)
 	match direction:
 		DIR_NORTH:
-			lbl.position = Vector2(-door_w * 0.5 - 10, door_h * 0.5 + 4)
+			lbl.position = Vector2(-vis_w * 0.5 - 10, vis_h * 0.5 + 4)
 		DIR_SOUTH:
-			lbl.position = Vector2(-door_w * 0.5 - 10, -door_h * 0.5 - 28)
+			lbl.position = Vector2(-vis_w * 0.5 - 10, -vis_h * 0.5 - 28)
 		DIR_EAST:
-			lbl.position = Vector2(-door_w * 0.5 - 40, -12)
+			lbl.position = Vector2(-vis_w * 0.5 - 40, -12)
 		DIR_WEST:
-			lbl.position = Vector2(door_w * 0.5 - 10, -12)
+			lbl.position = Vector2(vis_w * 0.5 - 10, -12)
 	door_zone.add_child(lbl)
 
 	# Direction arrow
@@ -2846,6 +2873,8 @@ func _start_next_level() -> void:
 	GameManager.roguelike_current_map_room = 0
 	GameManager.roguelike_visited_rooms = [0]
 	GameManager.roguelike_room_map[0]["visited"] = true
+	# Issue #1616: Mark start room of the new level as cleared (no enemies).
+	GameManager.roguelike_room_map[0]["cleared"] = true
 	GameManager.roguelike_target_room = -1
 
 	print("[RoguelikeLevel] Starting Level %d — %d rooms, difficulty ×%d" % [


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/godot-topdown-MVP#1616

Two bugs in the roguelike mode:

1. **Start room had enemies** — The start room was generated with `cleared: false`, so on the first entry (and any revisit), the `is_cleared_revisit` guard did not fire and enemies could appear. Fixed by marking the start room as `cleared: true` immediately in both `_start_new_run()` and `_start_next_level()`, making the existing guard fully reliable.

2. **Door transitions not recessed into walls** — Door zone visuals were 40 px tall/wide but the wall is only 24 px thick, so they protruded 8 px outside the level boundary and 8 px into the room floor. Fixed by separating visual dimensions (`vis_depth = t_wall = 24 px`) from collision dimensions (`t_wall + 16 px` to stay responsive) and positioning the door zone at the inner edge of the wall, so the coloured indicator sits flush inside the doorway gap.

## Changes

- `scripts/levels/roguelike_level.gd`
  - `_start_new_run()`: set `room_map[0]["cleared"] = true` for the start room
  - `_start_next_level()`: same for start room of every subsequent level
  - `_create_door_zone()`: separate `vis_w/vis_h` (wall-sized visuals) from `coll_w/coll_h` (slightly larger collision); position door at inner wall edge (`t_wall` instead of `t_wall/2`)

## Test plan

- [ ] Start a new roguelike run — start room has no enemies, all doors activate immediately
- [ ] Clear a combat room — doors unlock and visuals appear inside the wall gap (not floating)
- [ ] Walk through each door direction (N/S/E/W) — transition triggers as player enters the opening
- [ ] Restart run with Q — new start room again has no enemies
- [ ] Advance to level 2 — its start room also has no enemies

🤖 Generated with [Claude Code](https://claude.com/claude-code)