### PR TITLE
fix(#1751): fix combo counter overflow and missing display on Building and Labyrinth Complex maps

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-09T23:15:59.918Z for PR creation at branch issue-1751-2a8613a717b3 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1751

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-09T23:15:59.918Z for PR creation at branch issue-1751-2a8613a717b3 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1751

--- a/Scripts/Components/LevelInitFallback.cs
+++ b/Scripts/Components/LevelInitFallback.cs
@@ -93,6 +93,11 @@ public partial class LevelInitFallback : Node
     private Label? _magazinesLabel;
 
     /// <summary>
+    /// Combo label for UI (Issue #1751: shows current combo count).
+    /// </summary>
+    private Label? _comboLabel;
+
+    /// <summary>
     /// Revolver cylinder HUD display (Issue #691).
     /// Shows 5 cylinder slots with color-coded active chamber.
     /// </summary>
@@ -527,7 +532,51 @@ public partial class LevelInitFallback : Node
         if (_player != null && scoreManager.HasMethod("set_player"))
             scoreManager.Call("set_player", _player);
 
+        // Issue #1751: Connect to combo_changed signal to update the combo label.
+        if (scoreManager.HasSignal("combo_changed") &&
+            !scoreManager.IsConnected("combo_changed", new Callable(this, MethodName.OnComboChanged)))
+        {
+            scoreManager.Connect("combo_changed", new Callable(this, MethodName.OnComboChanged));
+        }
+
         LogToFile($"ScoreManager initialized with {_initialEnemyCount} enemies");
+    }
+
+    /// <summary>
+    /// Called when the combo count changes (Issue #1751).
+    /// Updates the combo label in the HUD.
+    /// </summary>
+    private void OnComboChanged(int combo, int points)
+    {
+        if (_comboLabel == null) return;
+        if (combo > 0)
+        {
+            _comboLabel.Text = $"x{combo} COMBO (+{points})";
+            _comboLabel.Visible = true;
+            _comboLabel.AddThemeColorOverride("font_color", GetComboColor(combo));
+            _comboLabel.Modulate = Colors.White;
+            var tween = CreateTween();
+            tween.TweenProperty(_comboLabel, "modulate", Colors.White, 0.1);
+        }
+        else
+        {
+            _comboLabel.Visible = false;
+        }
+    }
+
+    /// <summary>
+    /// Returns a color based on the current combo count (Issue #1751).
+    /// Matches the color scheme used by GDScript level scripts.
+    /// </summary>
+    private static Color GetComboColor(int combo)
+    {
+        if (combo >= 10) return new Color(1.0f, 0.0f, 1.0f, 1.0f);   // Magenta - extreme
+        if (combo >= 7)  return new Color(1.0f, 0.3f, 0.0f, 1.0f);   // Deep orange
+        if (combo >= 5)  return new Color(1.0f, 0.5f, 0.0f, 1.0f);   // Orange
+        if (combo >= 4)  return new Color(1.0f, 0.7f, 0.0f, 1.0f);   // Amber
+        if (combo >= 3)  return new Color(1.0f, 0.8f, 0.0f, 1.0f);   // Yellow-orange
+        if (combo >= 2)  return new Color(1.0f, 0.9f, 0.1f, 1.0f);   // Yellow
+        return new Color(1.0f, 0.8f, 0.2f, 1.0f);                     // Gold (combo 1)
     }
 
     /// <summary>
@@ -566,6 +615,22 @@ public partial class LevelInitFallback : Node
         _magazinesLabel.OffsetRight = 400;
         _magazinesLabel.OffsetBottom = 145;
         ui.AddChild(_magazinesLabel);
+
+        // Issue #1751: Create combo label to show current combo count.
+        // Matches GDScript level scripts: top-right anchored, 340px wide, gold color.
+        _comboLabel = new Label();
+        _comboLabel.Name = "ComboLabel";
+        _comboLabel.Text = "";
+        _comboLabel.HorizontalAlignment = HorizontalAlignment.Right;
+        _comboLabel.SetAnchorsPreset(Control.LayoutPreset.TopRight);
+        _comboLabel.OffsetLeft = -350;
+        _comboLabel.OffsetRight = -10;
+        _comboLabel.OffsetTop = 80;
+        _comboLabel.OffsetBottom = 120;
+        _comboLabel.AddThemeFontSizeOverride("font_size", 28);
+        _comboLabel.AddThemeColorOverride("font_color", new Color(1.0f, 0.8f, 0.2f, 1.0f));
+        _comboLabel.Visible = false;
+        ui.AddChild(_comboLabel);
     }
 
     /// <summary>

--- a/docs/case-studies/issue-1751/README.md
+++ b/docs/case-studies/issue-1751/README.md
@@ -1,0 +1,88 @@
+# Case Study: Issue #1751 — Combo counter not visible on Building and Labyrinth Complex maps
+
+## Summary
+
+After the initial fix for issue #1751 (widening the combo label to prevent text overflow), the repo owner reported that the combo counter no longer appears at all on two maps:
+- **Здание** (Building)
+- **Лабиринт Комплекс** (Labyrinth Complex / Labyrinth2)
+
+Log file: [`game_log_20260410_030727.txt`](./game_log_20260410_030727.txt)
+
+---
+
+## Timeline / Sequence of Events
+
+1. **Original bug (issue #1751)**: Combo counter text was clipped/truncated on the right side of the screen because `offset_left = -200` gave only 190px of width — not enough for text like "x3 COMBO (+300)" at font size 28.
+
+2. **Initial fix (PR #1787, commit `8d99616f`)**: Widened `offset_left` from `-200`/`-220` to `-350` in all 15 level scripts, giving ~340px of width.
+
+3. **New regression reported**: Combo counter doesn't appear at all on Building and Labyrinth Complex maps.
+
+---
+
+## Root Cause Analysis
+
+### Root Cause 1: BuildingLevel — GDScript `_ready()` never executes
+
+Key log line:
+```
+[LevelInitFallback] GDScript _ready() did NOT execute - performing C# fallback initialization
+```
+
+`building_level.gd` `_ready()` never runs. Instead, `LevelInitFallback.cs` (a C# component) handles all level initialization as a fallback. The problem: `LevelInitFallback.cs`'s `SetupDebugUI()` creates `DifficultyLabel` and `MagazinesLabel` but **does NOT**:
+- Create a `ComboLabel` node
+- Connect to the `ScoreManager`'s `combo_changed` signal
+
+Without a combo label or signal connection, no combo counter ever appears.
+
+**File**: `Scripts/Components/LevelInitFallback.cs`, method `SetupDebugUI()` (~line 538) and `InitializeScoreManager()` (~line 519)
+
+### Root Cause 2: Labyrinth2Level — ComboLabel node doesn't exist in scene tree
+
+`labyrinth2_level.gd` at line 663 tries to find the combo label in the scene tree:
+```gdscript
+_combo_label = get_node_or_null("CanvasLayer/UI/ComboLabel")
+```
+
+But there is **no `ComboLabel` node** in `scenes/levels/Labyrinth2Level.tscn`. Unlike other level scripts that dynamically create the combo label via `Label.new()` and `ui.add_child(_combo_label)`, `labyrinth2_level.gd` expects the node to already exist in the scene — and it doesn't.
+
+**File**: `scripts/levels/labyrinth2_level.gd`, line 663  
+**Scene**: `scenes/levels/Labyrinth2Level.tscn`
+
+---
+
+## Why Only These Two Maps?
+
+- All other 13 levels (with GDScript `_ready()` that works) dynamically create the combo label via `Label.new()` + `ui.add_child()`.
+- `BuildingLevel` is special: it has a GDScript but its `_ready()` doesn't execute (engine/scene configuration issue), falling back to C# code that doesn't know about the combo label.
+- `Labyrinth2Level` is special: it tries to find the combo label in the scene tree rather than creating it dynamically, and the node was never added to the `.tscn` file.
+
+---
+
+## Fix
+
+### Fix 1: `LevelInitFallback.cs`
+In `SetupDebugUI()`, add creation of `ComboLabel` (same as in GDScript levels: `offset_left = -350`, `offset_right = -10`, `offset_top = 80`, `offset_bottom = 120`, font size 28, gold color, `visible = false`).
+
+In `InitializeScoreManager()`, connect to `combo_changed` signal and handle it with a method that updates the combo label.
+
+### Fix 2: `labyrinth2_level.gd`
+Change the combo label initialization from:
+```gdscript
+_combo_label = get_node_or_null("CanvasLayer/UI/ComboLabel")
+```
+To dynamically create and add the label (same pattern as other levels):
+```gdscript
+_combo_label = Label.new()
+_combo_label.name = "ComboLabel"
+# ... configure properties ...
+ui.add_child(_combo_label)
+```
+
+---
+
+## Additional Context
+
+The `LevelInitFallback.cs` fallback is triggered when the level's GDScript `_ready()` doesn't execute. This can happen due to script compilation issues or scene configuration. The fallback is designed to handle core level setup, but was not updated to include the combo label feature when it was added in the previous PR.
+
+The `labyrinth2_level.gd` diverges in pattern from other level scripts — most create UI elements dynamically, but this one mixes scene-tree lookup for some elements and dynamic creation for others. The combo label was added to the script but its corresponding scene node was never added to the `.tscn` file.

--- a/scripts/levels/arena_level.gd
+++ b/scripts/levels/arena_level.gd
@@ -1115,7 +1115,7 @@ func _setup_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -220
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 90
 	_combo_label.offset_bottom = 130

--- a/scripts/levels/beach_level.gd
+++ b/scripts/levels/beach_level.gd
@@ -505,7 +505,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/building_level.gd
+++ b/scripts/levels/building_level.gd
@@ -994,7 +994,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/castle_level.gd
+++ b/scripts/levels/castle_level.gd
@@ -570,7 +570,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/city_level.gd
+++ b/scripts/levels/city_level.gd
@@ -437,7 +437,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/decadence_level.gd
+++ b/scripts/levels/decadence_level.gd
@@ -493,7 +493,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/docks_level.gd
+++ b/scripts/levels/docks_level.gd
@@ -519,7 +519,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/factory_level.gd
+++ b/scripts/levels/factory_level.gd
@@ -390,7 +390,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/labyrinth2_level.gd
+++ b/scripts/levels/labyrinth2_level.gd
@@ -660,7 +660,21 @@ func _setup_debug_ui() -> void:
 		_difficulty_label.offset_bottom = 110
 		ui.add_child(_difficulty_label)
 	_magazines_label = get_node_or_null("CanvasLayer/UI/MagazinesLabel")
-	_combo_label = get_node_or_null("CanvasLayer/UI/ComboLabel")
+	# Create combo label dynamically (no ComboLabel node exists in Labyrinth2Level.tscn)
+	if ui != null:
+		_combo_label = Label.new()
+		_combo_label.name = "ComboLabel"
+		_combo_label.text = ""
+		_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+		_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
+		_combo_label.offset_left = -350
+		_combo_label.offset_right = -10
+		_combo_label.offset_top = 80
+		_combo_label.offset_bottom = 120
+		_combo_label.add_theme_font_size_override("font_size", 28)
+		_combo_label.add_theme_color_override("font_color", Color(1.0, 0.8, 0.2, 1.0))
+		_combo_label.visible = false
+		ui.add_child(_combo_label)
 	_update_debug_ui()
 
 

--- a/scripts/levels/labyrinth_level.gd
+++ b/scripts/levels/labyrinth_level.gd
@@ -1034,7 +1034,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/railway_station_level.gd
+++ b/scripts/levels/railway_station_level.gd
@@ -508,7 +508,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/revolver_level.gd
+++ b/scripts/levels/revolver_level.gd
@@ -486,7 +486,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/roguelike_level.gd
+++ b/scripts/levels/roguelike_level.gd
@@ -2130,7 +2130,7 @@ func _on_combo_changed(combo: int, points: int) -> void:
 		_combo_label.text = ""
 		_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 		_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-		_combo_label.offset_left   = -200
+		_combo_label.offset_left   = -350
 		_combo_label.offset_right  = -10
 		_combo_label.offset_top    = 80
 		_combo_label.offset_bottom = 120

--- a/scripts/levels/sewer_level.gd
+++ b/scripts/levels/sewer_level.gd
@@ -467,7 +467,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120

--- a/scripts/levels/test_tier.gd
+++ b/scripts/levels/test_tier.gd
@@ -178,7 +178,7 @@ func _on_combo_changed(combo: int, points: int) -> void:
 		_combo_label.text = ""
 		_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 		_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-		_combo_label.offset_left = -200
+		_combo_label.offset_left = -350
 		_combo_label.offset_right = -10
 		_combo_label.offset_top = 80
 		_combo_label.offset_bottom = 120

--- a/scripts/levels/winter_forest_level.gd
+++ b/scripts/levels/winter_forest_level.gd
@@ -529,7 +529,7 @@ func _setup_debug_ui() -> void:
 	_combo_label.text = ""
 	_combo_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	_combo_label.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-	_combo_label.offset_left = -200
+	_combo_label.offset_left = -350
 	_combo_label.offset_right = -10
 	_combo_label.offset_top = 80
 	_combo_label.offset_bottom = 120


### PR DESCRIPTION
## Problem

The combo counter label in the HUD had two issues:

**Issue 1 (original):** Text like \"x3 COMBO (+300)\" was clipped at the right edge of the screen. All 15 level scripts created the combo label with only ~190px width — too narrow for the text at font size 28.

**Issue 2 (regression):** After the overflow fix, the combo counter stopped appearing entirely on two maps:
- **Здание (Building)**
- **Лабиринт Комплекс (Labyrinth2)**

## Root Causes

### Building Level — GDScript _ready() never executes
The game log revealed:
```
[LevelInitFallback] GDScript _ready() did NOT execute - performing C# fallback initialization
```
The C# `LevelInitFallback` handles all initialization for BuildingLevel, but its `SetupDebugUI()` never created a `ComboLabel` or connected to `ScoreManager`'s `combo_changed` signal.

### Labyrinth2 Level — ComboLabel node not in scene tree
`labyrinth2_level.gd` tried to find the combo label via:
```gdscript
_combo_label = get_node_or_null("CanvasLayer/UI/ComboLabel")
```
But no `ComboLabel` node exists in `Labyrinth2Level.tscn`, so `_combo_label` was always `null`.

## Fix

**overflow fix (all 15 levels):** Widened `offset_left` from `-200`/`-220` to `-350`, giving ~340px — enough for any combo text including large point values.

**BuildingLevel (`LevelInitFallback.cs`):** Added `ComboLabel` creation in `SetupDebugUI()` and `combo_changed` signal connection in `InitializeScoreManager()`, with matching color logic.

**Labyrinth2Level (`labyrinth2_level.gd`):** Changed from `get_node_or_null(...)` to dynamically create the label with `Label.new()` + `ui.add_child()`, matching the pattern used by all other level scripts.

## Case Study

Full root cause analysis is documented in [`docs/case-studies/issue-1751/`](docs/case-studies/issue-1751/README.md) with the game log attached by the reporter.

## How to Reproduce

1. Start Building or Labyrinth Complex map
2. Kill 3+ enemies quickly
3. Before fix: no \"x3 COMBO (+NNN)\" text appears at all
4. After fix: combo text appears correctly in the top-right corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes Jhon-Crow/godot-topdown-MVP#1751