### PR TITLE
fix(#1754): don't restore M16 laser after trajectory glasses in Gunslinger mode

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T18:08:12.722Z for PR creation at branch issue-1754-076e960a3abb for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1754

--- a/scripts/effects/trajectory_glasses_effect.gd
+++ b/scripts/effects/trajectory_glasses_effect.gd
@@ -608,21 +608,39 @@ func _restore_weapon_lasers() -> void:
 	if _weapon == null:
 		return
 
+	# Determine whether the built-in laser should be re-enabled.
+	# In Gunslinger mode the laser is disabled unless the Laser Sight active item is equipped.
+	# Restoring it unconditionally would introduce the bug reported in Issue #1754.
+	var should_enable_laser: bool = true
+	var difficulty_manager: Node = get_node_or_null("/root/DifficultyManager")
+	if difficulty_manager and difficulty_manager.has_method("should_disable_laser_sight"):
+		if difficulty_manager.should_disable_laser_sight():
+			# Laser is disabled in this difficulty — check whether the Laser Sight item overrides it.
+			var active_item_manager: Node = get_node_or_null("/root/ActiveItemManager")
+			var has_laser_item: bool = (
+				active_item_manager != null
+				and active_item_manager.has_method("should_force_laser_sight")
+				and active_item_manager.call("should_force_laser_sight")
+			)
+			should_enable_laser = has_laser_item
+			FileLogger.info("[TrajectoryGlasses] _restore_weapon_lasers: Gunslinger mode — laser_item=%s, should_enable=%s" % [
+				str(has_laser_item), str(should_enable_laser)
+			])
+
 	# Re-enable laser sight on C# weapons
 	if _weapon.has_method("SetLaserSightEnabled"):
-		_weapon.call("SetLaserSightEnabled", true)
-		FileLogger.info("[TrajectoryGlasses] Restored weapon laser sight")
+		_weapon.call("SetLaserSightEnabled", should_enable_laser)
+		FileLogger.info("[TrajectoryGlasses] Restored weapon laser sight (enabled=%s)" % str(should_enable_laser))
 	elif _weapon.has_method("set_laser_sight_enabled"):
-		_weapon.call("set_laser_sight_enabled", true)
-		FileLogger.info("[TrajectoryGlasses] Restored weapon laser sight (GDScript)")
+		_weapon.call("set_laser_sight_enabled", should_enable_laser)
+		FileLogger.info("[TrajectoryGlasses] Restored weapon laser sight GDScript (enabled=%s)" % str(should_enable_laser))
 
 	# Restore any Line2D children named "LaserSight"
 	var laser := _weapon.get_node_or_null("LaserSight")
 	if laser and laser is Line2D:
-		laser.visible = true
+		laser.visible = should_enable_laser
 
 	# Restore Power Fantasy laser if applicable
-	var difficulty_manager: Node = get_node_or_null("/root/DifficultyManager")
 	if difficulty_manager and difficulty_manager.has_method("should_force_blue_laser_sight"):
 		if difficulty_manager.should_force_blue_laser_sight():
 			var pf_laser := _weapon.get_node_or_null("PowerFantasyLaser")


### PR DESCRIPTION
## Problem

On Gunslinger (Стрелок) difficulty, weapon laser sights are intentionally disabled. However, after using the **Trajectory Glasses** active item and waiting for the effect to expire, the M16's laser sight reappeared — even though it should stay hidden in Gunslinger mode.

## Root Cause

`_restore_weapon_lasers()` in `trajectory_glasses_effect.gd` was calling `SetLaserSightEnabled(true)` unconditionally when the effect ended, overriding the Gunslinger-mode laser-disable that was applied during weapon `_Ready()`.

## Fix

Before restoring the laser, the function now checks `DifficultyManager.should_disable_laser_sight()`. If the current difficulty disables lasers, the laser is only re-enabled when the **Laser Sight** active item is equipped (which is the only legitimate override for Gunslinger mode, per Issue #947 / Issue #1727).

The same guard is applied to both the C# `SetLaserSightEnabled` call and the fallback `Line2D.visible` assignment.

## How to reproduce

1. Select Gunslinger (Стрелок) difficulty.
2. Equip an M16 (or any weapon with a built-in laser sight).
3. Confirm the laser is not visible (expected in Gunslinger mode).
4. Use the **Trajectory Glasses** active item and wait for the 10-second effect to end.
5. **Before fix**: M16 laser reappears. **After fix**: M16 laser stays hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes Jhon-Crow/godot-topdown-MVP#1754