### PR TITLE
feat(#1755): game-end screen — white text on black, dismiss on input → score screen

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-09T21:18:47.071Z for PR creation at branch issue-1755-0fe0d2d402dd for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1755

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-09T21:18:47.071Z for PR creation at branch issue-1755-0fe0d2d402dd for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1755

--- a/docs/case-studies/issue-1755/README.md
+++ b/docs/case-studies/issue-1755/README.md
@@ -1,0 +1,97 @@
+# Case Study: Issue #1755 — Game-End Screen Not Appearing in Railway Station Level
+
+## Overview
+
+After the initial implementation of the game-end screen (PR #1778), the owner reported three regressions:
+1. Camera behaviour was broken
+2. Exit point positions changed
+3. The "Конец. Спасибо за игру" message did not appear
+
+## Artifacts
+
+- [`game_log_20260410_022806.txt`](game_log_20260410_022806.txt) — full game log from the owner's Windows session (Godot 4.3-stable, debug=false)
+
+## Timeline of Events
+
+| Time (from log) | Event |
+|---|---|
+| 02:28:06 | Game started, LabyrinthLevel loaded first |
+| 02:28:22 | Player navigates to RailwayStationLevel (scene change begins) |
+| 02:28:23 | **`LevelInitFallback] GDScript _ready() did NOT execute`** — C# fallback initializer takes over |
+| 02:28:23 | C# fallback registers 15 enemies, places exit zone at **(120, 1544)** — wrong position |
+| 02:28:32 | Player restarts the level — same fallback fires again |
+| 02:28:40 | Third attempt — same fallback, same wrong exit zone at (120, 1544) |
+
+## Root Cause Analysis
+
+### Primary Root Cause: Duplicate `_unhandled_input` function
+
+The script `scripts/levels/railway_station_level.gd` contained **two definitions** of the virtual method `_unhandled_input(event: InputEvent)`:
+
+- **First definition** (line 641): added by PR #1778 — handles game-end screen dismiss on any key/mouse press
+- **Second definition** (line 1038): pre-existing — handles the 'W' key shortcut to watch a replay on the score screen
+
+In GDScript, a **duplicate function definition is a parse error**. When Godot tries to load the script it fails silently and the entire `.gd` file is treated as unattached. The C# `LevelInitFallback` system detects that `_ready()` never ran and performs its own minimal initialization.
+
+Consequences of the script failing to load:
+- `_ready()` never executed → no `_setup_exit_zone()` call → exit zones were not placed by our script
+- `_show_game_end_screen()` was never reachable
+- `_configure_camera()` was never called → camera defaults (no limits) were used → "camera broken"
+- The C# fallback placed a **single exit zone at (120, 1544)** — a position that doesn't correspond to any embankment gap
+- The C# fallback treated all 15 scene enemies as active (including the Exit_DroneOperator guards near the exit), meaning the exit would never activate until all 15 were killed
+
+### Why It Worked Before
+
+Before PR #1778, the script had only **one** `_unhandled_input` (the replay-key one at line 1038). The script parsed successfully, `_ready()` ran, and the level worked normally.
+
+When PR #1778 added a **new** `_unhandled_input` for the game-end screen dismiss, the second definition made the script unparseable.
+
+### Exit Zone Position Analysis
+
+The script's intended exit zone positions were correct based on the scene geometry:
+
+| Embankment | Center X | Half-width | Covers X |
+|---|---|---|---|
+| Embankment1 | 400 | 350 | 50..750 |
+| Embankment2 | 1150 | 350 | 800..1500 |
+| Embankment3 | 2150 | 350 | 1800..2500 |
+| Embankment4 | 3200 | 350 | 2850..3550 |
+
+Resulting gaps and exit zone centers:
+- Gap 1: x=750..800 → center (775, 1000), width 50 px ✓
+- Gap 2: x=1500..1800 → center (1650, 1000), width 300 px ✓
+- Gap 3: x=2500..2850 → center (2675, 1000), width 350 px ✓
+
+The C# fallback created a single zone at **(120, 1544)** — far from any gap.
+
+### Camera Analysis
+
+`_configure_camera()` sets `LIMIT_TOP = 900`. Since the embankment's south face is at y=900 and exit zones at y=1000 are south of that, the camera limit is not the cause of the player being unable to reach exits. The camera not being configured at all (when the script failed) caused the "camera broken" report — Godot's Camera2D default limits mean the camera could scroll to show the upper-left corner of the map, which would look "broken" compared to expected behavior.
+
+## Fix Applied
+
+Merged the two `_unhandled_input` handlers into a single function that handles both cases:
+
+```gdscript
+func _unhandled_input(event: InputEvent) -> void:
+    # Game-end screen: any click or key dismisses it and shows the score screen.
+    if _game_end_screen_shown:
+        if event is InputEventMouseButton or event is InputEventKey:
+            if event.is_pressed():
+                _dismiss_game_end_screen()
+        return
+    # Score screen: W key triggers the watch-replay shortcut.
+    if _score_shown:
+        if event is InputEventKey and event.pressed and not event.echo:
+            if event.keycode == KEY_W:
+                _on_watch_replay_pressed()
+```
+
+This eliminates the parse error, allowing the script to load correctly, `_ready()` to execute, and all level initialization (exit zones, camera limits, game-end screen) to work as intended.
+
+## Lessons Learned
+
+1. **GDScript silently degrades** when there is a parse error — the script simply doesn't attach, and a C# fallback (if present) masks the failure making it hard to detect.
+2. **Duplicate virtual method definitions** in GDScript cause a parse error at runtime rather than a compile-time warning visible to the developer.
+3. **Test with the full scene**: unit tests that mock the scene would not have caught this, because the parse error only manifests when the full `.gd` file is loaded by Godot's script engine.
+4. **Always search for existing definitions** before adding a new override of a built-in virtual method like `_unhandled_input`, `_process`, `_ready`, etc.

--- a/docs/case-studies/issue-1755/README.md
+++ b/docs/case-studies/issue-1755/README.md
@@ -95,3 +95,76 @@ This eliminates the parse error, allowing the script to load correctly, `_ready(
 2. **Duplicate virtual method definitions** in GDScript cause a parse error at runtime rather than a compile-time warning visible to the developer.
 3. **Test with the full scene**: unit tests that mock the scene would not have caught this, because the parse error only manifests when the full `.gd` file is loaded by Godot's script engine.
 4. **Always search for existing definitions** before adding a new override of a built-in virtual method like `_unhandled_input`, `_process`, `_ready`, etc.
+
+---
+
+## Follow-up Issue: Two New Bugs (Reported 2026-04-10)
+
+After the parse-error fix landed, the game-end screen appeared correctly. However two new bugs were reported in the PR comments:
+
+> 1. не исчезает при клике мышкой (doesn't disappear on mouse click)
+> 2. если нажать любую клавишу срабатывает переход к экрану счёта, но если ещё раз нажать любую клавишу экран счёта появляется заново (должно обрабатываться только одно нажатие) — if you press any key the score screen appears, but pressing any key again makes the score screen appear again (only one press should be handled)
+
+### Artifact
+
+- [`game_log_20260410_155902.txt`](game_log_20260410_155902.txt) — second game log from the owner's Windows session; confirms GDScript now loads correctly (`GDScript _ready() already ran (enemies tracked: 15)`)
+
+### Root Cause: Bug 1 — Mouse Click Does Not Dismiss
+
+`_show_game_end_screen()` created the black background `ColorRect` with `mouse_filter = Control.MOUSE_FILTER_IGNORE`. In Godot 4, a Control node with `MOUSE_FILTER_IGNORE` passes input events through — it does **not** generate `gui_input` signals and does **not** cause the engine to route a `InputEventMouseButton` through `_unhandled_input` on a Node2D parent.
+
+Godot 4's input routing for mouse events on a Control node with `MOUSE_FILTER_IGNORE`:
+- The event is forwarded to the next control in the focus chain, not bubbled to `_unhandled_input` on the scene root.
+- `_unhandled_input` receives events only after **all Control nodes in the scene tree have explicitly ignored** them. A full-screen `ColorRect` with `MOUSE_FILTER_IGNORE` is still a visible viewport-covering Control; the engine considers mouse events "handled by the GUI" at that layer before they reach `_unhandled_input`.
+
+Result: mouse button presses were silently consumed by the GUI system and never delivered to `_unhandled_input`.
+
+### Root Cause: Bug 2 — Score Screen Re-Appears on Repeated Key Presses
+
+After `_dismiss_game_end_screen()` was called:
+1. The function removed the overlay nodes and called `_proceed_to_score_screen()`.
+2. But `_game_end_screen_shown` was **never reset to `false`** — it stayed `true`.
+3. The next key press triggered `_unhandled_input` again.
+4. `_game_end_screen_shown` was `true` → entered the if-block → called `_dismiss_game_end_screen()` again.
+5. `_proceed_to_score_screen()` was called a second time → score screen appeared again.
+
+There was no guard preventing `_dismiss_game_end_screen()` from running more than once.
+
+### Fix Applied (2026-04-10)
+
+Two changes in `scripts/levels/railway_station_level.gd`:
+
+**1. Mouse input — switch to `gui_input` on the background ColorRect:**
+
+```gdscript
+bg.mouse_filter = Control.MOUSE_FILTER_STOP   # was MOUSE_FILTER_IGNORE
+bg.gui_input.connect(func(ev: InputEvent) -> void:
+    if ev is InputEventMouseButton and ev.is_pressed():
+        _dismiss_game_end_screen()
+)
+```
+
+`MOUSE_FILTER_STOP` causes the ColorRect to absorb mouse events and emit `gui_input`, which we use to call `_dismiss_game_end_screen()` exactly once.
+
+**2. Idempotent dismiss guard:**
+
+Added `var _game_end_dismissed: bool = false` to the class variables.
+
+`_dismiss_game_end_screen()` now starts with:
+```gdscript
+if _game_end_dismissed:
+    return
+_game_end_dismissed = true
+```
+
+`_unhandled_input()` checks `_game_end_screen_shown and not _game_end_dismissed` so that once dismissed, subsequent key presses fall through to the score-screen branch (W key replay shortcut) instead of re-triggering dismiss.
+
+### Why This Was Not Obvious
+
+- `MOUSE_FILTER_IGNORE` sounds like "ignore the mouse filter", but it actually means "this node ignores mouse input" (i.e., the node is invisible to mouse events). The naming is counterintuitive.
+- The lack of a dismiss guard was an oversight: the assumption was that the `_game_end_screen_shown` flag would prevent a second call, but that flag was never cleared.
+
+### Lessons Learned (Follow-up)
+
+1. **Control.MOUSE_FILTER_IGNORE means "this node ignores mouse"** — use `MOUSE_FILTER_STOP` + `gui_input` signal when you need a full-screen overlay to capture mouse clicks.
+2. **One-shot handlers need an explicit "already fired" guard** — flags that gate entry (`_game_end_screen_shown`) must be cleared or supplemented with a "dismissed" flag to prevent re-entry after the action executes.

--- a/docs/case-studies/issue-1755/game_log_20260410_155902.txt
+++ b/docs/case-studies/issue-1755/game_log_20260410_155902.txt
@@ -1,0 +1,2313 @@
+[15:59:02] [INFO] ============================================================
+[15:59:02] [INFO] GAME LOG STARTED
+[15:59:02] [INFO] ============================================================
+[15:59:02] [INFO] Timestamp: 2026-04-10T15:59:02
+[15:59:02] [INFO] Log file: I:/Загрузки/godot exe/сообщение о завершении/game_log_20260410_155902.txt
+[15:59:02] [INFO] Executable: I:/Загрузки/godot exe/сообщение о завершении/Godot-Top-Down-Template.exe
+[15:59:02] [INFO] OS: Windows
+[15:59:02] [INFO] Debug build: false
+[15:59:02] [INFO] Engine version: 4.3-stable (official)
+[15:59:02] [INFO] Project: Godot Top-Down Template
+[15:59:02] [INFO] Build info: not available (build_info.cfg not found)
+[15:59:02] [INFO] ------------------------------------------------------------
+[15:59:02] [INFO] [GameManager] GameManager ready
+[15:59:02] [INFO] [ScoreManager] ScoreManager ready
+[15:59:02] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[15:59:02] [INFO] [DifficultyManager] Loaded difficulty: Gunslinger (value: 5)
+[15:59:02] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[15:59:02] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[15:59:02] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[15:59:02] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[15:59:02] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[15:59:02] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[15:59:02] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[15:59:02] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[15:59:02] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[15:59:02] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[15:59:02] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[15:59:02] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[15:59:02] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[15:59:02] [INFO] [LastChance] Resetting all effects (scene change detected)
+[15:59:02] [INFO] [LastChance] Last chance shader loaded successfully
+[15:59:02] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[15:59:02] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[15:59:02] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[15:59:02] [INFO] [LastChance]   Sepia intensity: 0.70
+[15:59:02] [INFO] [LastChance]   Brightness: 0.60
+[15:59:02] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[15:59:02] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[15:59:02] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[15:59:02] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[15:59:02] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DroneGrenade.tscn
+[15:59:02] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: false, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: false, FPS drop logging: true, All weapons unlocked: true, All maps unlocked: true, Global stuck max time: 20.0s, Nav mesh visible: false, Search path visible: false, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false, Enemy path visible: false, Cover raycast visible: false, Tactical group: false, Cover infinite rays: true, Cover sector rays: true, Roguelike unlocked: false
+[15:59:02] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[15:59:02] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.49, music: 1.00
+[15:59:02] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true, revolver_aim_assist: true
+[15:59:02] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[15:59:02] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[15:59:02] [INFO] [CinemaEffects] Created effects layer at layer 99
+[15:59:02] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[15:59:02] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[15:59:02] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[15:59:02] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[15:59:02] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[15:59:02] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[15:59:02] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[15:59:02] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[15:59:02] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[15:59:02] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[15:59:02] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[15:59:02] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[15:59:02] [INFO] [GrenadeTimerHelper] Autoload ready
+[15:59:02] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[15:59:02] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[15:59:02] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[15:59:02] [INFO] [PowerFantasy]   Kill effect duration: 600ms
+[15:59:02] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[15:59:02] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[15:59:02] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[15:59:02] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[15:59:02] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[15:59:02] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[15:59:02] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[15:59:02] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[15:59:02] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[15:59:02] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[15:59:02] [INFO] [ProgressManager] ProgressManager ready, loaded 21 entries
+[15:59:02] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[15:59:02] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[15:59:02] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[15:59:02] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[15:59:02] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[15:59:02] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[15:59:02] [INFO] [SceneLoader] SceneLoader initialized
+[15:59:02] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[15:59:02] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[15:59:02] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[15:59:02] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[15:59:02] [INFO] [PersistManager] Restored kills_without_laser_sight: 578
+[15:59:02] [INFO] [PersistManager] Restored shots_fired_special_weapons: 104
+[15:59:02] [INFO] [PersistManager] Restored total_deaths: 46
+[15:59:02] [INFO] [PersistManager] Restored no_damage_levels_completed: 12
+[15:59:02] [INFO] [PersistManager] Restored levels_completed_rank_a_or_higher: 15
+[15:59:02] [INFO] [PersistManager] Restored kills_through_wall: 11
+[15:59:02] [INFO] [PersistManager] Restored levels_completed_with_silenced_pistol: 0
+[15:59:02] [INFO] [GameManager] Weapon selected: ak_gl
+[15:59:02] [INFO] [PersistManager] Restored selected weapon: ak_gl
+[15:59:02] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[15:59:02] [INFO] [GrenadeManager] Grenade type changed from Flashbang to F-1 Grenade
+[15:59:02] [INFO] [PersistManager] Restored selected grenade type: 2
+[15:59:02] [INFO] [PersistManager] Restored unlocked active item type: 0
+[15:59:02] [INFO] [PersistManager] Restored unlocked active item type: 11
+[15:59:02] [INFO] [ActiveItemManager] Active item changed from None to Homing Bullets
+[15:59:02] [INFO] [PersistManager] Restored selected active item type: 2
+[15:59:02] [INFO] [PersistManager] Loudspeaker progress restored: level 5, levels_completed=11
+[15:59:02] [INFO] [PersistManager] State loaded successfully
+[15:59:02] [INFO] [PersistManager] PersistManager ready
+[15:59:02] [INFO] [UnlockManager] UnlockManager ready
+[15:59:02] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["makarov_pm", "shotgun", "mini_uzi", "sniper", "revolver", "ak_gl", "silenced_pistol", "m16"]
+[15:59:02] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, warm_lights: true, ai: true
+[15:59:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:02] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[15:59:02] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[15:59:02] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[15:59:02] [ENEMY] [Enemy1] Death animation component initialized
+[15:59:02] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[15:59:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:02] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[15:59:02] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[15:59:02] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[15:59:02] [ENEMY] [Enemy2] Death animation component initialized
+[15:59:02] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[15:59:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:02] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[15:59:02] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[15:59:02] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[15:59:02] [ENEMY] [Enemy3] Death animation component initialized
+[15:59:02] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[15:59:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:02] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[15:59:02] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[15:59:02] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[15:59:02] [ENEMY] [Enemy4] Death animation component initialized
+[15:59:03] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[15:59:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:03] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[15:59:03] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[15:59:03] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[15:59:03] [ENEMY] [Enemy5] Death animation component initialized
+[15:59:03] [ENEMY] [Enemy5] [Gunslinger] Enemy glow applied
+[15:59:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:03] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[15:59:03] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[15:59:03] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[15:59:03] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[15:59:03] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[15:59:03] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[15:59:03] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[15:59:03] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[15:59:03] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[15:59:03] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[15:59:03] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[15:59:03] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[15:59:03] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[15:59:03] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[15:59:03] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[15:59:03] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[15:59:03] [INFO] [Player.Homing] Homing activation sound loaded
+[15:59:03] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[15:59:03] [INFO] [Player.Homing] Homing bullets equipped, charges: 2/2
+[15:59:03] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[15:59:03] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[15:59:03] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[15:59:03] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[15:59:03] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[15:59:03] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[15:59:03] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[15:59:03] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[15:59:03] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[15:59:03] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[15:59:03] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[15:59:03] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[15:59:03] [INFO] [Player.ItemVisual] Visual applied for item type: 2
+[15:59:03] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[15:59:03] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[15:59:03] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[15:59:03] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[15:59:03] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[15:59:03] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[15:59:03] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[15:59:03] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[15:59:03] [INFO] [Player.Jammer] JammerHUD initialized
+[15:59:03] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[15:59:03] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[15:59:03] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[15:59:03] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[15:59:03] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[15:59:03] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[15:59:03] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[15:59:03] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[15:59:03] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[15:59:03] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[15:59:03] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[15:59:03] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[15:59:03] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[15:59:03] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[15:59:03] [INFO] [GameManager] set_player() called with: <CharacterBody2D#83818972930> (class: CharacterBody2D)
+[15:59:03] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[15:59:03] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[15:59:03] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[15:59:03] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[15:59:03] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[15:59:03] [INFO] [ScoreManager] Level started with 5 enemies
+[15:59:03] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[15:59:03] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[15:59:03] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[15:59:03] [INFO] [ReplayManager] Replay data cleared
+[15:59:03] [INFO] [LabyrinthLevel] Previous replay data cleared
+[15:59:03] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[15:59:03] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[15:59:03] [INFO] [ReplayManager] Level: LabyrinthLevel
+[15:59:03] [INFO] [ReplayManager] Player: Player (valid: True)
+[15:59:03] [INFO] [ReplayManager] Enemies count: 5
+[15:59:03] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[15:59:03] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[15:59:03] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[15:59:03] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[15:59:03] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[15:59:03] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[15:59:03] [INFO] [LabyrinthLevel] Replay recording started successfully
+[15:59:03] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[15:59:03] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[15:59:03] [INFO] [CinemaEffects] Found player node: Player
+[15:59:03] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[15:59:03] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/RailwayStationLevel.tscn
+[15:59:03] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/RailwayStationLevel.tscn
+[15:59:03] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[15:59:03] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[15:59:03] [INFO] [UnlockManager] Restored saved unlock for weapon: ak_gl
+[15:59:03] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[15:59:03] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[15:59:03] [ENEMY] [Enemy1] Registered as sound listener
+[15:59:03] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[15:59:03] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[15:59:03] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[15:59:03] [ENEMY] [Enemy2] Registered as sound listener
+[15:59:03] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[15:59:03] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[15:59:03] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[15:59:03] [ENEMY] [Enemy3] Registered as sound listener
+[15:59:03] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[15:59:03] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[15:59:03] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[15:59:03] [ENEMY] [Enemy4] Registered as sound listener
+[15:59:03] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[15:59:03] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[15:59:03] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[15:59:03] [ENEMY] [Enemy5] Registered as sound listener
+[15:59:03] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 1, behavior: GUARD
+[15:59:03] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[15:59:03] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:59:03] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:59:03] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=315.0°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:59:03] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:59:03] [INFO] [Player] Detecting weapon pose (frame 3)...
+[15:59:03] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[15:59:03] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[15:59:03] [INFO] [PenultimateHit] Shader warmup complete in 1182 ms
+[15:59:03] [INFO] [LastChance] Shader warmup complete in 1182 ms
+[15:59:03] [INFO] [CinemaEffects] Cinema shader warmup complete in 1064 ms
+[15:59:03] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1056 ms
+[15:59:03] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[15:59:03] [INFO] [FlashbangPlayer] Shader warmup complete in 1053 ms
+[15:59:03] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[15:59:03] [INFO] [SceneLoader] ERROR: Invalid resource (falling back to sync): res://scenes/levels/RailwayStationLevel.tscn
+[15:59:03] [INFO] [SceneLoader] Using synchronous load fallback
+[15:59:04] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[15:59:04] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[15:59:04] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[15:59:04] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[15:59:04] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[15:59:04] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:59:04] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] BloodyFeetComponent ready on NearTracks_MachineGunnerLeft
+[15:59:04] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:59:04] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[15:59:04] [INFO] [LastChance] Resetting all effects (scene change detected)
+[15:59:04] [INFO] [CinemaEffects] Scene changed to: RailwayStationLevel
+[15:59:04] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[15:59:04] [INFO] [BlackMetalEffectsManager] Scene changed to: RailwayStationLevel
+[15:59:04] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[15:59:04] [INFO] [PersistManager] Startup navigation complete — arrived at: res://scenes/levels/RailwayStationLevel.tscn
+[15:59:04] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:04] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RailwayStationLevel.tscn
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation component initialized
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerLeft] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] BloodyFeetComponent ready on NearTracks_MachineGunnerRight
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerRight] Death animation component initialized
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerRight] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] BloodyFeetComponent ready on FarTracks_MachineGunnerLeft
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation component initialized
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerLeft] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] BloodyFeetComponent ready on FarTracks_MachineGunnerRight
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerRight] Death animation component initialized
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerRight] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator1] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator1] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator1] BloodyFeetComponent ready on Exit_DroneOperator1
+[15:59:04] [ENEMY] [Exit_DroneOperator1] Death animation component initialized
+[15:59:04] [INFO] [DroneOperator] VR headset visual created
+[15:59:04] [INFO] [DroneOperator] Tablet visual created
+[15:59:04] [INFO] [DroneOperator] Setup complete
+[15:59:04] [ENEMY] [Exit_DroneOperator1] Found cover at (721.5328, 1104) (distance: 21.9, player at (2000, 3100))
+[15:59:04] [ENEMY] [Exit_DroneOperator1] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator2] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator2] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator2] BloodyFeetComponent ready on Exit_DroneOperator2
+[15:59:04] [ENEMY] [Exit_DroneOperator2] Death animation component initialized
+[15:59:04] [INFO] [DroneOperator] VR headset visual created
+[15:59:04] [INFO] [DroneOperator] Tablet visual created
+[15:59:04] [INFO] [DroneOperator] Setup complete
+[15:59:04] [ENEMY] [Exit_DroneOperator2] Found cover at (1602.407, 1104) (distance: 4.7, player at (2000, 3100))
+[15:59:04] [ENEMY] [Exit_DroneOperator2] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator3] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator3] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator3] BloodyFeetComponent ready on Exit_DroneOperator3
+[15:59:04] [ENEMY] [Exit_DroneOperator3] Death animation component initialized
+[15:59:04] [INFO] [DroneOperator] VR headset visual created
+[15:59:04] [INFO] [DroneOperator] Tablet visual created
+[15:59:04] [INFO] [DroneOperator] Setup complete
+[15:59:04] [ENEMY] [Exit_DroneOperator3] Found cover at (1944, 1104) (distance: 556.0, player at (2000, 3100))
+[15:59:04] [ENEMY] [Exit_DroneOperator3] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator4] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator4] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator4] BloodyFeetComponent ready on Exit_DroneOperator4
+[15:59:04] [ENEMY] [Exit_DroneOperator4] Death animation component initialized
+[15:59:04] [INFO] [DroneOperator] VR headset visual created
+[15:59:04] [INFO] [DroneOperator] Tablet visual created
+[15:59:04] [INFO] [DroneOperator] Setup complete
+[15:59:04] [ENEMY] [Exit_DroneOperator4] Found cover at (1944, 1104) (distance: 1356.0, player at (2000, 3100))
+[15:59:04] [ENEMY] [Exit_DroneOperator4] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] BloodyFeetComponent ready on Spawn_GasMaskEnemy
+[15:59:04] [ENEMY] [Spawn_GasMaskEnemy] Death animation component initialized
+[15:59:04] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[15:59:04] [ENEMY] [Spawn_GasMaskEnemy] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft1] BloodyFeetComponent ready on Platform_TeleporterLeft1
+[15:59:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft1
+[15:59:04] [ENEMY] [Platform_TeleporterLeft1] Death animation component initialized
+[15:59:04] [ENEMY] [Platform_TeleporterLeft1] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft2] BloodyFeetComponent ready on Platform_TeleporterLeft2
+[15:59:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft2
+[15:59:04] [ENEMY] [Platform_TeleporterLeft2] Death animation component initialized
+[15:59:04] [ENEMY] [Platform_TeleporterLeft2] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft3] BloodyFeetComponent ready on Platform_TeleporterLeft3
+[15:59:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft3
+[15:59:04] [ENEMY] [Platform_TeleporterLeft3] Death animation component initialized
+[15:59:04] [ENEMY] [Platform_TeleporterLeft3] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight1] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight1] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight1] BloodyFeetComponent ready on Platform_TeleporterRight1
+[15:59:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight1
+[15:59:04] [ENEMY] [Platform_TeleporterRight1] Death animation component initialized
+[15:59:04] [ENEMY] [Platform_TeleporterRight1] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight2] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight2] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight2] BloodyFeetComponent ready on Platform_TeleporterRight2
+[15:59:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight2
+[15:59:04] [ENEMY] [Platform_TeleporterRight2] Death animation component initialized
+[15:59:04] [ENEMY] [Platform_TeleporterRight2] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight3] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight3] Found EnemyModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight3] BloodyFeetComponent ready on Platform_TeleporterRight3
+[15:59:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight3
+[15:59:04] [ENEMY] [Platform_TeleporterRight3] Death animation component initialized
+[15:59:04] [ENEMY] [Platform_TeleporterRight3] [Gunslinger] Enemy glow applied
+[15:59:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:59:04] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[15:59:04] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[15:59:04] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[15:59:04] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[15:59:04] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[15:59:04] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[15:59:04] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[15:59:04] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[15:59:04] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[15:59:04] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[15:59:04] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[15:59:04] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[15:59:04] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[15:59:04] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[15:59:04] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[15:59:04] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[15:59:04] [INFO] [Player.Homing] Homing activation sound loaded
+[15:59:04] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[15:59:04] [INFO] [Player.Homing] Homing bullets equipped, charges: 2/2
+[15:59:04] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[15:59:04] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[15:59:04] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[15:59:04] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[15:59:04] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[15:59:04] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[15:59:04] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[15:59:04] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[15:59:04] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[15:59:04] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[15:59:04] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[15:59:04] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[15:59:04] [INFO] [Player.ItemVisual] Visual applied for item type: 2
+[15:59:04] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[15:59:04] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[15:59:04] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[15:59:04] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[15:59:04] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[15:59:04] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[15:59:04] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[15:59:04] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[15:59:04] [INFO] [Player.Jammer] JammerHUD initialized
+[15:59:04] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[15:59:04] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[15:59:04] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[15:59:04] [INFO] [RailwayStationLevel] Found Environment/Enemies node with 15 children
+[15:59:04] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerRight': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerRight': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator1': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator2': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator3': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator4': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Spawn_GasMaskEnemy': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft1': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft2': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft3': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight1': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight2': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight3': script=true, has_died_signal=true
+[15:59:04] [INFO] [RailwayStationLevel] Enemy tracking complete: 15 enemies registered
+[15:59:04] [INFO] [RailwayStationLevel] Setting up weapon: ak_gl
+[15:59:04] [INFO] [RailwayStationLevel] AKGL already equipped by C# Player - skipping GDScript weapon swap
+[15:59:04] [INFO] [GameManager] set_player() called with: <CharacterBody2D#156380434603> (class: CharacterBody2D)
+[15:59:04] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[15:59:04] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[15:59:04] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[15:59:04] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[15:59:04] [INFO] [ScoreManager] Level started with 15 enemies
+[15:59:04] [INFO] [RailwayStationLevel] ReplayManager found as C# autoload
+[15:59:04] [INFO] [ReplayManager] Replay data cleared
+[15:59:04] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[15:59:04] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[15:59:04] [INFO] [ReplayManager] Level: RailwayStationLevel
+[15:59:04] [INFO] [ReplayManager] Player: Player (valid: True)
+[15:59:04] [INFO] [ReplayManager] Enemies count: 15
+[15:59:04] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[15:59:04] [INFO] [ReplayManager]   Enemy 0: NearTracks_MachineGunnerLeft
+[15:59:04] [INFO] [ReplayManager]   Enemy 1: NearTracks_MachineGunnerRight
+[15:59:04] [INFO] [ReplayManager]   Enemy 2: FarTracks_MachineGunnerLeft
+[15:59:04] [INFO] [ReplayManager]   Enemy 3: FarTracks_MachineGunnerRight
+[15:59:04] [INFO] [ReplayManager]   Enemy 4: Exit_DroneOperator1
+[15:59:04] [INFO] [ReplayManager]   Enemy 5: Exit_DroneOperator2
+[15:59:04] [INFO] [ReplayManager]   Enemy 6: Exit_DroneOperator3
+[15:59:04] [INFO] [ReplayManager]   Enemy 7: Exit_DroneOperator4
+[15:59:04] [INFO] [ReplayManager]   Enemy 8: Spawn_GasMaskEnemy
+[15:59:04] [INFO] [ReplayManager]   Enemy 9: Platform_TeleporterLeft1
+[15:59:04] [INFO] [ReplayManager]   Enemy 10: Platform_TeleporterLeft2
+[15:59:04] [INFO] [ReplayManager]   Enemy 11: Platform_TeleporterLeft3
+[15:59:04] [INFO] [ReplayManager]   Enemy 12: Platform_TeleporterRight1
+[15:59:04] [INFO] [ReplayManager]   Enemy 13: Platform_TeleporterRight2
+[15:59:04] [INFO] [ReplayManager]   Enemy 14: Platform_TeleporterRight3
+[15:59:04] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[15:59:04] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[15:59:04] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 15) - skipping fallback
+[15:59:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Blood detector created and attached to NearTracks_MachineGunnerLeft
+[15:59:04] [INFO] [CinemaEffects] Found player node: Player
+[15:59:04] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[15:59:04] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerLeft (total: 1)
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerLeft] Registered as sound listener
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerLeft] Spawned at (300, 2670), hp: 2, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Blood detector created and attached to NearTracks_MachineGunnerRight
+[15:59:04] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerRight (total: 2)
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerRight] Registered as sound listener
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerRight] Spawned at (3700, 2670), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Blood detector created and attached to FarTracks_MachineGunnerLeft
+[15:59:04] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerLeft (total: 3)
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerLeft] Registered as sound listener
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerLeft] Spawned at (300, 1890), hp: 2, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Blood detector created and attached to FarTracks_MachineGunnerRight
+[15:59:04] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerRight (total: 4)
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerRight] Registered as sound listener
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerRight] Spawned at (3700, 1890), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator1] Blood detector created and attached to Exit_DroneOperator1
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator1 (total: 5)
+[15:59:04] [ENEMY] [Exit_DroneOperator1] Registered as sound listener
+[15:59:04] [ENEMY] [Exit_DroneOperator1] Spawned at (700, 1100), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator2] Blood detector created and attached to Exit_DroneOperator2
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator2 (total: 6)
+[15:59:04] [ENEMY] [Exit_DroneOperator2] Registered as sound listener
+[15:59:04] [ENEMY] [Exit_DroneOperator2] Spawned at (1600, 1100), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator3] Blood detector created and attached to Exit_DroneOperator3
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator3 (total: 7)
+[15:59:04] [ENEMY] [Exit_DroneOperator3] Registered as sound listener
+[15:59:04] [ENEMY] [Exit_DroneOperator3] Spawned at (2500, 1100), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Exit_DroneOperator4] Blood detector created and attached to Exit_DroneOperator4
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator4 (total: 8)
+[15:59:04] [ENEMY] [Exit_DroneOperator4] Registered as sound listener
+[15:59:04] [ENEMY] [Exit_DroneOperator4] Spawned at (3300, 1100), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Blood detector created and attached to Spawn_GasMaskEnemy
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Spawn_GasMaskEnemy (total: 9)
+[15:59:04] [ENEMY] [Spawn_GasMaskEnemy] Registered as sound listener
+[15:59:04] [ENEMY] [Spawn_GasMaskEnemy] Spawned at (900, 3075), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Blood detector created and attached to Platform_TeleporterLeft1
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft1 (total: 10)
+[15:59:04] [ENEMY] [Platform_TeleporterLeft1] Registered as sound listener
+[15:59:04] [ENEMY] [Platform_TeleporterLeft1] Spawned at (200, 3500), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Blood detector created and attached to Platform_TeleporterLeft2
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft2 (total: 11)
+[15:59:04] [ENEMY] [Platform_TeleporterLeft2] Registered as sound listener
+[15:59:04] [ENEMY] [Platform_TeleporterLeft2] Spawned at (400, 3500), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Blood detector created and attached to Platform_TeleporterLeft3
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft3 (total: 12)
+[15:59:04] [ENEMY] [Platform_TeleporterLeft3] Registered as sound listener
+[15:59:04] [ENEMY] [Platform_TeleporterLeft3] Spawned at (600, 3500), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight1] Blood detector created and attached to Platform_TeleporterRight1
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight1 (total: 13)
+[15:59:04] [ENEMY] [Platform_TeleporterRight1] Registered as sound listener
+[15:59:04] [ENEMY] [Platform_TeleporterRight1] Spawned at (3400, 3500), hp: 1, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight2] Blood detector created and attached to Platform_TeleporterRight2
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight2 (total: 14)
+[15:59:04] [ENEMY] [Platform_TeleporterRight2] Registered as sound listener
+[15:59:04] [ENEMY] [Platform_TeleporterRight2] Spawned at (3600, 3500), hp: 2, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Platform_TeleporterRight3] Blood detector created and attached to Platform_TeleporterRight3
+[15:59:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight3 (total: 15)
+[15:59:04] [ENEMY] [Platform_TeleporterRight3] Registered as sound listener
+[15:59:04] [ENEMY] [Platform_TeleporterRight3] Spawned at (3800, 3500), hp: 2, behavior: GUARD
+[15:59:04] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[15:59:04] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=15
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=0.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=0.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[15:59:04] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[15:59:04] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[15:59:04] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[15:59:04] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: none -> P1:visible, state=IDLE, target=1.9°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [Spawn_GasMaskEnemy] State: IDLE -> COMBAT
+[15:59:04] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=213.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:59:04] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (762.361, 3378.544) (distance: 345.9, player at (2000, 3100))
+[15:59:04] [INFO] [Player] Detecting weapon pose (frame 3)...
+[15:59:04] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[15:59:04] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[15:59:04] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[15:59:04] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[15:59:04] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[15:59:04] [INFO] [LastChance] Found player: Player
+[15:59:04] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[15:59:04] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[15:59:04] [INFO] [LastChance] Connected to player Died signal (C#)
+[15:59:04] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[15:59:04] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 2019 ms
+[15:59:04] [INFO] [SceneLoader] Background load started successfully
+[15:59:05] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=15
+[15:59:06] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=15
+[15:59:07] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=15
+[15:59:08] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=15
+[15:59:08] [INFO] [PerformanceSettings] AI disabled
+[15:59:09] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=15
+[15:59:10] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=15
+[15:59:11] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=15
+[15:59:12] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=15
+[15:59:13] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (1 total)
+[15:59:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1230.842, 3025.672), source=PLAYER (AKGL), range=871, listeners=15
+[15:59:13] [ENEMY] [Spawn_GasMaskEnemy] Heard gunshot at (1230.842, 3025.672), intensity=0.06, distance=212
+[15:59:13] [ENEMY] [Platform_TeleporterLeft3] Heard gunshot at (1230.842, 3025.672), intensity=0.00, distance=789
+[15:59:13] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=13, self=0
+[15:59:13] [ENEMY] [Spawn_GasMaskEnemy] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:13] [ENEMY] [Spawn_GasMaskEnemy] Hit: dmg=2, hp=1/1->-1/1
+[15:59:13] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:13] [ENEMY] [Spawn_GasMaskEnemy] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:13] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:13] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:13] [INFO] [GameManager] kills_without_laser_sight: 579
+[15:59:13] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[15:59:13] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:13] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:13] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:13] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:13] [INFO] [SoundPropagation] Unregistered listener: Spawn_GasMaskEnemy (remaining: 14)
+[15:59:13] [INFO] [DeathAnim] Started - Angle: 173.6 deg, Index: 23
+[15:59:13] [ENEMY] [Spawn_GasMaskEnemy] Death animation started with hit direction: (-0.993735, 0.111758)
+[15:59:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1205.068, 3011.52), source=NEUTRAL (null), range=900, listeners=14
+[15:59:13] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1205.068, 3011.52), intensity=0.00, dist=778
+[15:59:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=13, self=0
+[15:59:13] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (2 total)
+[15:59:13] [INFO] [WeaponHintsComponent] Hint added 'reload': [color=#ff4444][R][/color] [color=#888888][F] [R][/color] Перезарядись
+[15:59:13] [INFO] [WeaponHintsComponent] Reload hint revealed for: ak_gl
+[15:59:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1171.442, 3025.672), source=PLAYER (AKGL), range=871, listeners=14
+[15:59:13] [ENEMY] [Platform_TeleporterLeft3] Heard gunshot at (1171.442, 3025.672), intensity=0.00, distance=743
+[15:59:13] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=13, self=0
+[15:59:13] [INFO] [WeaponHintsComponent] Strikethrough setup 'reload': 1 lines
+[15:59:13] [ENEMY] [Spawn_GasMaskEnemy] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (949.7481, 3115.767) (added to group)
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (932.821, 3054.209) (added to group)
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (950.5085, 3058.735) (added to group)
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (934.0799, 3126.002) (added to group)
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (941.6688, 3093.001) (added to group)
+[15:59:13] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=15
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (961.5628, 3061.693) (added to group)
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (963.5106, 3114.474) (added to group)
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (940.9627, 3138.004) (added to group)
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (883.013, 3059.027) (added to group)
+[15:59:13] [ENEMY] [Spawn_GasMaskEnemy] Ragdoll activated
+[15:59:13] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (889.5985, 3163.942) (added to group)
+[15:59:13] [INFO] [PowerFantasy] Effect duration expired after 610.00 ms
+[15:59:13] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (890.6665, 3155.041) (added to group)
+[15:59:13] [INFO] [BloodDecal] Blood puddle created at (869.2168, 3175.946) (added to group)
+[15:59:14] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[15:59:14] [INFO] [ReplayManager] Recording frame 600 (9,9s): player_valid=True, enemies=15
+[15:59:14] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[15:59:14] [INFO] [GrenadeBase] Grenade created at (707.2437, 3076.645) (frozen)
+[15:59:14] [INFO] [VOGGrenade] Shrapnel scene loaded from: res://scenes/projectiles/Shrapnel.tscn
+[15:59:14] [INFO] [VOGGrenade] Launched - waiting for impact (no timer, impact-triggered only)
+[15:59:14] [INFO] [VOGGrenade] Grenade launched from underbarrel - impact detection enabled
+[15:59:14] [INFO] [GrenadeTimer] Initialized for Frag grenade, effect radius: 337
+[15:59:14] [INFO] [GrenadeTimerHelper] Attached GrenadeTimer to VOGGrenade (type: Frag)
+[15:59:14] [INFO] [GrenadeTimer] Timer activated! 4 seconds until explosion
+[15:59:14] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[15:59:14] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(717.53, 3025.672), source=PLAYER (AKGL), range=871, listeners=14
+[15:59:14] [ENEMY] [NearTracks_MachineGunnerLeft] Heard gunshot at (717.53, 3025.672), intensity=0.01, distance=548
+[15:59:14] [ENEMY] [Platform_TeleporterLeft1] Heard gunshot at (717.53, 3025.672), intensity=0.01, distance=702
+[15:59:14] [ENEMY] [Platform_TeleporterLeft2] Heard gunshot at (717.53, 3025.672), intensity=0.01, distance=571
+[15:59:14] [ENEMY] [Platform_TeleporterLeft3] Heard gunshot at (717.53, 3025.672), intensity=0.01, distance=489
+[15:59:14] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=10, self=0
+[15:59:14] [INFO] [WeaponHintsComponent] Grenade launcher fired — launcher hint dismissed
+[15:59:14] [INFO] [Player] AKGL grenade launcher fired!
+[15:59:14] [ENEMY] [Spawn_GasMaskEnemy] Death animation completed
+[15:59:15] [INFO] [GrenadeBase] Collision detected with Platform_TeleporterLeft3 (type: CharacterBody2D)
+[15:59:15] [INFO] [VOGGrenade] Impact detected! Body: Platform_TeleporterLeft3 (type: CharacterBody2D), triggering explosion
+[15:59:15] [INFO] [VOGGrenade] Impact detected - exploding immediately!
+[15:59:15] [INFO] [GrenadeBase] EXPLODED at (631.677, 3491.271)!
+[15:59:15] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(631.677, 3491.271), source=NEUTRAL (VOGGrenade), range=2937, listeners=14
+[15:59:15] [ENEMY] [FarTracks_MachineGunnerLeft] Heard EXPLOSION at (631.677, 3491.271), intensity=0.00, distance=1635
+[15:59:15] [ENEMY] [Platform_TeleporterRight1] Heard EXPLOSION at (631.677, 3491.271), intensity=0.00, distance=2768
+[15:59:15] [INFO] [SoundPropagation] Sound result: notified=8, out_of_range=6, self=0
+[15:59:15] [ENEMY] [Platform_TeleporterLeft2] Hit: dmg=1, hp=1/1->0/1
+[15:59:15] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:15] [ENEMY] [Platform_TeleporterLeft2] Enemy died (ricochet: false, penetration: false, player_kill: false)
+[15:59:15] [INFO] [GameManager] register_kill: skipping non-player kill (enemy-vs-enemy or ally-vs-enemy)
+[15:59:15] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[15:59:15] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:15] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:15] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:15] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:15] [ENEMY] [Platform_TeleporterLeft2] [AllyDeath] Notified 2 enemies
+[15:59:15] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft2 (remaining: 13)
+[15:59:15] [INFO] [DeathAnim] Started - Angle: 177.8 deg, Index: 23
+[15:59:15] [ENEMY] [Platform_TeleporterLeft2] Death animation started with hit direction: (-0.999291, 0.03765)
+[15:59:15] [INFO] [VOGGrenade] Applied 99 HE damage to enemy at distance 231.8
+[15:59:15] [ENEMY] [Platform_TeleporterLeft3] Hit: dmg=1, hp=1/1->0/1
+[15:59:15] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:15] [ENEMY] [Platform_TeleporterLeft3] Enemy died (ricochet: false, penetration: false, player_kill: false)
+[15:59:15] [INFO] [GameManager] register_kill: skipping non-player kill (enemy-vs-enemy or ally-vs-enemy)
+[15:59:15] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[15:59:15] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:15] [INFO] [PowerFantasy] Effect timer reset to 600ms
+[15:59:15] [ENEMY] [Platform_TeleporterLeft3] [AllyDeath] Notified 1 enemies
+[15:59:15] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft3 (remaining: 12)
+[15:59:15] [INFO] [DeathAnim] Started - Angle: 164.6 deg, Index: 22
+[15:59:15] [ENEMY] [Platform_TeleporterLeft3] Death animation started with hit direction: (-0.964068, 0.265654)
+[15:59:15] [INFO] [VOGGrenade] Applied 99 HE damage to enemy at distance 32.9
+[15:59:15] [INFO] [VOGGrenade] Spawned shrapnel #1 at angle 13.8 degrees
+[15:59:15] [INFO] [VOGGrenade] Spawned shrapnel #2 at angle 25.7 degrees
+[15:59:15] [INFO] [VOGGrenade] Spawned shrapnel #3 at angle 88.8 degrees
+[15:59:15] [INFO] [VOGGrenade] Spawned shrapnel #4 at angle 140.5 degrees
+[15:59:15] [INFO] [VOGGrenade] Spawned shrapnel #5 at angle 181.5 degrees
+[15:59:15] [INFO] [VOGGrenade] Spawned shrapnel #6 at angle 230.5 degrees
+[15:59:15] [INFO] [VOGGrenade] Spawned shrapnel #7 at angle 245.9 degrees
+[15:59:15] [INFO] [VOGGrenade] Spawned shrapnel #8 at angle 308.6 degrees
+[15:59:15] [INFO] [GrenadeTimer] Impact detected with Platform_TeleporterLeft3 - EXPLODING!
+[15:59:15] [INFO] [GrenadeTimer] GDScript already handled Frag explosion - skipping C# duplicate (Issue #886)
+[15:59:15] [INFO] [ReplayManager] Recording frame 660 (10,4s): player_valid=True, enemies=15
+[15:59:15] [INFO] [PowerFantasy] Effect duration expired after 617.00 ms
+[15:59:15] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:15] [ENEMY] [Platform_TeleporterLeft1] Hit: dmg=1, hp=1/1->0/1
+[15:59:15] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:15] [ENEMY] [Platform_TeleporterLeft1] Enemy died (ricochet: false, penetration: false, player_kill: false)
+[15:59:15] [INFO] [GameManager] register_kill: skipping non-player kill (enemy-vs-enemy or ally-vs-enemy)
+[15:59:15] [INFO] [ScoreManager] Kill registered. Combo: 4 (points: 5000)
+[15:59:15] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:15] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:15] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:15] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:15] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft1 (remaining: 11)
+[15:59:15] [INFO] [DeathAnim] Started - Angle: 4.9 deg, Index: 12
+[15:59:15] [ENEMY] [Platform_TeleporterLeft1] Death animation started with hit direction: (0.996336, 0.085527)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (327.8227, 3547.455) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (342.4449, 3507.727) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (558.2226, 3513.88) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (359.6546, 3511.286) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (315.3359, 3508.808) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (330.9524, 3514.604) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (353.9642, 3515.778) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (544.6899, 3547.594) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (530.1173, 3506.031) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (314.9814, 3513.442) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (302.9673, 3537.56) (added to group)
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (520.5619, 3531.205) (added to group)
+[15:59:15] [ENEMY] [NearTracks_MachineGunnerLeft] Hit: dmg=1, hp=2/2->1/2
+[15:59:15] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:59:15] [INFO] [BloodDecal] Blood puddle created at (332.2617, 2631) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (525.8259, 3510.344) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (525.2933, 3551.856) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (533.7543, 3523.302) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (339.252, 3557.301) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (521.079, 3523.952) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (547.6977, 3515.466) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (539.3658, 3552.045) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (502.123, 3549.908) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (285.828, 3547.338) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (279.9455, 3508.803) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (279.9544, 3578.15) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (473.1099, 3541.09) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (487.1395, 3520.151) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (262.6155, 3508.043) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (257.2088, 3493.407) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (320.5893, 3569.956) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (276.42, 3510.909) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (482.3181, 3634.704) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (253.3311, 3521.116) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (266.7294, 3491.019) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (290.51, 3588.81) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (269.033, 3507.084) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (478.7644, 3626.103) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (507.0797, 3588.566) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (276.9257, 3566.345) (added to group)
+[15:59:16] [ENEMY] [Platform_TeleporterLeft2] Ragdoll activated
+[15:59:16] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:16] [ENEMY] [Platform_TeleporterLeft3] Ragdoll activated
+[15:59:16] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (285.7029, 3564.385) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (321.3686, 3581.21) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (476.4534, 3566.809) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (276.3634, 3557.781) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (270.477, 3553.82) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (475.0566, 3668.715) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (308.3427, 3594.911) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (471.8991, 3589.503) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (418.8394, 3550.197) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (287.9897, 3564.634) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (305.0876, 3522.201) (added to group)
+[15:59:16] [INFO] [BloodyFeet:Player] Blood ran out - no more footprints
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (230.4433, 3513.661) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (255.3003, 3502.161) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (221.3692, 3601.237) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (295.9714, 3531.469) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (446.9058, 3640.931) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (530.8592, 3629.485) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (463.9753, 3597.168) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (313.6759, 3533.728) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (323.1912, 3586.516) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (206.1273, 3522.514) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (321.2092, 3539.821) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (418.5113, 3567.938) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (269.9618, 3516.5) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (254.7231, 3578.278) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (277.4887, 3631.615) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (436.4789, 3616.27) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (459.0898, 3671.36) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (333.9369, 2663.515) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (348.5488, 2644.826) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (331.9768, 2633.737) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (320.0605, 3495.165) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (347.4838, 3554.703) (added to group)
+[15:59:16] [ENEMY] [Platform_TeleporterLeft1] Ragdoll activated
+[15:59:16] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (306.7759, 3638.658) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (248.7217, 3642.871) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (325.6462, 3508.259) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (319.451, 2644.702) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (192.8503, 3632.13) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (239.4192, 3568.17) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (427.7974, 3572.909) (added to group)
+[15:59:16] [INFO] [PowerFantasy] Effect duration expired after 602.00 ms
+[15:59:16] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (376.31, 3654.796) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (427.1734, 3657.98) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (338.1665, 3540.619) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (404.7375, 3733.894) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (385.0378, 3611.073) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (318.5783, 3578.272) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (342.1624, 3654.358) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (293.2361, 3578.511) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (408.0257, 3600.441) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (368.6697, 2650.728) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (350.5272, 3586.906) (added to group)
+[15:59:16] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (364.0921, 3555.441) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (385.0351, 3520.423) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (403.9004, 3534.265) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (367.9535, 3647.755) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (349.7947, 3626.533) (added to group)
+[15:59:16] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (380.2844, 3649.094) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (335.857, 3621.413) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (398.7545, 2644.528) (added to group)
+[15:59:16] [INFO] [ReplayManager] Recording frame 720 (11,3s): player_valid=True, enemies=15
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (333.6645, 2661.73) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (394.274, 2683.789) (added to group)
+[15:59:16] [INFO] [BloodDecal] Blood puddle created at (473.531, 2678.783) (added to group)
+[15:59:17] [INFO] [ActiveItemManager.Jammer] VERBOSE: 0 jammer(s) in group, player=(1089,3143)
+[15:59:17] [INFO] [Player.Homing] Homing scanner loop started (Issue #890)
+[15:59:17] [INFO] [Player.Homing] Homing activated! Duration: 1,2s, charges remaining: 1/2
+[15:59:17] [ENEMY] [Platform_TeleporterLeft2] Death animation completed
+[15:59:17] [ENEMY] [Platform_TeleporterLeft3] Death animation completed
+[15:59:17] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (3 total)
+[15:59:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1140.042, 3165.487), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:17] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:17] [ENEMY] [Platform_TeleporterLeft1] Death animation completed
+[15:59:17] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (4 total)
+[15:59:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1183.961, 3165.681), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:17] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1210.335, 3181.559), source=NEUTRAL (null), range=900, listeners=11
+[15:59:17] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:17] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (5 total)
+[15:59:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1227.961, 3165.681), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:17] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:17] [INFO] [ReplayManager] Recording frame 780 (12,3s): player_valid=True, enemies=15
+[15:59:17] [INFO] [BloodyFeet:Player] Blood ran out - no more footprints
+[15:59:17] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (6 total)
+[15:59:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1271.961, 3165.681), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:17] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:17] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (7 total)
+[15:59:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1315.961, 3165.681), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:17] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:17] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1337.425, 3184.145), source=NEUTRAL (null), range=900, listeners=11
+[15:59:17] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:17] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (8 total)
+[15:59:17] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1359.834, 3165.989), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:17] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:17] [INFO] [WeaponHintsComponent] Auto-dismiss timer: clearing all remaining hints for ak_gl
+[15:59:17] [INFO] [WeaponHintsComponent] Dismissing hint 'reload'
+[15:59:18] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (9 total)
+[15:59:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1398.221, 3179.539), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:18] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (10 total)
+[15:59:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1433.802, 3199.864), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:18] [INFO] [Player.Homing] Homing scanner loop stopped (Issue #890)
+[15:59:18] [INFO] [Player.Homing] Homing effect expired, charges remaining: 1/2
+[15:59:18] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (11 total)
+[15:59:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1476.526, 3202.944), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1461.134, 3217.109), source=NEUTRAL (null), range=900, listeners=11
+[15:59:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:18] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (12 total)
+[15:59:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1520.526, 3202.944), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:18] [ENEMY] [Platform_TeleporterRight1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:18] [ENEMY] [Platform_TeleporterRight2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:18] [INFO] [ReplayManager] Recording frame 840 (13,3s): player_valid=True, enemies=15
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:18] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (13 total)
+[15:59:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1564.526, 3202.944), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] Hit: dmg=1, hp=2/2->1/2
+[15:59:18] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] [#910] Hit triggered COMBAT from IDLE
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] Found cover at (3278.807, 3443.338) (distance: 524.3, player at (1570.026, 3202.944))
+[15:59:18] [INFO] [Teleporter] Teleported from (3800, 3500) to (3278.807, 3443.338)
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] [#1355] Damage-triggered teleport succeeded
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:18] [ENEMY] [Platform_TeleporterRight1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:18] [INFO] [WeaponHintsComponent] Hint 'reload' dismissed
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:18] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1586.32, 3225.093), source=NEUTRAL (null), range=900, listeners=11
+[15:59:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:18] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (14 total)
+[15:59:18] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1606.326, 3202.944), source=PLAYER (AKGL), range=871, listeners=11
+[15:59:18] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=11, self=0
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] Hit: dmg=2, hp=1/2->-1/2
+[15:59:18] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:18] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:18] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:18] [INFO] [GameManager] kills_without_laser_sight: 580
+[15:59:18] [INFO] [ScoreManager] Kill registered. Combo: 5 (points: 7500)
+[15:59:18] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:18] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:18] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:18] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] [AllyDeath] Notified 2 enemies
+[15:59:18] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight3 (remaining: 10)
+[15:59:18] [INFO] [DeathAnim] Started - Angle: 52.9 deg, Index: 15
+[15:59:18] [ENEMY] [Platform_TeleporterRight3] Death animation started with hit direction: (0.603676, 0.79723)
+[15:59:18] [ENEMY] [Platform_TeleporterRight1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:19] [INFO] [PowerFantasy] Effect duration expired after 600.00 ms
+[15:59:19] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:19] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1628.693, 3216.352), source=NEUTRAL (null), range=900, listeners=10
+[15:59:19] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:19] [ENEMY] [Platform_TeleporterRight2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:19] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (15 total)
+[15:59:19] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1651.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:19] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:19] [ENEMY] [Platform_TeleporterRight2] Hit: dmg=1, hp=2/2->1/2
+[15:59:19] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:59:19] [ENEMY] [Platform_TeleporterRight2] [#910] Hit triggered COMBAT from IDLE
+[15:59:19] [ENEMY] [Platform_TeleporterRight2] Found cover at (3270.397, 3413.398) (distance: 340.8, player at (1657.478, 3202.944))
+[15:59:19] [INFO] [Teleporter] Teleported from (3600, 3500) to (3270.397, 3413.398)
+[15:59:19] [ENEMY] [Platform_TeleporterRight2] [#1355] Damage-triggered teleport succeeded
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3861.408, 3532.565) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3880.378, 3543.807) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3888.379, 3514.836) (added to group)
+[15:59:19] [INFO] [ReplayManager] Recording frame 900 (13,7s): player_valid=True, enemies=15
+[15:59:19] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (16 total)
+[15:59:19] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1695.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:19] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3890.67, 3538.322) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3313.975, 3488.33) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3880.129, 3572.385) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3306.709, 3517.465) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3312.397, 3495.679) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3905.141, 3514.784) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3874.765, 3554.464) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3919.12, 3526.401) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3320.528, 3499.234) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3289.246, 3520.962) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3302.653, 3558.222) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3362.087, 3517.633) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3341.41, 3503.518) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3914.963, 3614.755) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3351.104, 3511.884) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3316.698, 3504.703) (added to group)
+[15:59:19] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (17 total)
+[15:59:19] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1739.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:19] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3296.184, 3530.5) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3887.761, 3593.388) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3290.143, 3543.075) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3297.336, 3554.85) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3374.698, 3580.588) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3310.138, 3547.646) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3318.811, 3593.317) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3661.663, 3502.513) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3310.585, 3595.829) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3322.075, 3549.941) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3657.255, 3482.719) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3648.367, 3495.139) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3923.672, 3640.878) (added to group)
+[15:59:19] [ENEMY] [Platform_TeleporterRight3] Ragdoll activated
+[15:59:19] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3684.496, 3503.667) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3356.514, 3562.698) (added to group)
+[15:59:19] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1766.154, 3216.698), source=NEUTRAL (null), range=900, listeners=10
+[15:59:19] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:19] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (18 total)
+[15:59:19] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1783.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:19] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3393.389, 3573.905) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3399.204, 3622.407) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3670.801, 3540.561) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3928.712, 3572.366) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3710.074, 3468.824) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3676.853, 3547.111) (added to group)
+[15:59:19] [ENEMY] [Platform_TeleporterRight2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3662.606, 3555.371) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3696.209, 3507.269) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3912.268, 3590.97) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3404.85, 3586.126) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3735.715, 3581.241) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3320.418, 3659.363) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3338.935, 3589.307) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3672.158, 3502.696) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3457.804, 3625.228) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3338.049, 3652.298) (added to group)
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3672.075, 3511.156) (added to group)
+[15:59:19] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (19 total)
+[15:59:19] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1827.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:19] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:19] [INFO] [BloodDecal] Blood puddle created at (3399.75, 3697.063) (added to group)
+[15:59:20] [INFO] [BloodDecal] Blood puddle created at (3709.862, 3520.588) (added to group)
+[15:59:20] [INFO] [BloodDecal] Blood puddle created at (3343.706, 3738.299) (added to group)
+[15:59:20] [INFO] [BloodDecal] Blood puddle created at (3477.455, 3680.949) (added to group)
+[15:59:20] [INFO] [BloodDecal] Blood puddle created at (3347.553, 3780.801) (added to group)
+[15:59:20] [INFO] [BloodDecal] Blood puddle created at (3758.673, 3542.167) (added to group)
+[15:59:20] [INFO] [BloodDecal] Blood puddle created at (3732.457, 3547.421) (added to group)
+[15:59:20] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (20 total)
+[15:59:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1871.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:20] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:20] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (21 total)
+[15:59:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1915.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:20] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:20] [ENEMY] [Platform_TeleporterRight2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:20] [ENEMY] [Platform_TeleporterRight3] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:20] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1937.962, 3223.226), source=NEUTRAL (null), range=900, listeners=10
+[15:59:20] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:20] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (22 total)
+[15:59:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1959.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:20] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:20] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (23 total)
+[15:59:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2003.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:20] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:20] [INFO] [ReplayManager] Recording frame 960 (14,7s): player_valid=True, enemies=15
+[15:59:20] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (24 total)
+[15:59:20] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2047.978, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:20] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=10, self=0
+[15:59:20] [ENEMY] [Platform_TeleporterRight2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:20] [ENEMY] [Platform_TeleporterRight3] Death animation completed
+[15:59:21] [ENEMY] [Platform_TeleporterRight2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:21] [INFO] [ReplayManager] Recording frame 1020 (15,7s): player_valid=True, enemies=15
+[15:59:22] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[15:59:22] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:22] [ENEMY] [NearTracks_MachineGunnerRight] Player reloading: false -> true
+[15:59:22] [ENEMY] [FarTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:22] [ENEMY] [FarTracks_MachineGunnerRight] Player reloading: false -> true
+[15:59:22] [ENEMY] [Exit_DroneOperator1] Player reloading: false -> true
+[15:59:22] [ENEMY] [Exit_DroneOperator2] Player reloading: false -> true
+[15:59:22] [ENEMY] [Exit_DroneOperator3] Player reloading: false -> true
+[15:59:22] [ENEMY] [Exit_DroneOperator4] Player reloading: false -> true
+[15:59:22] [ENEMY] [Platform_TeleporterRight1] Player reloading: false -> true
+[15:59:22] [ENEMY] [Platform_TeleporterRight2] Player reloading: false -> true
+[15:59:22] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(2615.478, 3202.944), source=PLAYER (Player), range=900, listeners=10
+[15:59:22] [ENEMY] [Platform_TeleporterRight1] Heard player RELOAD at (2615.478, 3202.944), intensity=0.00, distance=839
+[15:59:22] [ENEMY] [Platform_TeleporterRight2] Heard player RELOAD at (2615.478, 3202.944), intensity=0.01, distance=688
+[15:59:22] [ENEMY] [Platform_TeleporterRight2] Vulnerability sound triggered pursuit - transitioning from IN_COVER to PURSUING
+[15:59:22] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=8, self=0
+[15:59:22] [INFO] [Player.Reload.Anim] LeftArm: pos=(5.9725432, 2.4631557), target=(4, 2), base=(24, 6)
+[15:59:22] [INFO] [Player.Reload.Anim] RightArm: pos=(-1.656764, 6), target=(-2, 6), base=(-2, 6)
+[15:59:22] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[15:59:22] [INFO] [ReplayManager] Recording frame 1080 (16,7s): player_valid=True, enemies=15
+[15:59:22] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[15:59:22] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:22] [ENEMY] [NearTracks_MachineGunnerRight] Player reloading: true -> false
+[15:59:22] [ENEMY] [FarTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:22] [ENEMY] [FarTracks_MachineGunnerRight] Player reloading: true -> false
+[15:59:22] [ENEMY] [Exit_DroneOperator1] Player reloading: true -> false
+[15:59:22] [ENEMY] [Exit_DroneOperator2] Player reloading: true -> false
+[15:59:22] [ENEMY] [Exit_DroneOperator3] Player reloading: true -> false
+[15:59:22] [ENEMY] [Exit_DroneOperator4] Player reloading: true -> false
+[15:59:22] [ENEMY] [Platform_TeleporterRight1] Player reloading: true -> false
+[15:59:22] [ENEMY] [Platform_TeleporterRight2] Player reloading: true -> false
+[15:59:22] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[15:59:22] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[15:59:23] [INFO] [ReplayManager] Recording frame 1140 (17,7s): player_valid=True, enemies=15
+[15:59:24] [INFO] [ScoreManager] Combo ended at 5. Max combo: 5
+[15:59:24] [INFO] [ReplayManager] Recording frame 1200 (18,7s): player_valid=True, enemies=15
+[15:59:24] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (25 total)
+[15:59:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3201.034, 3202.944), source=PLAYER (AKGL), range=871, listeners=10
+[15:59:24] [ENEMY] [NearTracks_MachineGunnerRight] Heard gunshot at (3201.034, 3202.944), intensity=0.00, distance=730
+[15:59:24] [ENEMY] [Platform_TeleporterRight1] Heard gunshot at (3201.034, 3202.944), intensity=0.02, distance=358
+[15:59:24] [ENEMY] [Platform_TeleporterRight2] Heard gunshot at (3201.034, 3202.944), intensity=0.05, distance=222
+[15:59:24] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=7, self=0
+[15:59:24] [ENEMY] [Platform_TeleporterRight2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:24] [ENEMY] [Platform_TeleporterRight2] Hit: dmg=2, hp=1/2->-1/2
+[15:59:24] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:24] [ENEMY] [Platform_TeleporterRight2] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:24] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:24] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:24] [INFO] [GameManager] kills_without_laser_sight: 581
+[15:59:24] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[15:59:24] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:24] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:24] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:24] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:24] [ENEMY] [Platform_TeleporterRight2] [AllyDeath] Notified 1 enemies
+[15:59:24] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight2 (remaining: 9)
+[15:59:24] [INFO] [DeathAnim] Started - Angle: 69.7 deg, Index: 16
+[15:59:24] [ENEMY] [Platform_TeleporterRight2] Death animation started with hit direction: (0.347227, 0.937781)
+[15:59:24] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (26 total)
+[15:59:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3237.8, 3212.441), source=PLAYER (AKGL), range=871, listeners=9
+[15:59:24] [ENEMY] [NearTracks_MachineGunnerRight] Heard gunshot at (3237.8, 3212.441), intensity=0.00, distance=713
+[15:59:24] [ENEMY] [Platform_TeleporterRight1] Heard gunshot at (3237.8, 3212.441), intensity=0.02, distance=330
+[15:59:24] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=7, self=0
+[15:59:24] [ENEMY] [Platform_TeleporterRight2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:24] [ENEMY] [Platform_TeleporterRight1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:24] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (27 total)
+[15:59:24] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3267.289, 3236.853), source=PLAYER (AKGL), range=871, listeners=9
+[15:59:24] [ENEMY] [NearTracks_MachineGunnerRight] Heard gunshot at (3267.289, 3236.853), intensity=0.00, distance=713
+[15:59:24] [ENEMY] [Platform_TeleporterRight1] Heard gunshot at (3267.289, 3236.853), intensity=0.03, distance=295
+[15:59:24] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=7, self=0
+[15:59:25] [ENEMY] [Platform_TeleporterRight2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:25] [ENEMY] [Platform_TeleporterRight1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3302.421, 3513.317) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3270.505, 3485.441) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3333.388, 3495.442) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3262.986, 3510.442) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3302.036, 3548.713) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3287.263, 3524.556) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3274.718, 3515.089) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3312.643, 3520.811) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3271.498, 3533.875) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3323.9, 3553.64) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3282.374, 3602.168) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3321.185, 3555.504) (added to group)
+[15:59:25] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (28 total)
+[15:59:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3346.822, 3278.538), source=PLAYER (AKGL), range=871, listeners=9
+[15:59:25] [ENEMY] [NearTracks_MachineGunnerRight] Heard gunshot at (3346.822, 3278.538), intensity=0.01, distance=704
+[15:59:25] [ENEMY] [Platform_TeleporterRight1] Heard gunshot at (3346.822, 3278.538), intensity=0.05, distance=228
+[15:59:25] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=7, self=0
+[15:59:25] [ENEMY] [Platform_TeleporterRight2] Ragdoll activated
+[15:59:25] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:25] [INFO] [PowerFantasy] Effect duration expired after 600.00 ms
+[15:59:25] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3309.579, 3629.969) (added to group)
+[15:59:25] [ENEMY] [Platform_TeleporterRight1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3289.025, 3635.652) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3361.093, 3611.68) (added to group)
+[15:59:25] [ENEMY] [Platform_TeleporterRight1] Hit: dmg=2, hp=1/1->-1/1
+[15:59:25] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:25] [ENEMY] [Platform_TeleporterRight1] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:25] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:25] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:25] [INFO] [GameManager] kills_without_laser_sight: 582
+[15:59:25] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[15:59:25] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:25] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:25] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:25] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:25] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight1 (remaining: 8)
+[15:59:25] [INFO] [DeathAnim] Started - Angle: 71.7 deg, Index: 16
+[15:59:25] [ENEMY] [Platform_TeleporterRight1] Death animation started with hit direction: (0.314716, 0.949186)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3331.006, 3636) (added to group)
+[15:59:25] [INFO] [ReplayManager] Recording frame 1260 (19,5s): player_valid=True, enemies=15
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3296.737, 3567.967) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3369.287, 3622.085) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3254.771, 3623.684) (added to group)
+[15:59:25] [INFO] [BloodDecal] Blood puddle created at (3289.813, 3581.903) (added to group)
+[15:59:25] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (29 total)
+[15:59:25] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3384.223, 3278.538), source=PLAYER (AKGL), range=871, listeners=8
+[15:59:25] [ENEMY] [NearTracks_MachineGunnerRight] Heard gunshot at (3384.223, 3278.538), intensity=0.01, distance=686
+[15:59:25] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=7, self=0
+[15:59:26] [INFO] [PowerFantasy] Effect duration expired after 617.00 ms
+[15:59:26] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:26] [ENEMY] [Platform_TeleporterRight1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3290.136, 3676.213) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3252.775, 3693.845) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3277.237, 3664.445) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3252.167, 3711.465) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3343.833, 3706.168) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3344.017, 3586.076) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3253.351, 3705.533) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3274.968, 3640.503) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3266.623, 3761.731) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3312.411, 3654.899) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3414.557, 3590.432) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3440.274, 3593.061) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3398.791, 3598.786) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3395.488, 3567.444) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3436.21, 3563.061) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3396.677, 3600.925) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3445.057, 3584.701) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3434.403, 3601.503) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3458.469, 3675.56) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3404.068, 3657.542) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3438.507, 3656.146) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3410.432, 3673.054) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3450.704, 3620.188) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3405.808, 3671.653) (added to group)
+[15:59:26] [ENEMY] [Platform_TeleporterRight1] Ragdoll activated
+[15:59:26] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3468.357, 3678.547) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3509.673, 3669.289) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3418.286, 3750.835) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3490.976, 3703.903) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3397.795, 3718.658) (added to group)
+[15:59:26] [INFO] [ReplayManager] Recording frame 1320 (20,0s): player_valid=True, enemies=15
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3464.92, 3746.73) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3457.205, 3675.966) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3441.605, 3681.267) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3445.601, 3704.243) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3464.307, 3734.37) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3390.21, 3693.673) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3466.267, 3755.538) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3395.123, 3797.891) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3509.174, 3721.403) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3460.197, 3795.736) (added to group)
+[15:59:26] [INFO] [BloodDecal] Blood puddle created at (3391.145, 3774.914) (added to group)
+[15:59:27] [ENEMY] [Platform_TeleporterRight2] Death animation completed
+[15:59:27] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[15:59:27] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:27] [ENEMY] [NearTracks_MachineGunnerRight] Player reloading: false -> true
+[15:59:27] [ENEMY] [FarTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:27] [ENEMY] [FarTracks_MachineGunnerRight] Player reloading: false -> true
+[15:59:27] [ENEMY] [Exit_DroneOperator1] Player reloading: false -> true
+[15:59:27] [ENEMY] [Exit_DroneOperator2] Player reloading: false -> true
+[15:59:27] [ENEMY] [Exit_DroneOperator3] Player reloading: false -> true
+[15:59:27] [ENEMY] [Exit_DroneOperator4] Player reloading: false -> true
+[15:59:27] [ENEMY] [Platform_TeleporterRight1] Player reloading: false -> true
+[15:59:27] [ENEMY] [Platform_TeleporterRight2] Player reloading: false -> true
+[15:59:27] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(3646.543, 3082.754), source=PLAYER (Player), range=900, listeners=8
+[15:59:27] [ENEMY] [NearTracks_MachineGunnerRight] Heard player RELOAD at (3646.543, 3082.754), intensity=0.01, distance=416
+[15:59:27] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=7, self=0
+[15:59:27] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[15:59:27] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[15:59:27] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:27] [ENEMY] [NearTracks_MachineGunnerRight] Player reloading: true -> false
+[15:59:27] [ENEMY] [FarTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:27] [ENEMY] [FarTracks_MachineGunnerRight] Player reloading: true -> false
+[15:59:27] [ENEMY] [Exit_DroneOperator1] Player reloading: true -> false
+[15:59:27] [ENEMY] [Exit_DroneOperator2] Player reloading: true -> false
+[15:59:27] [ENEMY] [Exit_DroneOperator3] Player reloading: true -> false
+[15:59:27] [ENEMY] [Exit_DroneOperator4] Player reloading: true -> false
+[15:59:27] [ENEMY] [Platform_TeleporterRight1] Player reloading: true -> false
+[15:59:27] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[15:59:27] [INFO] [Player.Reload.Anim] LeftArm: pos=(14.812426, 5.9054046), target=(24, 6), base=(24, 6)
+[15:59:27] [INFO] [Player.Reload.Anim] RightArm: pos=(-2.0003161, 7.4524856), target=(-2, 6), base=(-2, 6)
+[15:59:27] [INFO] [ReplayManager] Recording frame 1380 (21,0s): player_valid=True, enemies=15
+[15:59:27] [ENEMY] [Platform_TeleporterRight1] Death animation completed
+[15:59:27] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[15:59:28] [INFO] [ReplayManager] Recording frame 1440 (22,0s): player_valid=True, enemies=15
+[15:59:29] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (30 total)
+[15:59:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2670.419), source=PLAYER (AKGL), range=871, listeners=8
+[15:59:29] [ENEMY] [NearTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2670.419), intensity=0.05, distance=220
+[15:59:29] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2670.419), intensity=0.00, distance=811
+[15:59:29] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=6, self=0
+[15:59:29] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:29] [INFO] [ReplayManager] Recording frame 1500 (23,0s): player_valid=True, enemies=15
+[15:59:29] [ENEMY] [NearTracks_MachineGunnerRight] Hit: dmg=2, hp=1/1->-1/1
+[15:59:29] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:29] [ENEMY] [NearTracks_MachineGunnerRight] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:29] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:29] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:29] [INFO] [GameManager] kills_without_laser_sight: 583
+[15:59:29] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[15:59:29] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:29] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:29] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:29] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:29] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerRight (remaining: 7)
+[15:59:29] [INFO] [DeathAnim] Started - Angle: 177.0 deg, Index: 23
+[15:59:29] [ENEMY] [NearTracks_MachineGunnerRight] Death animation started with hit direction: (-0.998585, 0.053182)
+[15:59:29] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (31 total)
+[15:59:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2656.786), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:29] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2656.786), intensity=0.00, distance=798
+[15:59:29] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:29] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:29] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (32 total)
+[15:59:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:29] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:29] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:29] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:29] [INFO] [BloodDecal] Blood puddle created at (3612.456, 2707.704) (added to group)
+[15:59:29] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (33 total)
+[15:59:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:29] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:29] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:29] [INFO] [BloodDecal] Blood puddle created at (3608.819, 2665.918) (added to group)
+[15:59:29] [INFO] [BloodDecal] Blood puddle created at (3620.799, 2707.669) (added to group)
+[15:59:29] [INFO] [BloodDecal] Blood puddle created at (3634.012, 2677.698) (added to group)
+[15:59:30] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:30] [INFO] [BloodDecal] Blood puddle created at (3596.68, 2682.106) (added to group)
+[15:59:30] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (34 total)
+[15:59:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:30] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:30] [ENEMY] [NearTracks_MachineGunnerRight] Ragdoll activated
+[15:59:30] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:30] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:30] [INFO] [PowerFantasy] Effect duration expired after 601.00 ms
+[15:59:30] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:30] [INFO] [BloodDecal] Blood puddle created at (3575.679, 2708.941) (added to group)
+[15:59:30] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (35 total)
+[15:59:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:30] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:30] [INFO] [BloodDecal] Blood puddle created at (3577.041, 2702.293) (added to group)
+[15:59:30] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:30] [INFO] [BloodDecal] Blood puddle created at (3552.471, 2708.124) (added to group)
+[15:59:30] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (36 total)
+[15:59:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:30] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:30] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:30] [INFO] [ReplayManager] Recording frame 1560 (23,9s): player_valid=True, enemies=15
+[15:59:30] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (37 total)
+[15:59:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:30] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:30] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:30] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (38 total)
+[15:59:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:30] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:30] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:30] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (39 total)
+[15:59:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:30] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:30] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:30] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (40 total)
+[15:59:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:30] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:30] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:31] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (41 total)
+[15:59:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:31] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:31] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:31] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (42 total)
+[15:59:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:31] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:31] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:31] [ENEMY] [NearTracks_MachineGunnerRight] Death animation completed
+[15:59:31] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (43 total)
+[15:59:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:31] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:31] [ENEMY] [NearTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:31] [INFO] [ReplayManager] Recording frame 1620 (24,9s): player_valid=True, enemies=15
+[15:59:31] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (44 total)
+[15:59:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:31] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:31] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (45 total)
+[15:59:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:31] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:31] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (46 total)
+[15:59:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:31] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:32] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (47 total)
+[15:59:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.935, 2655.542), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:32] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:32] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:32] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[15:59:32] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:32] [ENEMY] [FarTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:32] [ENEMY] [FarTracks_MachineGunnerRight] Player reloading: false -> true
+[15:59:32] [ENEMY] [Exit_DroneOperator1] Player reloading: false -> true
+[15:59:32] [ENEMY] [Exit_DroneOperator2] Player reloading: false -> true
+[15:59:32] [ENEMY] [Exit_DroneOperator3] Player reloading: false -> true
+[15:59:32] [ENEMY] [Exit_DroneOperator4] Player reloading: false -> true
+[15:59:32] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(3919.935, 2655.542), source=PLAYER (Player), range=900, listeners=7
+[15:59:32] [ENEMY] [FarTracks_MachineGunnerRight] Heard player RELOAD at (3919.935, 2655.542), intensity=0.00, distance=797
+[15:59:32] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:32] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[15:59:32] [INFO] [ReplayManager] Recording frame 1680 (25,9s): player_valid=True, enemies=15
+[15:59:32] [INFO] [Player.Reload.Anim] LeftArm: pos=(10.585645, 5.289981), target=(12, 6), base=(24, 6)
+[15:59:32] [INFO] [Player.Reload.Anim] RightArm: pos=(-2.0000002, 7.644043), target=(-2, 8), base=(-2, 6)
+[15:59:32] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[15:59:32] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:32] [ENEMY] [FarTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:32] [ENEMY] [FarTracks_MachineGunnerRight] Player reloading: true -> false
+[15:59:32] [ENEMY] [Exit_DroneOperator1] Player reloading: true -> false
+[15:59:32] [ENEMY] [Exit_DroneOperator2] Player reloading: true -> false
+[15:59:32] [ENEMY] [Exit_DroneOperator3] Player reloading: true -> false
+[15:59:32] [ENEMY] [Exit_DroneOperator4] Player reloading: true -> false
+[15:59:32] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[15:59:32] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[15:59:32] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(3899.342, 2613.045), source=NEUTRAL (null), range=900, listeners=7
+[15:59:32] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (3899.342, 2613.045), intensity=0.00, dist=750
+[15:59:32] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:33] [INFO] [ReplayManager] Recording frame 1740 (26,9s): player_valid=True, enemies=15
+[15:59:34] [INFO] [ReplayManager] Recording frame 1800 (27,9s): player_valid=True, enemies=15
+[15:59:34] [INFO] [ScoreManager] Combo ended at 3. Max combo: 5
+[15:59:35] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (48 total)
+[15:59:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1920.708), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.925, 1920.708), intensity=0.05, distance=222
+[15:59:35] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:35] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (49 total)
+[15:59:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1920.486), source=PLAYER (AKGL), range=871, listeners=7
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3919.925, 1920.486), intensity=0.05, distance=222
+[15:59:35] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=6, self=0
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] Hit: dmg=2, hp=1/1->-1/1
+[15:59:35] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:35] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:35] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:35] [INFO] [GameManager] kills_without_laser_sight: 584
+[15:59:35] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[15:59:35] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:35] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:35] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:35] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:35] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerRight (remaining: 6)
+[15:59:35] [INFO] [DeathAnim] Started - Angle: -174.4 deg, Index: 0
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] Death animation started with hit direction: (-0.995205, -0.097808)
+[15:59:35] [INFO] [ReplayManager] Recording frame 1860 (28,9s): player_valid=True, enemies=15
+[15:59:35] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (50 total)
+[15:59:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1914.806), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:35] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:35] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(3897.526, 1900.253), source=NEUTRAL (null), range=900, listeners=6
+[15:59:35] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:35] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (51 total)
+[15:59:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1896.886), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:35] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:35] [INFO] [BloodDecal] Blood puddle created at (3639.48, 1874.392) (added to group)
+[15:59:35] [INFO] [BloodDecal] Blood puddle created at (3647.581, 1905.761) (added to group)
+[15:59:35] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (52 total)
+[15:59:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1893.26), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:35] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:35] [INFO] [BloodDecal] Blood puddle created at (3590.574, 1899.541) (added to group)
+[15:59:35] [INFO] [BloodDecal] Blood puddle created at (3610.085, 1899.499) (added to group)
+[15:59:35] [INFO] [BloodDecal] Blood puddle created at (3596.903, 1914.009) (added to group)
+[15:59:35] [INFO] [BloodDecal] Blood puddle created at (3609.4, 1857.588) (added to group)
+[15:59:35] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:36] [INFO] [BloodDecal] Blood puddle created at (3597.027, 1910.937) (added to group)
+[15:59:36] [INFO] [BloodDecal] Blood puddle created at (3604.984, 1876.939) (added to group)
+[15:59:36] [INFO] [BloodDecal] Blood puddle created at (3610.426, 1917.839) (added to group)
+[15:59:36] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (53 total)
+[15:59:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1893.26), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:36] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerRight] Ragdoll activated
+[15:59:36] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:36] [INFO] [PowerFantasy] Effect duration expired after 650.00 ms
+[15:59:36] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:36] [INFO] [BloodDecal] Blood puddle created at (3632.188, 1905.226) (added to group)
+[15:59:36] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (54 total)
+[15:59:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1893.26), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:36] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:36] [INFO] [BloodDecal] Blood puddle created at (3498.331, 1924.135) (added to group)
+[15:59:36] [INFO] [BloodDecal] Blood puddle created at (3591.646, 1907.799) (added to group)
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:36] [INFO] [BloodDecal] Blood puddle created at (3581.45, 1916.433) (added to group)
+[15:59:36] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (55 total)
+[15:59:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1893.26), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:36] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:36] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (56 total)
+[15:59:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1893.26), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:36] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:36] [INFO] [ReplayManager] Recording frame 1920 (29,8s): player_valid=True, enemies=15
+[15:59:36] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (57 total)
+[15:59:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1893.26), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:36] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:36] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (58 total)
+[15:59:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1893.26), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:36] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:36] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (59 total)
+[15:59:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1893.26), source=PLAYER (AKGL), range=871, listeners=6
+[15:59:36] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=6, self=0
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerLeft] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerLeft] Hit: dmg=2, hp=2/2->0/2
+[15:59:36] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerLeft] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:36] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:36] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:36] [INFO] [GameManager] kills_without_laser_sight: 585
+[15:59:36] [INFO] [ScoreManager] Kill registered. Combo: 2 (points: 1500)
+[15:59:36] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:36] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:36] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:36] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:36] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerLeft (remaining: 5)
+[15:59:36] [INFO] [DeathAnim] Started - Angle: -179.6 deg, Index: 0
+[15:59:36] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation started with hit direction: (-0.999977, -0.006768)
+[15:59:37] [ENEMY] [FarTracks_MachineGunnerRight] Death animation completed
+[15:59:37] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (60 total)
+[15:59:37] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1893.26), source=PLAYER (AKGL), range=871, listeners=5
+[15:59:37] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0
+[15:59:37] [ENEMY] [FarTracks_MachineGunnerRight] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:37] [INFO] [ReplayManager] Recording frame 1980 (30,2s): player_valid=True, enemies=15
+[15:59:37] [INFO] [PowerFantasy] Effect duration expired after 601.00 ms
+[15:59:37] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:37] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[15:59:37] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:37] [ENEMY] [FarTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:37] [ENEMY] [FarTracks_MachineGunnerRight] Player reloading: false -> true
+[15:59:37] [ENEMY] [Exit_DroneOperator1] Player reloading: false -> true
+[15:59:37] [ENEMY] [Exit_DroneOperator2] Player reloading: false -> true
+[15:59:37] [ENEMY] [Exit_DroneOperator3] Player reloading: false -> true
+[15:59:37] [ENEMY] [Exit_DroneOperator4] Player reloading: false -> true
+[15:59:37] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(3919.925, 1893.26), source=PLAYER (Player), range=900, listeners=5
+[15:59:37] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (240.3562, 1886.519) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (223.1918, 1927.93) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (232.0904, 1917.63) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (254.9513, 1924.247) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (254.5655, 1900.086) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (227.735, 1926.35) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (215.5693, 1900.447) (added to group)
+[15:59:37] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (199.7026, 1910.118) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (232.875, 1898.315) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (185.1812, 1909.472) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (223.2227, 1908.391) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (153.8219, 1909.875) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (209.0571, 1915.762) (added to group)
+[15:59:37] [ENEMY] [FarTracks_MachineGunnerLeft] Ragdoll activated
+[15:59:37] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (225.3159, 1916.36) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (204.6685, 1919.755) (added to group)
+[15:59:37] [INFO] [BloodDecal] Blood puddle created at (166.1221, 1886.155) (added to group)
+[15:59:38] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[15:59:38] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:38] [ENEMY] [FarTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:38] [ENEMY] [FarTracks_MachineGunnerRight] Player reloading: true -> false
+[15:59:38] [ENEMY] [Exit_DroneOperator1] Player reloading: true -> false
+[15:59:38] [ENEMY] [Exit_DroneOperator2] Player reloading: true -> false
+[15:59:38] [ENEMY] [Exit_DroneOperator3] Player reloading: true -> false
+[15:59:38] [ENEMY] [Exit_DroneOperator4] Player reloading: true -> false
+[15:59:38] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[15:59:38] [INFO] [BloodDecal] Blood puddle created at (156.7358, 1925.49) (added to group)
+[15:59:38] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[15:59:38] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(3903.992, 1857.536), source=NEUTRAL (null), range=900, listeners=5
+[15:59:38] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0
+[15:59:38] [INFO] [ReplayManager] Recording frame 2040 (31,2s): player_valid=True, enemies=15
+[15:59:38] [INFO] [ActiveItemManager.Jammer] VERBOSE: 0 jammer(s) in group, player=(3920,1721)
+[15:59:38] [INFO] [Player.Homing] Homing scanner loop started (Issue #890)
+[15:59:38] [INFO] [Player.Homing] Homing activated! Duration: 1,2s, charges remaining: 0/2
+[15:59:39] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation completed
+[15:59:39] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (61 total)
+[15:59:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1671.926), source=PLAYER (AKGL), range=871, listeners=5
+[15:59:39] [ENEMY] [Exit_DroneOperator4] Heard gunshot at (3919.925, 1671.926), intensity=0.00, distance=827
+[15:59:39] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0
+[15:59:39] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (62 total)
+[15:59:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1627.926), source=PLAYER (AKGL), range=871, listeners=5
+[15:59:39] [ENEMY] [Exit_DroneOperator4] Heard gunshot at (3919.925, 1627.926), intensity=0.00, distance=799
+[15:59:39] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0
+[15:59:39] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (63 total)
+[15:59:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1583.926), source=PLAYER (AKGL), range=871, listeners=5
+[15:59:39] [ENEMY] [Exit_DroneOperator4] Heard gunshot at (3919.925, 1583.926), intensity=0.00, distance=772
+[15:59:39] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0
+[15:59:39] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(3906.417, 1559.899), source=NEUTRAL (null), range=900, listeners=5
+[15:59:39] [ENEMY] [Exit_DroneOperator4] Heard CASING_KICK at (3906.417, 1559.899), intensity=0.00, dist=747
+[15:59:39] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0
+[15:59:39] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (64 total)
+[15:59:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1539.926), source=PLAYER (AKGL), range=871, listeners=5
+[15:59:39] [ENEMY] [Exit_DroneOperator4] Heard gunshot at (3919.925, 1539.926), intensity=0.00, distance=747
+[15:59:39] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=4, self=0
+[15:59:39] [INFO] [ReplayManager] Recording frame 2100 (32,2s): player_valid=True, enemies=15
+[15:59:39] [ENEMY] [Exit_DroneOperator3] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:39] [ENEMY] [Exit_DroneOperator3] Hit: dmg=2, hp=1/1->-1/1
+[15:59:39] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:39] [INFO] [BloodDecal] Blood puddle created at (2437.673, 1101) (added to group)
+[15:59:39] [ENEMY] [Exit_DroneOperator3] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:39] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:39] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:39] [INFO] [GameManager] kills_without_laser_sight: 586
+[15:59:39] [INFO] [ScoreManager] Kill registered. Combo: 3 (points: 3000)
+[15:59:39] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:39] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:39] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:39] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:39] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator3 (remaining: 4)
+[15:59:39] [INFO] [DeathAnim] Started - Angle: -158.9 deg, Index: 1
+[15:59:39] [ENEMY] [Exit_DroneOperator3] Death animation started with hit direction: (-0.933087, -0.359651)
+[15:59:39] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (65 total)
+[15:59:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1495.926), source=PLAYER (AKGL), range=871, listeners=4
+[15:59:39] [ENEMY] [Exit_DroneOperator4] Heard gunshot at (3919.925, 1495.926), intensity=0.00, distance=723
+[15:59:39] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=3, self=0
+[15:59:40] [ENEMY] [Exit_DroneOperator4] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:40] [INFO] [PowerFantasy] Effect duration expired after 601.00 ms
+[15:59:40] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:40] [ENEMY] [Exit_DroneOperator4] Hit: dmg=2, hp=1/1->-1/1
+[15:59:40] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:40] [INFO] [BloodDecal] Blood puddle created at (3319.823, 1101) (added to group)
+[15:59:40] [ENEMY] [Exit_DroneOperator4] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:40] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:40] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:40] [INFO] [GameManager] kills_without_laser_sight: 587
+[15:59:40] [INFO] [ScoreManager] Kill registered. Combo: 4 (points: 5000)
+[15:59:40] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:40] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:40] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:40] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:40] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator4 (remaining: 3)
+[15:59:40] [INFO] [DeathAnim] Started - Angle: -50.5 deg, Index: 8
+[15:59:40] [ENEMY] [Exit_DroneOperator4] Death animation started with hit direction: (0.636449, -0.771319)
+[15:59:40] [ENEMY] [Exit_DroneOperator4] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:40] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(3901.768, 1475.929), source=NEUTRAL (null), range=900, listeners=3
+[15:59:40] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0
+[15:59:40] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (66 total)
+[15:59:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1462.867), source=PLAYER (AKGL), range=871, listeners=3
+[15:59:40] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0
+[15:59:40] [INFO] [ReplayManager] Recording frame 2160 (32,4s): player_valid=True, enemies=15
+[15:59:40] [INFO] [PowerFantasy] Effect duration expired after 618.00 ms
+[15:59:40] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:40] [INFO] [BloodDecal] Blood puddle created at (2448.585, 1119.515) (added to group)
+[15:59:40] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (67 total)
+[15:59:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1439), source=PLAYER (AKGL), range=871, listeners=3
+[15:59:40] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0
+[15:59:40] [INFO] [BloodDecal] Blood puddle created at (2446.42, 1111.007) (added to group)
+[15:59:40] [INFO] [BloodDecal] Blood puddle created at (2451.777, 1107.588) (added to group)
+[15:59:41] [ENEMY] [Exit_DroneOperator3] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2412.324, 1149.938) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2445.804, 1156.334) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3355.568, 1114.045) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3355.997, 1114.818) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2408.753, 1160.48) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2419.49, 1161.665) (added to group)
+[15:59:41] [ENEMY] [Exit_DroneOperator3] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:41] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (68 total)
+[15:59:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=3
+[15:59:41] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2406.301, 1157.804) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2389.482, 1152.404) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2414.495, 1134.232) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3343.386, 1120.085) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2376.063, 1107.985) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3397.887, 1107.373) (added to group)
+[15:59:41] [ENEMY] [Exit_DroneOperator3] Ragdoll activated
+[15:59:41] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3375.7, 1103.377) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2400.564, 1146.361) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2384.778, 1134.849) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2416.988, 1124.78) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3402.562, 1100.974) (added to group)
+[15:59:41] [ENEMY] [Exit_DroneOperator3] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:41] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (69 total)
+[15:59:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=3
+[15:59:41] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0
+[15:59:41] [INFO] [Player.Homing] Homing scanner loop stopped (Issue #890)
+[15:59:41] [INFO] [Player.Homing] Homing effect expired, charges remaining: 0/2
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2318.041, 1203.293) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2345.263, 1102.542) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2412.985, 1169.276) (added to group)
+[15:59:41] [ENEMY] [Exit_DroneOperator4] Ragdoll activated
+[15:59:41] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2389.715, 1143.073) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3381.353, 1126.193) (added to group)
+[15:59:41] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (70 total)
+[15:59:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=3
+[15:59:41] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=3, self=0
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3399.337, 1136.843) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3477.787, 1104.451) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2301.432, 1247.089) (added to group)
+[15:59:41] [ENEMY] [Exit_DroneOperator2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2371.76, 1220.492) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (2352.118, 1148.303) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3397.421, 1144.521) (added to group)
+[15:59:41] [ENEMY] [Exit_DroneOperator2] Hit: dmg=2, hp=1/1->-1/1
+[15:59:41] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:41] [ENEMY] [Exit_DroneOperator2] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:41] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:41] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:41] [INFO] [GameManager] kills_without_laser_sight: 588
+[15:59:41] [INFO] [ScoreManager] Kill registered. Combo: 5 (points: 7500)
+[15:59:41] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:41] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:41] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:41] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:41] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator2 (remaining: 2)
+[15:59:41] [INFO] [DeathAnim] Started - Angle: -175.8 deg, Index: 0
+[15:59:41] [ENEMY] [Exit_DroneOperator2] Death animation started with hit direction: (-0.997329, -0.073038)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3387.219, 1159.95) (added to group)
+[15:59:41] [INFO] [ReplayManager] Recording frame 2220 (33,1s): player_valid=True, enemies=15
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3423.829, 1166.259) (added to group)
+[15:59:41] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (71 total)
+[15:59:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=2
+[15:59:41] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3369.83, 1154.079) (added to group)
+[15:59:41] [INFO] [BloodDecal] Blood puddle created at (3382.974, 1101.75) (added to group)
+[15:59:42] [ENEMY] [Exit_DroneOperator2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:42] [INFO] [PowerFantasy] Effect duration expired after 600.00 ms
+[15:59:42] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:42] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (72 total)
+[15:59:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=2
+[15:59:42] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1546.401, 1103.44) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1516.329, 1126.837) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1520.822, 1098.309) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1547.704, 1126.612) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1542.655, 1126.248) (added to group)
+[15:59:42] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (73 total)
+[15:59:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=2
+[15:59:42] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1543.452, 1099.513) (added to group)
+[15:59:42] [ENEMY] [Exit_DroneOperator2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1506.294, 1125.989) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1545.16, 1099.014) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1514.553, 1087.999) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1510.654, 1166.891) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1461.487, 1121.255) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1491.25, 1142.057) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1499.828, 1167.759) (added to group)
+[15:59:42] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (74 total)
+[15:59:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=2
+[15:59:42] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1488.742, 1151.877) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1450.252, 1185.37) (added to group)
+[15:59:42] [ENEMY] [Exit_DroneOperator2] Ragdoll activated
+[15:59:42] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1442.676, 1185.76) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1517.922, 1116.303) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1468.93, 1193.864) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1488.701, 1197.406) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1510.893, 1119.125) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1434.213, 1144.771) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1481.245, 1165.761) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1494.501, 1213.778) (added to group)
+[15:59:42] [INFO] [ReplayManager] Recording frame 2280 (33,6s): player_valid=True, enemies=15
+[15:59:42] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (75 total)
+[15:59:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=2
+[15:59:42] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=2, self=0
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1414.036, 1260.357) (added to group)
+[15:59:42] [ENEMY] [Exit_DroneOperator1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1454.105, 1230.026) (added to group)
+[15:59:42] [ENEMY] [Exit_DroneOperator4] Death animation completed
+[15:59:42] [ENEMY] [Exit_DroneOperator1] Hit: dmg=2, hp=1/1->-1/1
+[15:59:42] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:42] [ENEMY] [Exit_DroneOperator1] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:42] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:42] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:42] [INFO] [GameManager] kills_without_laser_sight: 589
+[15:59:42] [INFO] [ScoreManager] Kill registered. Combo: 6 (points: 10500)
+[15:59:42] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:42] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:42] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:42] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:42] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator1 (remaining: 1)
+[15:59:42] [INFO] [DeathAnim] Started - Angle: -176.4 deg, Index: 0
+[15:59:42] [ENEMY] [Exit_DroneOperator1] Death animation started with hit direction: (-0.997974, -0.063618)
+[15:59:42] [ENEMY] [Exit_DroneOperator3] Death animation completed
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1493.961, 1232.099) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1497.52, 1190.958) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1396.209, 1160.477) (added to group)
+[15:59:42] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (76 total)
+[15:59:42] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:42] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1491.195, 1195.902) (added to group)
+[15:59:42] [INFO] [BloodDecal] Blood puddle created at (1372.757, 1186.358) (added to group)
+[15:59:43] [INFO] [PowerFantasy] Effect duration expired after 601.00 ms
+[15:59:43] [INFO] [PowerFantasy] Ending power fantasy effect
+[15:59:43] [ENEMY] [Exit_DroneOperator1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:43] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (77 total)
+[15:59:43] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:43] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:43] [ENEMY] [Exit_DroneOperator1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (654.3354, 1127.562) (added to group)
+[15:59:43] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (78 total)
+[15:59:43] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:43] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (604.8637, 1113.699) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (648.6362, 1151.971) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (611.5652, 1181.017) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (601.7635, 1148.373) (added to group)
+[15:59:43] [INFO] [ReplayManager] Recording frame 2340 (34,1s): player_valid=True, enemies=15
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (614.3051, 1164.557) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (643.1306, 1167.516) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (583.28, 1173.343) (added to group)
+[15:59:43] [ENEMY] [Exit_DroneOperator1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (561.5634, 1143.754) (added to group)
+[15:59:43] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (79 total)
+[15:59:43] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.925, 1434.167), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:43] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (553.7933, 1177.281) (added to group)
+[15:59:43] [ENEMY] [Exit_DroneOperator1] Ragdoll activated
+[15:59:43] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (530.1221, 1155.499) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (611.1496, 1150.573) (added to group)
+[15:59:43] [ENEMY] [Exit_DroneOperator3] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (563.6409, 1120.107) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (595.6143, 1136.827) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (571.405, 1196.603) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (565.0081, 1231.666) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (510.2896, 1174.883) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (562.4114, 1223.881) (added to group)
+[15:59:43] [ENEMY] [Exit_DroneOperator2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:43] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (80 total)
+[15:59:43] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3919.591, 1434.167), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:43] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (571.3301, 1142.995) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (548.057, 1230.777) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (541.3751, 1151.154) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (581.8953, 1239.195) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (611.8375, 1182.841) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (524.3814, 1231.291) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (498.0669, 1245.593) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (534.8676, 1157.198) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (584.3868, 1238.256) (added to group)
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (511.9939, 1301.439) (added to group)
+[15:59:43] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(3894.731, 1415.459), source=NEUTRAL (null), range=900, listeners=1
+[15:59:43] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:43] [INFO] [BloodDecal] Blood puddle created at (562.2488, 1153.087) (added to group)
+[15:59:43] [ENEMY] [Exit_DroneOperator2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:44] [ENEMY] [Exit_DroneOperator2] Death animation completed
+[15:59:44] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[15:59:44] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:44] [ENEMY] [Exit_DroneOperator1] Player reloading: false -> true
+[15:59:44] [ENEMY] [Exit_DroneOperator2] Player reloading: false -> true
+[15:59:44] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(3836.091, 1434.167), source=PLAYER (Player), range=900, listeners=1
+[15:59:44] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:44] [ENEMY] [Exit_DroneOperator1] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:44] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[15:59:44] [ENEMY] [Exit_DroneOperator2] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:44] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[15:59:44] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:44] [ENEMY] [Exit_DroneOperator1] Player reloading: true -> false
+[15:59:44] [ENEMY] [Exit_DroneOperator2] Player reloading: true -> false
+[15:59:44] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[15:59:44] [INFO] [ReplayManager] Recording frame 2400 (35,1s): player_valid=True, enemies=15
+[15:59:44] [INFO] [Player.Reload.Anim] LeftArm: pos=(23.609253, 5.994663), target=(24, 6), base=(24, 6)
+[15:59:44] [INFO] [Player.Reload.Anim] RightArm: pos=(-2.000001, 6.0606775), target=(-2, 6), base=(-2, 6)
+[15:59:44] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[15:59:44] [ENEMY] [Exit_DroneOperator1] Death animation completed
+[15:59:45] [INFO] [ReplayManager] Recording frame 2460 (36,1s): player_valid=True, enemies=15
+[15:59:46] [INFO] [Player] AKGL grenade launcher empty - no grenade available
+[15:59:46] [INFO] [ReplayManager] Recording frame 2520 (37,1s): player_valid=True, enemies=15
+[15:59:46] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (81 total)
+[15:59:46] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2981.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:46] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:47] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2954.477, 1220.439), source=NEUTRAL (null), range=900, listeners=1
+[15:59:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:47] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (82 total)
+[15:59:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2937.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:47] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (83 total)
+[15:59:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2893.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:47] [INFO] [ReplayManager] Recording frame 2580 (38,1s): player_valid=True, enemies=15
+[15:59:47] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (84 total)
+[15:59:47] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2656.939, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:48] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (85 total)
+[15:59:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2612.939, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:48] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:48] [INFO] [ScoreManager] Combo ended at 6. Max combo: 6
+[15:59:48] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (86 total)
+[15:59:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2568.939, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:48] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:48] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2541.708, 1219.423), source=NEUTRAL (null), range=900, listeners=1
+[15:59:48] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:48] [INFO] [ReplayManager] Recording frame 2640 (39,1s): player_valid=True, enemies=15
+[15:59:48] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (87 total)
+[15:59:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2420.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:48] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:48] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[15:59:48] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2393.698, 1225.53), source=NEUTRAL (null), range=900, listeners=1
+[15:59:48] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:48] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (88 total)
+[15:59:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2376.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:48] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:48] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (89 total)
+[15:59:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2332.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:48] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:49] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (90 total)
+[15:59:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2288.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:49] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:49] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2261.094, 1229.933), source=NEUTRAL (null), range=900, listeners=1
+[15:59:49] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:49] [INFO] [ReplayManager] Recording frame 2700 (40,1s): player_valid=True, enemies=15
+[15:59:49] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (91 total)
+[15:59:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:49] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:49] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2073.381, 1221.312), source=NEUTRAL (null), range=900, listeners=1
+[15:59:49] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:49] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (92 total)
+[15:59:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2057.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:49] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:49] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (93 total)
+[15:59:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2013.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:49] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:50] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (94 total)
+[15:59:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1969.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:50] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:50] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1943.794, 1227.829), source=NEUTRAL (null), range=900, listeners=1
+[15:59:50] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:50] [INFO] [BloodyFeet:Player] Blood ran out - no more footprints
+[15:59:50] [INFO] [ReplayManager] Recording frame 2760 (41,1s): player_valid=True, enemies=15
+[15:59:50] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (95 total)
+[15:59:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1749.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:50] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:50] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (96 total)
+[15:59:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1705.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:50] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:50] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (97 total)
+[15:59:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1661.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:50] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:51] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1632.01, 1223.639), source=NEUTRAL (null), range=900, listeners=1
+[15:59:51] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:51] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (98 total)
+[15:59:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1617.439, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:51] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:51] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[15:59:51] [INFO] [ReplayManager] Recording frame 2820 (42,1s): player_valid=True, enemies=15
+[15:59:52] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (99 total)
+[15:59:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1204.939, 1240.18), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:52] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:52] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (100 total)
+[15:59:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1162.853, 1244.8), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:52] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:52] [INFO] [ReplayManager] Recording frame 2880 (43,1s): player_valid=True, enemies=15
+[15:59:52] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (101 total)
+[15:59:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1128.5, 1268.09), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:52] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:52] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (102 total)
+[15:59:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1097.388, 1299.203), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:52] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:52] [INFO] [BloodyFeet:Player] Blood ran out - no more footprints
+[15:59:53] [INFO] [ReplayManager] Recording frame 2940 (44,1s): player_valid=True, enemies=15
+[15:59:53] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[15:59:53] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: false -> true
+[15:59:53] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(828.5308, 1566.315), source=PLAYER (Player), range=900, listeners=1
+[15:59:53] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=1, self=0
+[15:59:54] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[15:59:54] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[15:59:54] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: true -> false
+[15:59:54] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[15:59:54] [INFO] [ReplayManager] Recording frame 3000 (45,1s): player_valid=True, enemies=15
+[15:59:54] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[15:59:55] [INFO] [ReplayManager] Recording frame 3060 (46,1s): player_valid=True, enemies=15
+[15:59:56] [INFO] [ReplayManager] Recording frame 3120 (47,1s): player_valid=True, enemies=15
+[15:59:57] [INFO] [ReplayManager] Recording frame 3180 (48,1s): player_valid=True, enemies=15
+[15:59:58] [INFO] [ReplayManager] Recording frame 3240 (49,1s): player_valid=True, enemies=15
+[15:59:59] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (103 total)
+[15:59:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(80.07364, 2641.61), source=PLAYER (AKGL), range=871, listeners=1
+[15:59:59] [ENEMY] [NearTracks_MachineGunnerLeft] Heard gunshot at (80.07364, 2641.61), intensity=0.05, distance=222
+[15:59:59] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=0, self=0
+[15:59:59] [ENEMY] [NearTracks_MachineGunnerLeft] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:59] [ENEMY] [NearTracks_MachineGunnerLeft] Hit: dmg=2, hp=1/2->-1/2
+[15:59:59] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[15:59:59] [ENEMY] [NearTracks_MachineGunnerLeft] Enemy died (ricochet: false, penetration: false, player_kill: true)
+[15:59:59] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:59:59] [INFO] [UnlockManager] Kill condition met — items now available to unlock in armory
+[15:59:59] [INFO] [GameManager] kills_without_laser_sight: 590
+[15:59:59] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[15:59:59] [INFO] [PowerFantasy] Enemy killed - triggering 300ms last chance effect
+[15:59:59] [INFO] [PowerFantasy] Starting power fantasy effect:
+[15:59:59] [INFO] [PowerFantasy]   - Time scale: 0.10
+[15:59:59] [INFO] [PowerFantasy]   - Duration: 600ms
+[15:59:59] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerLeft (remaining: 0)
+[15:59:59] [INFO] [DeathAnim] Started - Angle: 7.3 deg, Index: 12
+[15:59:59] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation started with hit direction: (0.991785, 0.127918)
+[15:59:59] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(102.6589, 2661.118), source=NEUTRAL (null), range=900, listeners=0
+[15:59:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[15:59:59] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (104 total)
+[15:59:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(80.07364, 2653.188), source=PLAYER (AKGL), range=871, listeners=0
+[15:59:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[15:59:59] [ENEMY] [NearTracks_MachineGunnerLeft] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:59] [INFO] [ReplayManager] Recording frame 3300 (50,1s): player_valid=True, enemies=15
+[15:59:59] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (105 total)
+[15:59:59] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(80.07364, 2653.721), source=PLAYER (AKGL), range=871, listeners=0
+[15:59:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[15:59:59] [ENEMY] [NearTracks_MachineGunnerLeft] [#1311] Player bullet entered threat sphere — suppression triggered
+[15:59:59] [INFO] [BloodDecal] Blood puddle created at (348.4499, 2671.059) (added to group)
+[15:59:59] [INFO] [BloodDecal] Blood puddle created at (383.7613, 2691.108) (added to group)
+[15:59:59] [INFO] [BloodDecal] Blood puddle created at (403.4067, 2672.362) (added to group)
+[15:59:59] [INFO] [BloodDecal] Blood puddle created at (366.6444, 2684.951) (added to group)
+[15:59:59] [INFO] [BloodDecal] Blood puddle created at (375.7502, 2708.158) (added to group)
+[15:59:59] [INFO] [BloodDecal] Blood puddle created at (415.7769, 2705.633) (added to group)
+[15:59:59] [INFO] [BloodDecal] Blood puddle created at (368.0045, 2697.377) (added to group)
+[15:59:59] [INFO] [BloodDecal] Blood puddle created at (433.3658, 2695.458) (added to group)
+[15:59:59] [INFO] [BloodDecal] Blood puddle created at (383.8976, 2688.11) (added to group)
+[15:59:59] [ENEMY] [NearTracks_MachineGunnerLeft] Ragdoll activated
+[15:59:59] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[15:59:59] [INFO] [PowerFantasy] Effect duration expired after 601.00 ms
+[15:59:59] [INFO] [PowerFantasy] Ending power fantasy effect
+[16:00:00] [INFO] [Player.Reload.Anim] Phase changed to: GrabMagazine (duration: 0,25s)
+[16:00:00] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: false -> true
+[16:00:00] [INFO] [SoundPropagation] Sound emitted: type=RELOAD, pos=(80.07364, 2570.288), source=PLAYER (Player), range=900, listeners=0
+[16:00:00] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[16:00:00] [INFO] [Player.Reload.Anim] Phase changed to: InsertMagazine (duration: 0,30s)
+[16:00:00] [INFO] [ReplayManager] Recording frame 3360 (51,0s): player_valid=True, enemies=15
+[16:00:00] [INFO] [Player.Reload.Anim] Phase changed to: PullBolt (duration: 0,35s)
+[16:00:00] [ENEMY] [NearTracks_MachineGunnerLeft] Player reloading: true -> false
+[16:00:00] [INFO] [Player.Reload.Anim] Phase changed to: ReturnIdle (duration: 0,20s)
+[16:00:00] [INFO] [Player.Reload.Anim] Animation complete, returning to normal
+[16:00:00] [INFO] [Player.Reload.Anim] LeftArm: pos=(23.713013, 5.999048), target=(24, 6), base=(24, 6)
+[16:00:00] [INFO] [Player.Reload.Anim] RightArm: pos=(-2.0000005, 6.0470386), target=(-2, 6), base=(-2, 6)
+[16:00:01] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation completed
+[16:00:01] [INFO] [ReplayManager] Recording frame 3420 (52,0s): player_valid=True, enemies=15
+[16:00:02] [INFO] [ReplayManager] Recording frame 3480 (53,0s): player_valid=True, enemies=15
+[16:00:03] [INFO] [ReplayManager] Recording frame 3540 (54,0s): player_valid=True, enemies=15
+[16:00:04] [INFO] [ScoreManager] Combo ended at 1. Max combo: 6
+[16:00:04] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[16:00:04] [INFO] [ReplayManager] Recording frame 3600 (55,0s): player_valid=True, enemies=15
+[16:00:05] [INFO] [ReplayManager] Recording frame 3660 (56,0s): player_valid=True, enemies=15
+[16:00:05] [INFO] [RailwayStationLevel] Player controls disabled (level completed)
+[16:00:05] [INFO] [ReplayManager] === REPLAY RECORDING STOPPED ===
+[16:00:05] [INFO] [ReplayManager] Total frames recorded: 3667
+[16:00:05] [INFO] [ReplayManager] Total duration: 56,07s
+[16:00:05] [INFO] [ReplayManager] Blood decals at end: 373 (baseline at frame 0: 0)
+[16:00:05] [INFO] [ReplayManager] Casings at end: 105 (baseline at frame 0: 0)
+[16:00:05] [INFO] [ReplayManager] Footprints recorded: 0
+[16:00:05] [INFO] [ReplayManager] has_replay() will return: True
+[16:00:05] [INFO] [GameManager] Level completed — damage_taken: 0
+[16:00:05] [INFO] [PersistManager] State saved to user://game_state.cfg
+[16:00:05] [INFO] [UnlockManager] No-damage level condition met — Combat Disposition now available to unlock in armory
+[16:00:05] [INFO] [GameManager] No-damage level condition met — no_damage_levels_completed: 13
+[16:00:05] [INFO] [GameManager] Rank-A level completed (already counted for this map) — levels_completed_rank_a_or_higher unchanged: 15
+[16:00:05] [INFO] [ProgressManager] No improvement for res://scenes/levels/RailwayStationLevel.tscn on Gunslinger (existing: rank=S, score=157061)
+[16:00:05] [INFO] [ScoreManager] Level completed! Final score: 55290, Rank: A
+[16:00:11] [INFO] [RailwayStationLevel] Level Select button pressed
+[16:00:16] [INFO] [RailwayStationLevel] Restart button pressed
+[16:00:16] [INFO] [GameManager] restart_scene() — starting scene reload
+[16:00:16] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:00:16] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] BloodyFeetComponent ready on NearTracks_MachineGunnerLeft
+[16:00:16] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:00:16] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[16:00:16] [INFO] [LastChance] Resetting all effects (scene change detected)
+[16:00:16] [INFO] [CinemaEffects] Scene changed to: RailwayStationLevel
+[16:00:16] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[16:00:16] [INFO] [BlackMetalEffectsManager] Scene changed to: RailwayStationLevel
+[16:00:16] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[16:00:16] [INFO] [PersistManager] State saved to user://game_state.cfg
+[16:00:16] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RailwayStationLevel.tscn
+[16:00:16] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation component initialized
+[16:00:16] [ENEMY] [NearTracks_MachineGunnerLeft] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] BloodyFeetComponent ready on NearTracks_MachineGunnerRight
+[16:00:16] [ENEMY] [NearTracks_MachineGunnerRight] Death animation component initialized
+[16:00:16] [ENEMY] [NearTracks_MachineGunnerRight] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] BloodyFeetComponent ready on FarTracks_MachineGunnerLeft
+[16:00:16] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation component initialized
+[16:00:16] [ENEMY] [FarTracks_MachineGunnerLeft] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] BloodyFeetComponent ready on FarTracks_MachineGunnerRight
+[16:00:16] [ENEMY] [FarTracks_MachineGunnerRight] Death animation component initialized
+[16:00:16] [ENEMY] [FarTracks_MachineGunnerRight] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator1] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator1] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator1] BloodyFeetComponent ready on Exit_DroneOperator1
+[16:00:16] [ENEMY] [Exit_DroneOperator1] Death animation component initialized
+[16:00:16] [INFO] [DroneOperator] VR headset visual created
+[16:00:16] [INFO] [DroneOperator] Tablet visual created
+[16:00:16] [INFO] [DroneOperator] Setup complete
+[16:00:16] [ENEMY] [Exit_DroneOperator1] Found cover at (0, 0) (distance: 1303.8, player at (2000, 3100))
+[16:00:16] [ENEMY] [Exit_DroneOperator1] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator2] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator2] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator2] BloodyFeetComponent ready on Exit_DroneOperator2
+[16:00:16] [ENEMY] [Exit_DroneOperator2] Death animation component initialized
+[16:00:16] [INFO] [DroneOperator] VR headset visual created
+[16:00:16] [INFO] [DroneOperator] Tablet visual created
+[16:00:16] [INFO] [DroneOperator] Setup complete
+[16:00:16] [ENEMY] [Exit_DroneOperator2] Found cover at (0, 0) (distance: 1941.6, player at (2000, 3100))
+[16:00:16] [ENEMY] [Exit_DroneOperator2] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator3] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator3] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator3] BloodyFeetComponent ready on Exit_DroneOperator3
+[16:00:16] [ENEMY] [Exit_DroneOperator3] Death animation component initialized
+[16:00:16] [INFO] [DroneOperator] VR headset visual created
+[16:00:16] [INFO] [DroneOperator] Tablet visual created
+[16:00:16] [INFO] [DroneOperator] Setup complete
+[16:00:16] [ENEMY] [Exit_DroneOperator3] Found cover at (0, 0) (distance: 2731.3, player at (2000, 3100))
+[16:00:16] [ENEMY] [Exit_DroneOperator3] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator4] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator4] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator4] BloodyFeetComponent ready on Exit_DroneOperator4
+[16:00:16] [ENEMY] [Exit_DroneOperator4] Death animation component initialized
+[16:00:16] [INFO] [DroneOperator] VR headset visual created
+[16:00:16] [INFO] [DroneOperator] Tablet visual created
+[16:00:16] [INFO] [DroneOperator] Setup complete
+[16:00:16] [ENEMY] [Exit_DroneOperator4] Found cover at (0, 0) (distance: 3478.5, player at (2000, 3100))
+[16:00:16] [ENEMY] [Exit_DroneOperator4] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] BloodyFeetComponent ready on Spawn_GasMaskEnemy
+[16:00:16] [ENEMY] [Spawn_GasMaskEnemy] Death animation component initialized
+[16:00:16] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[16:00:16] [ENEMY] [Spawn_GasMaskEnemy] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft1] BloodyFeetComponent ready on Platform_TeleporterLeft1
+[16:00:16] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft1
+[16:00:16] [ENEMY] [Platform_TeleporterLeft1] Death animation component initialized
+[16:00:16] [ENEMY] [Platform_TeleporterLeft1] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft2] BloodyFeetComponent ready on Platform_TeleporterLeft2
+[16:00:16] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft2
+[16:00:16] [ENEMY] [Platform_TeleporterLeft2] Death animation component initialized
+[16:00:16] [ENEMY] [Platform_TeleporterLeft2] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft3] BloodyFeetComponent ready on Platform_TeleporterLeft3
+[16:00:16] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft3
+[16:00:16] [ENEMY] [Platform_TeleporterLeft3] Death animation component initialized
+[16:00:16] [ENEMY] [Platform_TeleporterLeft3] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight1] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight1] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight1] BloodyFeetComponent ready on Platform_TeleporterRight1
+[16:00:16] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight1
+[16:00:16] [ENEMY] [Platform_TeleporterRight1] Death animation component initialized
+[16:00:16] [ENEMY] [Platform_TeleporterRight1] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight2] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight2] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight2] BloodyFeetComponent ready on Platform_TeleporterRight2
+[16:00:16] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight2
+[16:00:16] [ENEMY] [Platform_TeleporterRight2] Death animation component initialized
+[16:00:16] [ENEMY] [Platform_TeleporterRight2] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight3] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight3] Found EnemyModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight3] BloodyFeetComponent ready on Platform_TeleporterRight3
+[16:00:16] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight3
+[16:00:16] [ENEMY] [Platform_TeleporterRight3] Death animation component initialized
+[16:00:16] [ENEMY] [Platform_TeleporterRight3] [Gunslinger] Enemy glow applied
+[16:00:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:00:16] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[16:00:16] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[16:00:16] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[16:00:16] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[16:00:16] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[16:00:16] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[16:00:16] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[16:00:16] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[16:00:16] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[16:00:16] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[16:00:16] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[16:00:16] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[16:00:16] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[16:00:16] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[16:00:16] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[16:00:16] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[16:00:16] [INFO] [Player.Homing] Homing activation sound loaded
+[16:00:16] [INFO] [Player.Homing] Homing scanner loop ready (Issue #890), samples=88200
+[16:00:16] [INFO] [Player.Homing] Homing bullets equipped, charges: 2/2
+[16:00:16] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[16:00:16] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[16:00:16] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[16:00:16] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[16:00:16] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[16:00:16] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[16:00:16] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[16:00:16] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[16:00:16] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[16:00:16] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[16:00:16] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[16:00:16] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[16:00:16] [INFO] [Player.ItemVisual] Visual applied for item type: 2
+[16:00:16] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[16:00:16] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[16:00:16] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[16:00:16] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[16:00:16] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[16:00:16] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[16:00:16] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[16:00:16] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[16:00:16] [INFO] [Player.Jammer] JammerHUD initialized
+[16:00:16] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[16:00:16] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[16:00:16] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[16:00:16] [INFO] [RailwayStationLevel] Found Environment/Enemies node with 15 children
+[16:00:16] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerRight': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerRight': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator1': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator2': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator3': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator4': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Spawn_GasMaskEnemy': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft1': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft2': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft3': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight1': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight2': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight3': script=true, has_died_signal=true
+[16:00:16] [INFO] [RailwayStationLevel] Enemy tracking complete: 15 enemies registered
+[16:00:16] [INFO] [RailwayStationLevel] Setting up weapon: ak_gl
+[16:00:16] [INFO] [RailwayStationLevel] AKGL already equipped by C# Player - skipping GDScript weapon swap
+[16:00:16] [INFO] [GameManager] set_player() called with: <CharacterBody2D#608459297330> (class: CharacterBody2D)
+[16:00:16] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[16:00:16] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[16:00:16] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[16:00:16] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[16:00:16] [INFO] [ScoreManager] Level started with 15 enemies
+[16:00:16] [INFO] [RailwayStationLevel] ReplayManager found as C# autoload
+[16:00:16] [INFO] [ReplayManager] Replay data cleared
+[16:00:16] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[16:00:16] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[16:00:16] [INFO] [ReplayManager] Level: RailwayStationLevel
+[16:00:16] [INFO] [ReplayManager] Player: Player (valid: True)
+[16:00:16] [INFO] [ReplayManager] Enemies count: 15
+[16:00:16] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[16:00:16] [INFO] [ReplayManager]   Enemy 0: NearTracks_MachineGunnerLeft
+[16:00:16] [INFO] [ReplayManager]   Enemy 1: NearTracks_MachineGunnerRight
+[16:00:16] [INFO] [ReplayManager]   Enemy 2: FarTracks_MachineGunnerLeft
+[16:00:16] [INFO] [ReplayManager]   Enemy 3: FarTracks_MachineGunnerRight
+[16:00:16] [INFO] [ReplayManager]   Enemy 4: Exit_DroneOperator1
+[16:00:16] [INFO] [ReplayManager]   Enemy 5: Exit_DroneOperator2
+[16:00:16] [INFO] [ReplayManager]   Enemy 6: Exit_DroneOperator3
+[16:00:16] [INFO] [ReplayManager]   Enemy 7: Exit_DroneOperator4
+[16:00:16] [INFO] [ReplayManager]   Enemy 8: Spawn_GasMaskEnemy
+[16:00:16] [INFO] [ReplayManager]   Enemy 9: Platform_TeleporterLeft1
+[16:00:16] [INFO] [ReplayManager]   Enemy 10: Platform_TeleporterLeft2
+[16:00:16] [INFO] [ReplayManager]   Enemy 11: Platform_TeleporterLeft3
+[16:00:16] [INFO] [ReplayManager]   Enemy 12: Platform_TeleporterRight1
+[16:00:16] [INFO] [ReplayManager]   Enemy 13: Platform_TeleporterRight2
+[16:00:16] [INFO] [ReplayManager]   Enemy 14: Platform_TeleporterRight3
+[16:00:16] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[16:00:16] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[16:00:16] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 15) - skipping fallback
+[16:00:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Blood detector created and attached to NearTracks_MachineGunnerLeft
+[16:00:16] [INFO] [CinemaEffects] Found player node: Player
+[16:00:16] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[16:00:16] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerLeft (total: 1)
+[16:00:16] [ENEMY] [NearTracks_MachineGunnerLeft] Registered as sound listener
+[16:00:16] [ENEMY] [NearTracks_MachineGunnerLeft] Spawned at (300, 2670), hp: 2, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Blood detector created and attached to NearTracks_MachineGunnerRight
+[16:00:16] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerRight (total: 2)
+[16:00:16] [ENEMY] [NearTracks_MachineGunnerRight] Registered as sound listener
+[16:00:16] [ENEMY] [NearTracks_MachineGunnerRight] Spawned at (3700, 2670), hp: 2, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Blood detector created and attached to FarTracks_MachineGunnerLeft
+[16:00:16] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerLeft (total: 3)
+[16:00:16] [ENEMY] [FarTracks_MachineGunnerLeft] Registered as sound listener
+[16:00:16] [ENEMY] [FarTracks_MachineGunnerLeft] Spawned at (300, 1890), hp: 1, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Blood detector created and attached to FarTracks_MachineGunnerRight
+[16:00:16] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerRight (total: 4)
+[16:00:16] [ENEMY] [FarTracks_MachineGunnerRight] Registered as sound listener
+[16:00:16] [ENEMY] [FarTracks_MachineGunnerRight] Spawned at (3700, 1890), hp: 2, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator1] Blood detector created and attached to Exit_DroneOperator1
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator1 (total: 5)
+[16:00:16] [ENEMY] [Exit_DroneOperator1] Registered as sound listener
+[16:00:16] [ENEMY] [Exit_DroneOperator1] Spawned at (700, 1100), hp: 1, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator2] Blood detector created and attached to Exit_DroneOperator2
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator2 (total: 6)
+[16:00:16] [ENEMY] [Exit_DroneOperator2] Registered as sound listener
+[16:00:16] [ENEMY] [Exit_DroneOperator2] Spawned at (1600, 1100), hp: 2, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator3] Blood detector created and attached to Exit_DroneOperator3
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator3 (total: 7)
+[16:00:16] [ENEMY] [Exit_DroneOperator3] Registered as sound listener
+[16:00:16] [ENEMY] [Exit_DroneOperator3] Spawned at (2500, 1100), hp: 1, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Exit_DroneOperator4] Blood detector created and attached to Exit_DroneOperator4
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator4 (total: 8)
+[16:00:16] [ENEMY] [Exit_DroneOperator4] Registered as sound listener
+[16:00:16] [ENEMY] [Exit_DroneOperator4] Spawned at (3300, 1100), hp: 1, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Blood detector created and attached to Spawn_GasMaskEnemy
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Spawn_GasMaskEnemy (total: 9)
+[16:00:16] [ENEMY] [Spawn_GasMaskEnemy] Registered as sound listener
+[16:00:16] [ENEMY] [Spawn_GasMaskEnemy] Spawned at (900, 3075), hp: 2, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Blood detector created and attached to Platform_TeleporterLeft1
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft1 (total: 10)
+[16:00:16] [ENEMY] [Platform_TeleporterLeft1] Registered as sound listener
+[16:00:16] [ENEMY] [Platform_TeleporterLeft1] Spawned at (200, 3500), hp: 2, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Blood detector created and attached to Platform_TeleporterLeft2
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft2 (total: 11)
+[16:00:16] [ENEMY] [Platform_TeleporterLeft2] Registered as sound listener
+[16:00:16] [ENEMY] [Platform_TeleporterLeft2] Spawned at (400, 3500), hp: 1, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Blood detector created and attached to Platform_TeleporterLeft3
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft3 (total: 12)
+[16:00:16] [ENEMY] [Platform_TeleporterLeft3] Registered as sound listener
+[16:00:16] [ENEMY] [Platform_TeleporterLeft3] Spawned at (600, 3500), hp: 2, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight1] Blood detector created and attached to Platform_TeleporterRight1
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight1 (total: 13)
+[16:00:16] [ENEMY] [Platform_TeleporterRight1] Registered as sound listener
+[16:00:16] [ENEMY] [Platform_TeleporterRight1] Spawned at (3400, 3500), hp: 1, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight2] Blood detector created and attached to Platform_TeleporterRight2
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight2 (total: 14)
+[16:00:16] [ENEMY] [Platform_TeleporterRight2] Registered as sound listener
+[16:00:16] [ENEMY] [Platform_TeleporterRight2] Spawned at (3600, 3500), hp: 2, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Platform_TeleporterRight3] Blood detector created and attached to Platform_TeleporterRight3
+[16:00:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight3 (total: 15)
+[16:00:16] [ENEMY] [Platform_TeleporterRight3] Registered as sound listener
+[16:00:16] [ENEMY] [Platform_TeleporterRight3] Spawned at (3800, 3500), hp: 1, behavior: GUARD
+[16:00:16] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[16:00:16] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=15
+[16:00:16] [INFO] [Player] Detecting weapon pose (frame 3)...
+[16:00:16] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[16:00:16] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[16:00:16] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[16:00:16] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[16:00:16] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[16:00:16] [INFO] [LastChance] Found player: Player
+[16:00:16] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[16:00:16] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[16:00:16] [INFO] [LastChance] Connected to player Died signal (C#)
+[16:00:16] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[16:00:17] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=15
+[16:00:18] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=15
+[16:00:19] [INFO] ------------------------------------------------------------
+[16:00:19] [INFO] GAME LOG ENDED: 2026-04-10T16:00:19
+[16:00:19] [INFO] ============================================================

--- a/scripts/levels/railway_station_level.gd
+++ b/scripts/levels/railway_station_level.gd
@@ -786,7 +786,7 @@ func _show_victory_message() -> void:
 		return
 	var victory_label := Label.new()
 	victory_label.name = "VictoryLabel"
-	victory_label.text = "RAILWAY STATION CLEARED!"
+	victory_label.text = "Конец. Спасибо за игру"
 	victory_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	victory_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	victory_label.add_theme_font_size_override("font_size", 48)

--- a/scripts/levels/railway_station_level.gd
+++ b/scripts/levels/railway_station_level.gd
@@ -26,6 +26,8 @@ var _extra_exit_zones: Array = []
 var _level_cleared: bool = false
 var _score_shown: bool = false
 var _level_completed: bool = false
+var _game_end_screen_shown: bool = false
+var _pending_score_data: Dictionary = {}
 const SATURATION_DURATION: float = 0.15
 const SATURATION_INTENSITY: float = 0.25
 var _enemies: Array = []
@@ -588,7 +590,75 @@ func _complete_level_with_score() -> void:
 		var aim: Node = get_node_or_null("/root/ActiveItemManager")
 		if aim and aim.has_method("notify_level_completed"):
 			aim.notify_level_completed(score_data.get("kills", 0) > 0)
-		_show_score_screen(score_data)
+		_pending_score_data = score_data
+		_show_game_end_screen()
+	else:
+		_show_game_end_screen()
+
+
+## Shows the end-of-game screen: white text on solid black background (Issue #1755).
+## Player must click or press any key to dismiss it, then the score screen is shown.
+func _show_game_end_screen() -> void:
+	if _game_end_screen_shown:
+		return
+	_game_end_screen_shown = true
+	var canvas_layer := get_node_or_null("CanvasLayer")
+	if canvas_layer == null:
+		_proceed_to_score_screen()
+		return
+
+	var bg := ColorRect.new()
+	bg.name = "GameEndBackground"
+	bg.color = Color(0.0, 0.0, 0.0, 1.0)
+	bg.set_anchors_preset(Control.PRESET_FULL_RECT)
+	bg.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	canvas_layer.add_child(bg)
+
+	var label := Label.new()
+	label.name = "GameEndLabel"
+	label.text = "Конец. Спасибо за игру"
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	label.add_theme_font_size_override("font_size", 64)
+	label.add_theme_color_override("font_color", Color(1.0, 1.0, 1.0, 1.0))
+	label.set_anchors_preset(Control.PRESET_FULL_RECT)
+	label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	canvas_layer.add_child(label)
+
+	var hint := Label.new()
+	hint.name = "GameEndHint"
+	hint.text = "Нажмите любую клавишу или кнопку мыши..."
+	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	hint.vertical_alignment = VERTICAL_ALIGNMENT_BOTTOM
+	hint.add_theme_font_size_override("font_size", 20)
+	hint.add_theme_color_override("font_color", Color(0.6, 0.6, 0.6, 1.0))
+	hint.set_anchors_preset(Control.PRESET_FULL_RECT)
+	hint.offset_bottom = -30
+	hint.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	canvas_layer.add_child(hint)
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if not _game_end_screen_shown:
+		return
+	if event is InputEventMouseButton or event is InputEventKey:
+		if event.is_pressed():
+			_dismiss_game_end_screen()
+
+
+func _dismiss_game_end_screen() -> void:
+	var canvas_layer := get_node_or_null("CanvasLayer")
+	if canvas_layer:
+		for child_name in ["GameEndBackground", "GameEndLabel", "GameEndHint"]:
+			var node := canvas_layer.get_node_or_null(child_name)
+			if node:
+				node.queue_free()
+	_proceed_to_score_screen()
+
+
+func _proceed_to_score_screen() -> void:
+	if not _pending_score_data.is_empty():
+		_show_score_screen(_pending_score_data)
 	else:
 		_show_victory_message()
 

--- a/scripts/levels/railway_station_level.gd
+++ b/scripts/levels/railway_station_level.gd
@@ -27,6 +27,7 @@ var _level_cleared: bool = false
 var _score_shown: bool = false
 var _level_completed: bool = false
 var _game_end_screen_shown: bool = false
+var _game_end_dismissed: bool = false
 var _pending_score_data: Dictionary = {}
 const SATURATION_DURATION: float = 0.15
 const SATURATION_INTENSITY: float = 0.25
@@ -611,7 +612,12 @@ func _show_game_end_screen() -> void:
 	bg.name = "GameEndBackground"
 	bg.color = Color(0.0, 0.0, 0.0, 1.0)
 	bg.set_anchors_preset(Control.PRESET_FULL_RECT)
-	bg.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	# MOUSE_FILTER_STOP captures mouse clicks so gui_input fires (IGNORE would miss them).
+	bg.mouse_filter = Control.MOUSE_FILTER_STOP
+	bg.gui_input.connect(func(ev: InputEvent) -> void:
+		if ev is InputEventMouseButton and ev.is_pressed():
+			_dismiss_game_end_screen()
+	)
 	canvas_layer.add_child(bg)
 
 	var label := Label.new()
@@ -639,11 +645,11 @@ func _show_game_end_screen() -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	# Game-end screen: any click or key dismisses it and shows the score screen.
-	if _game_end_screen_shown:
-		if event is InputEventMouseButton or event is InputEventKey:
-			if event.is_pressed():
-				_dismiss_game_end_screen()
+	# Game-end screen: any key press dismisses it and shows the score screen.
+	# Mouse clicks are handled via gui_input on the background ColorRect.
+	if _game_end_screen_shown and not _game_end_dismissed:
+		if event is InputEventKey and event.is_pressed() and not event.echo:
+			_dismiss_game_end_screen()
 		return
 	# Score screen: W key triggers the watch-replay shortcut.
 	if _score_shown:
@@ -653,6 +659,9 @@ func _unhandled_input(event: InputEvent) -> void:
 
 
 func _dismiss_game_end_screen() -> void:
+	if _game_end_dismissed:
+		return
+	_game_end_dismissed = true
 	var canvas_layer := get_node_or_null("CanvasLayer")
 	if canvas_layer:
 		for child_name in ["GameEndBackground", "GameEndLabel", "GameEndHint"]:

--- a/scripts/levels/railway_station_level.gd
+++ b/scripts/levels/railway_station_level.gd
@@ -639,11 +639,17 @@ func _show_game_end_screen() -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	if not _game_end_screen_shown:
+	# Game-end screen: any click or key dismisses it and shows the score screen.
+	if _game_end_screen_shown:
+		if event is InputEventMouseButton or event is InputEventKey:
+			if event.is_pressed():
+				_dismiss_game_end_screen()
 		return
-	if event is InputEventMouseButton or event is InputEventKey:
-		if event.is_pressed():
-			_dismiss_game_end_screen()
+	# Score screen: W key triggers the watch-replay shortcut.
+	if _score_shown:
+		if event is InputEventKey and event.pressed and not event.echo:
+			if event.keycode == KEY_W:
+				_on_watch_replay_pressed()
 
 
 func _dismiss_game_end_screen() -> void:
@@ -1033,14 +1039,6 @@ func _get_next_level_path() -> String:
 				return level_paths[i + 1]
 			return ""
 	return ""
-
-
-func _unhandled_input(event: InputEvent) -> void:
-	if not _score_shown:
-		return
-	if event is InputEventKey and event.pressed and not event.echo:
-		if event.keycode == KEY_W:
-			_on_watch_replay_pressed()
 
 
 func _on_watch_replay_pressed() -> void:

--- a/tests/unit/test_railway_station_level.gd
+++ b/tests/unit/test_railway_station_level.gd
@@ -1,0 +1,149 @@
+extends GutTest
+## Unit tests for railway_station_level.gd — game-end screen behaviour (Issue #1755).
+##
+## The owner requested that touching the exit point shows a fullscreen black-background
+## screen with white "Конец. Спасибо за игру" text.  The player must click the mouse
+## or press any key to dismiss it; only then does the regular score screen appear.
+
+
+# ============================================================================
+# Mock Railway Station Level
+# ============================================================================
+
+
+class MockRailwayStationLevel:
+	## Mirrors the new state variables added for Issue #1755.
+	var _level_completed: bool = false
+	var _game_end_screen_shown: bool = false
+	var _pending_score_data: Dictionary = {}
+	var _level_cleared: bool = false
+
+	## Tracking flags used by the tests.
+	var game_end_screen_displayed: bool = false
+	var score_screen_displayed: bool = false
+	var victory_message_displayed: bool = false
+	var dismissed: bool = false
+
+	## Simulate completing the level (player touched exit).
+	func complete_level_with_score(score_data: Dictionary) -> void:
+		if _level_completed:
+			return
+		_level_completed = true
+		_pending_score_data = score_data
+		_show_game_end_screen()
+
+	## Show the end-of-game screen (black bg + white text).
+	func _show_game_end_screen() -> void:
+		if _game_end_screen_shown:
+			return
+		_game_end_screen_shown = true
+		game_end_screen_displayed = true
+
+	## Simulate the player pressing a key or clicking the mouse.
+	func handle_dismiss_input() -> void:
+		if not _game_end_screen_shown:
+			return
+		_dismiss_game_end_screen()
+
+	## Remove the end screen and proceed to score.
+	func _dismiss_game_end_screen() -> void:
+		dismissed = true
+		_proceed_to_score_screen()
+
+	## Show score or fallback victory message.
+	func _proceed_to_score_screen() -> void:
+		if not _pending_score_data.is_empty():
+			_show_score_screen(_pending_score_data)
+		else:
+			_show_victory_message()
+
+	func _show_score_screen(_score_data: Dictionary) -> void:
+		score_screen_displayed = true
+
+	func _show_victory_message() -> void:
+		victory_message_displayed = true
+
+
+var level: MockRailwayStationLevel
+
+
+func before_each() -> void:
+	level = MockRailwayStationLevel.new()
+
+
+func after_each() -> void:
+	level = null
+
+
+# ============================================================================
+# Game-end screen display tests
+# ============================================================================
+
+
+func test_game_end_screen_shown_when_player_reaches_exit() -> void:
+	var score_data := {"rank": "S", "total_score": 100, "kills": 0}
+	level.complete_level_with_score(score_data)
+	assert_true(level.game_end_screen_displayed,
+		"Game-end screen must be shown immediately when exit is reached")
+
+
+func test_score_screen_not_shown_immediately_after_exit() -> void:
+	var score_data := {"rank": "A", "total_score": 50, "kills": 0}
+	level.complete_level_with_score(score_data)
+	assert_false(level.score_screen_displayed,
+		"Score screen must NOT appear until the player dismisses the end screen")
+
+
+func test_score_screen_appears_after_dismiss() -> void:
+	var score_data := {"rank": "B", "total_score": 25, "kills": 0}
+	level.complete_level_with_score(score_data)
+	level.handle_dismiss_input()
+	assert_true(level.score_screen_displayed,
+		"Score screen must appear after the player dismisses the end screen")
+
+
+func test_game_end_screen_not_shown_twice() -> void:
+	var score_data := {"rank": "C", "total_score": 10, "kills": 0}
+	level.complete_level_with_score(score_data)
+	# Attempt a second trigger — should be a no-op.
+	level._show_game_end_screen()
+	# If guard works, _game_end_screen_shown stays true but display count stays 1.
+	assert_true(level._game_end_screen_shown,
+		"_game_end_screen_shown flag must stay true")
+	assert_true(level.game_end_screen_displayed,
+		"Game-end screen display should still be recorded")
+
+
+func test_complete_level_idempotent() -> void:
+	var score_data := {"rank": "S", "total_score": 200, "kills": 5}
+	level.complete_level_with_score(score_data)
+	level.complete_level_with_score(score_data)  # Second call should be ignored.
+	level.handle_dismiss_input()
+	assert_true(level.score_screen_displayed,
+		"Score screen must appear exactly once even if complete_level called twice")
+
+
+func test_pending_score_data_stored_before_dismiss() -> void:
+	var score_data := {"rank": "A+", "total_score": 999, "kills": 10}
+	level.complete_level_with_score(score_data)
+	assert_eq(level._pending_score_data, score_data,
+		"Score data must be preserved so it can be shown after dismiss")
+
+
+func test_fallback_to_victory_message_when_no_score_data() -> void:
+	# Simulate a level where ScoreManager is unavailable: no score_data stored.
+	level._game_end_screen_shown = true
+	level._dismiss_game_end_screen()
+	assert_true(level.victory_message_displayed,
+		"Victory message must be shown when no pending score data is available")
+	assert_false(level.score_screen_displayed,
+		"Score screen must NOT be shown when there is no score data")
+
+
+func test_input_before_end_screen_does_nothing() -> void:
+	# Calling dismiss before the screen is shown should be a no-op.
+	level.handle_dismiss_input()
+	assert_false(level.dismissed,
+		"Dismiss must have no effect before the end screen is shown")
+	assert_false(level.score_screen_displayed,
+		"Score screen must not appear if dismiss is called prematurely")

--- a/tests/unit/test_railway_station_level.gd
+++ b/tests/unit/test_railway_station_level.gd
@@ -15,11 +15,13 @@ class MockRailwayStationLevel:
 	## Mirrors the new state variables added for Issue #1755.
 	var _level_completed: bool = false
 	var _game_end_screen_shown: bool = false
+	var _game_end_dismissed: bool = false   # guard added to fix Bug 2 (re-appearance)
 	var _pending_score_data: Dictionary = {}
 	var _level_cleared: bool = false
 
 	## Tracking flags used by the tests.
 	var game_end_screen_displayed: bool = false
+	var score_screen_display_count: int = 0
 	var score_screen_displayed: bool = false
 	var victory_message_displayed: bool = false
 	var dismissed: bool = false
@@ -39,14 +41,21 @@ class MockRailwayStationLevel:
 		_game_end_screen_shown = true
 		game_end_screen_displayed = true
 
-	## Simulate the player pressing a key or clicking the mouse.
-	func handle_dismiss_input() -> void:
-		if not _game_end_screen_shown:
-			return
-		_dismiss_game_end_screen()
+	## Simulate the player pressing a key (keyboard path via _unhandled_input).
+	func handle_key_input() -> void:
+		if _game_end_screen_shown and not _game_end_dismissed:
+			_dismiss_game_end_screen()
+
+	## Simulate the player clicking the mouse (mouse path via gui_input on bg).
+	func handle_mouse_input() -> void:
+		if _game_end_screen_shown:
+			_dismiss_game_end_screen()
 
 	## Remove the end screen and proceed to score.
 	func _dismiss_game_end_screen() -> void:
+		if _game_end_dismissed:
+			return
+		_game_end_dismissed = true
 		dismissed = true
 		_proceed_to_score_screen()
 
@@ -58,6 +67,7 @@ class MockRailwayStationLevel:
 			_show_victory_message()
 
 	func _show_score_screen(_score_data: Dictionary) -> void:
+		score_screen_display_count += 1
 		score_screen_displayed = true
 
 	func _show_victory_message() -> void:
@@ -97,7 +107,7 @@ func test_score_screen_not_shown_immediately_after_exit() -> void:
 func test_score_screen_appears_after_dismiss() -> void:
 	var score_data := {"rank": "B", "total_score": 25, "kills": 0}
 	level.complete_level_with_score(score_data)
-	level.handle_dismiss_input()
+	level.handle_key_input()
 	assert_true(level.score_screen_displayed,
 		"Score screen must appear after the player dismisses the end screen")
 
@@ -118,7 +128,7 @@ func test_complete_level_idempotent() -> void:
 	var score_data := {"rank": "S", "total_score": 200, "kills": 5}
 	level.complete_level_with_score(score_data)
 	level.complete_level_with_score(score_data)  # Second call should be ignored.
-	level.handle_dismiss_input()
+	level.handle_key_input()
 	assert_true(level.score_screen_displayed,
 		"Score screen must appear exactly once even if complete_level called twice")
 
@@ -142,8 +152,46 @@ func test_fallback_to_victory_message_when_no_score_data() -> void:
 
 func test_input_before_end_screen_does_nothing() -> void:
 	# Calling dismiss before the screen is shown should be a no-op.
-	level.handle_dismiss_input()
+	level.handle_key_input()
 	assert_false(level.dismissed,
 		"Dismiss must have no effect before the end screen is shown")
 	assert_false(level.score_screen_displayed,
 		"Score screen must not appear if dismiss is called prematurely")
+
+
+# ============================================================================
+# Regression tests for Bug 1 and Bug 2 (Issue #1755 follow-up, 2026-04-10)
+# ============================================================================
+
+
+func test_mouse_click_dismisses_end_screen() -> void:
+	## Bug 1 regression: mouse click must dismiss the game-end screen.
+	var score_data := {"rank": "S", "total_score": 100, "kills": 0}
+	level.complete_level_with_score(score_data)
+	level.handle_mouse_input()
+	assert_true(level.dismissed,
+		"Mouse click must dismiss the game-end screen")
+	assert_true(level.score_screen_displayed,
+		"Score screen must appear after mouse-click dismiss")
+
+
+func test_score_screen_appears_only_once_after_repeated_key_presses() -> void:
+	## Bug 2 regression: repeated key presses must not re-show the score screen.
+	var score_data := {"rank": "A", "total_score": 50, "kills": 0}
+	level.complete_level_with_score(score_data)
+	level.handle_key_input()   # First press — dismisses end screen, shows score
+	level.handle_key_input()   # Second press — must be ignored
+	level.handle_key_input()   # Third press — must be ignored
+	assert_eq(level.score_screen_display_count, 1,
+		"Score screen must appear exactly once, no matter how many keys are pressed")
+
+
+func test_score_screen_appears_only_once_after_repeated_mouse_clicks() -> void:
+	## Bug 2 regression (mouse path): repeated clicks must not re-show the score screen.
+	var score_data := {"rank": "B", "total_score": 30, "kills": 0}
+	level.complete_level_with_score(score_data)
+	level.handle_mouse_input()   # First click — dismisses end screen, shows score
+	level.handle_mouse_input()   # Second click — must be ignored (gui_input lambda also
+	level.handle_mouse_input()   # Third click    checks _game_end_dismissed guard)
+	assert_eq(level.score_screen_display_count, 1,
+		"Score screen must appear exactly once even if the mouse is clicked multiple times")


### PR DESCRIPTION
## Summary

Implements the game-end screen requested in issue #1755 and fixes all reported regressions.

### Flow

1. Player touches exit zone → fullscreen **black background** + **white** "Конец. Спасибо за игру" (64 px) appears
2. Small grey hint at bottom: "Нажмите любую клавишу или кнопку мыши..."
3. Player **clicks mouse** OR **presses any key** → end screen dismissed → **score screen appears**
4. Only the first dismiss action is honoured — repeated clicks/key presses are ignored

---

### Bugs fixed in this PR

#### Round 1 — Script parse error (commit `378ad3a7`)

Cause: two `_unhandled_input` definitions in the same script → GDScript parse error → `_ready()` never ran → C# fallback placed exit zone at wrong position → camera limits unset → game-end screen unreachable.

Fix: merged both handlers into a single `_unhandled_input`.

#### Round 2 — Mouse click + re-appearance (commit `509e0bd7`)

**Bug 1 — mouse click had no effect.**
Root cause: `ColorRect` with `MOUSE_FILTER_IGNORE` does not emit `gui_input` and mouse events do not reach `_unhandled_input` on a Node2D parent in Godot 4.
Fix: `MOUSE_FILTER_STOP` + `bg.gui_input.connect(...)` to call `_dismiss_game_end_screen()` on press.

**Bug 2 — score screen re-appeared on every subsequent key press.**
Root cause: `_game_end_dismissed` flag was never set, so `_unhandled_input` kept calling `_proceed_to_score_screen()` on every key press after the initial dismiss.
Fix: added `_game_end_dismissed: bool` guard; `_dismiss_game_end_screen()` is now idempotent.

---

### Files changed

| File | Change |
|---|---|
| `scripts/levels/railway_station_level.gd` | All implementation changes |
| `tests/unit/test_railway_station_level.gd` | 8 unit tests + 3 new regression tests |
| `docs/case-studies/issue-1755/README.md` | Full root-cause analysis for both rounds |
| `docs/case-studies/issue-1755/game_log_20260410_155902.txt` | Game log artifact (second session) |

---

### How to verify

1. Build the project and load the Railway Station level.
2. Reach the exit (embankment gap at the top of the map).
3. Confirm the black screen with "Конец. Спасибо за игру" appears.
4. Click the mouse — screen should dismiss and score screen should appear (Bug 1 regression).
5. On a fresh run, press a key to dismiss the end screen, then press additional keys — score screen must NOT re-appear (Bug 2 regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes Jhon-Crow/godot-topdown-MVP#1755