### PR TITLE
fix: reduce spacing and improve grade display in level cards

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-09T23:40:31.594Z for PR creation at branch issue-1783-dc3698301973 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1783

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-09T23:40:31.594Z for PR creation at branch issue-1783-dc3698301973 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1783

--- a/scripts/ui/levels_menu.gd
+++ b/scripts/ui/levels_menu.gd
@@ -523,6 +523,7 @@ func _create_level_card(level_data: Dictionary, is_current: bool, unlocked: bool
 		var difficulty_label := Label.new()
 		difficulty_label.text = difficulty_name + ":"
 		difficulty_label.add_theme_font_size_override("font_size", 9)
+		difficulty_label.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 		if not unlocked:
 			difficulty_label.add_theme_color_override("font_color", Color(0.3, 0.3, 0.35, 0.6))
 		else:
@@ -536,7 +537,8 @@ func _create_level_card(level_data: Dictionary, is_current: bool, unlocked: bool
 
 		var grade_label := Label.new()
 		grade_label.text = best_rank if not best_rank.is_empty() else "—"
-		grade_label.add_theme_font_size_override("font_size", 9)
+		grade_label.add_theme_font_size_override("font_size", 14)
+		grade_label.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 		if grade_font:
 			grade_label.add_theme_font_override("font", grade_font)
 		if not unlocked:

--- a/scripts/ui/levels_menu.gd
+++ b/scripts/ui/levels_menu.gd
@@ -505,7 +505,7 @@ func _create_level_card(level_data: Dictionary, is_current: bool, unlocked: bool
 	var progress_manager: Node = get_node_or_null("/root/ProgressManager")
 	var progress_vbox := VBoxContainer.new()
 	progress_vbox.layout_mode = 2
-	progress_vbox.add_theme_constant_override("separation", 1)
+	progress_vbox.add_theme_constant_override("separation", 0)
 	vbox.add_child(progress_vbox)
 
 	# Load custom font for grade display
@@ -534,7 +534,7 @@ func _create_level_card(level_data: Dictionary, is_current: bool, unlocked: bool
 
 		var grade_label := Label.new()
 		grade_label.text = best_rank if not best_rank.is_empty() else "—"
-		grade_label.add_theme_font_size_override("font_size", 14)
+		grade_label.add_theme_font_size_override("font_size", 9)
 		if grade_font:
 			grade_label.add_theme_font_override("font", grade_font)
 		if not unlocked:

--- a/scripts/ui/levels_menu.gd
+++ b/scripts/ui/levels_menu.gd
@@ -400,6 +400,7 @@ func _create_level_card(level_data: Dictionary, is_current: bool, unlocked: bool
 	card_style.corner_radius_top_right = 6
 	card_style.corner_radius_bottom_left = 6
 	card_style.corner_radius_bottom_right = 6
+	card_style.content_margin_bottom = 8.0
 	card.add_theme_stylebox_override("panel", card_style)
 
 	# Card content
@@ -498,6 +499,7 @@ func _create_level_card(level_data: Dictionary, is_current: bool, unlocked: bool
 		desc_label.add_theme_color_override("font_color", Color(0.6, 0.65, 0.7, 1.0))
 	desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD
 	desc_label.custom_minimum_size.x = CARD_WIDTH - 20
+	desc_label.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	vbox.add_child(desc_label)
 
 	# Progress results for all difficulties (shown as letter grades)


### PR DESCRIPTION
## Problem

The difficulty rows (Easy, Normal, Hard, Power Fantasy, Black Metal, Gunslinger) in level cards had several issues:
1. Very large visual gaps between rows when all 6 grades are shown
2. The difficulty section appeared at inconsistent vertical positions across cards
3. Grade labels were too small to read clearly
4. Row content was not vertically centered when label heights differed

## Fix

All changes in \`scripts/ui/levels_menu.gd\`:

- Reduced \`grade_label\` font size from **14px → 9px** initially, then re-increased to **14px** based on feedback (grades were too small at 9px)
- Set \`progress_vbox\` separation from **1px → 0px** to remove extra gap between rows
- Set \`desc_label.size_flags_vertical = SIZE_EXPAND_FILL\` so the description fills available space, pinning the difficulty section to the bottom of each card consistently
- Added \`content_margin_bottom = 8px\` to the card StyleBox so the last difficulty row always has a comfortable gap from the card's bottom edge
- Added \`size_flags_vertical = SIZE_SHRINK_CENTER\` to both \`difficulty_label\` and \`grade_label\` so row content is **vertically centered** when the grade font (14px) is taller than the difficulty name (9px)

## Result

- Grade letters (S, A+, A, B, C, D, F) are prominently displayed at 14px — clearly readable
- Difficulty name labels at 9px are vertically centered relative to the taller grade letters
- Compact, readable difficulty rows regardless of which grades are filled
- The difficulty section is always positioned at the bottom of the card with consistent 8px margin
- No more layout drift between cards with different description lengths

Closes #1783