### PR TITLE
fix(#1805): allow grenadier to shoot rifle during COMBAT state

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T23:33:55.123Z for PR creation at branch issue-1805-df6d19c3568b for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1805

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-10T23:33:55.123Z for PR creation at branch issue-1805-df6d19c3568b for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1805

--- a/docs/case-studies/issue-1805/case-study.md
+++ b/docs/case-studies/issue-1805/case-study.md
@@ -1,0 +1,203 @@
+# Case Study: Issue #1805 — Гренадер не стреляет на карте Канализация
+
+## Overview
+
+**Issue:** Grenadier (гренадер) enemy on the Канализация (Sewer) map does not shoot.  
+**Reporter:** Jhon-Crow  
+**Severity:** Bug — Grenadier is non-functional as an armed combatant on Sewer level.  
+**Related Issues:** #604 (Grenadier introduction), #657 (T8/T9 triggers added), #363, #959, #1305.
+
+---
+
+## Screenshot from Issue
+
+The issue screenshot shows the Grenadier enemy (wearing the grenadier vest) on the Sewer map. The enemy patrols and throws grenades, but never fires its rifle.
+
+---
+
+## Data Collected
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `scripts/objects/enemy.gd` | Main enemy AI (4991 lines) |
+| `scripts/components/grenadier_grenade_component.gd` | Grenadier-specific grenade behavior (506 lines) |
+| `scripts/components/enemy_grenade_component.gd` | Base grenade component |
+| `scenes/levels/SewerLevel.tscn` | Sewer level scene (TopRoomGrenadier instance) |
+| `scripts/levels/sewer_level.gd` | Sewer level script |
+
+### Grenadier Scene Configuration (SewerLevel.tscn, lines 1667–1674)
+
+```
+[node name="TopRoomGrenadier" parent="Environment/Enemies" instance=ExtResource("4_enemy")]
+position = Vector2(400, 280)
+behavior_mode = 0         # PATROL
+patrol_offsets = Array[Vector2]([Vector2(100, 0), Vector2(-100, 0)])
+is_grenadier = true
+destroy_on_death = true
+enable_flanking = true
+enable_cover = true
+```
+
+Notable: No explicit `weapon_type` — defaults to `WeaponType.RIFLE` (0). No explicit `grenade_count` — uses `GrenadierGrenadeComponent` bag of 8 grenades.
+
+---
+
+## Timeline / Sequence of Events Reconstruction
+
+### Issue #604 — Grenadier introduced
+
+- Added `is_grenadier` boolean export to `enemy.gd`.
+- When `is_grenadier = true`, a `GrenadierGrenadeComponent` is used instead of `EnemyGrenadeComponent`.
+- `GrenadierGrenadeComponent` manages a bag of 8 grenades (3 flashbangs + 5 offensive on normal; 1 defensive + 7 offensive on hard).
+- Added `try_passage_throw()`: grenadier proactively throws grenades into passages before entering them (during PURSUING state).
+- Allies wait for grenadier's grenade to explode before advancing.
+- Grenadier was placed in SewerLevel.tscn as `TopRoomGrenadier`.
+
+### Issue #657 — Triggers T8 and T9 added to GrenadierGrenadeComponent
+
+- **T8 (Direct Sight)**: After 0.5s of seeing the player at a safe throwing distance, `is_ready()` returns `true`.
+- **T9 (Low Suspicion)**: After 1.0s of any suspicion (memory target) while player is hidden, `is_ready()` returns `true`.
+- Both triggers were added to make the grenadier more proactively throw grenades during encounters.
+
+### The Bug Manifests
+
+The grenade throw priority check in `enemy.gd` at line 1322:
+
+```gdscript
+# GRENADE THROW PRIORITY (Issue #363, #959, #1305)
+if _combat_allowed and _goap_world_state.get("ready_to_throw_grenade", false) and not (_pacifist and _pacifist.is_pacifist):
+    if try_throw_grenade():
+        return  # ← EARLY RETURN prevents state machine from executing!
+```
+
+This check is at the **TOP of `_process_ai_state()`**, before the state machine `match` block:
+
+```gdscript
+match _current_state:
+    AIState.IDLE: _process_idle_state(delta)
+    AIState.COMBAT: _process_combat_state(delta)  # ← This never runs!
+    ...
+```
+
+**The problem flow:**
+
+1. Grenadier detects player → transitions to COMBAT state.
+2. On the **very next physics frame** where the grenadier has line-of-sight and is at safe distance, the T8 timer starts accumulating.
+3. After just **0.5 seconds**, T8 fires: `is_ready()` returns `true` → `ready_to_throw_grenade = true`.
+4. Line 1322 fires: `try_throw_grenade()` is called → grenade thrown → **returns early**.
+5. `_process_combat_state()` is **never reached** in this frame.
+6. While `_is_throwing = true` (grenade animation), state machine is interrupted each frame.
+7. After throw completes, a **15-second cooldown** (`throw_cooldown`) begins.
+8. During cooldown: `ready_to_throw_grenade = false`, so COMBAT state can now process... BUT:
+9. Within 1 second of any suspicion/memory, **T9 fires**: `is_ready()` returns `true` again.
+10. Another grenade is thrown → another 15-second wait.
+11. Cycle repeats indefinitely. The grenadier **never shoots its rifle**.
+
+---
+
+## Root Cause Analysis
+
+### Primary Root Cause
+
+**The grenade throw intercept at line 1322 of `enemy.gd` fires before `_process_combat_state()` can execute the shooting phase.**
+
+The `GrenadierGrenadeComponent.is_ready()` method (which overrides the base component) includes:
+- **T8**: Returns `true` after 0.5s of direct sight at throwable distance
+- **T9**: Returns `true` after 1.0s of any suspicion
+
+Both T8 and T9 were added in Issue #657 to make the grenadier "more aggressive" with grenades. However, because these triggers fire so quickly (0.5s and 1.0s), and because the grenade throw check is at the TOP of `_process_ai_state()` with an early `return`, the COMBAT state's shooting phase (`_process_combat_state()`) is never executed during the combat encounter.
+
+### Contributing Factor
+
+The COMBAT state's "exposed" shooting phase requires:
+1. The grenadier to be in COMBAT state
+2. `_combat_exposed = true` (set after approach phase completes — needs 2 seconds OR 250px proximity)
+3. A clear shot exists
+
+But because the grenade throw intercept fires after only 0.5s (T8), the COMBAT state never gets the 2 seconds needed to complete the approach phase and enter the shooting phase.
+
+### Why Only Sewer?
+
+Other levels may not have this issue because:
+1. Grenadiers in other levels might have different combat encounter distances (if player is too close, T8 doesn't fire — safety distance check)
+2. On Hard difficulty, the grenade count pattern differs
+3. The Sewer map's TopRoom is a specific layout where the engagement distance keeps the grenadier perpetually in T8's "safe throw range"
+
+---
+
+## Possible Solutions
+
+### Solution A (Implemented): Skip grenade throw intercept during COMBAT state for grenadiers
+
+**Rationale**: When a grenadier is in COMBAT state, it should be focused on shooting. Grenade throwing should happen during PURSUING (passage throws) or as an interruption only in non-COMBAT states.
+
+**Change** (enemy.gd, line 1322):
+```gdscript
+# Before fix:
+if _combat_allowed and _goap_world_state.get("ready_to_throw_grenade", false) and not (_pacifist and _pacifist.is_pacifist):
+
+# After fix:
+# Issue #1805: Grenadiers in COMBAT state should shoot their rifle, not only throw grenades.
+# Grenade throws are still available during PURSUING (passage throws), IDLE, and other states.
+if _combat_allowed and _goap_world_state.get("ready_to_throw_grenade", false) and not (_pacifist and _pacifist.is_pacifist) and not (is_grenadier and _current_state == AIState.COMBAT):
+```
+
+**Pros:**
+- Minimal change, surgical fix
+- Grenadiers still throw passage grenades during PURSUING
+- Grenadiers still throw grenades in IDLE/FLANKING/SEEKING_COVER states
+- Grenadiers can now shoot their rifle during COMBAT state
+
+**Cons:**
+- Grenadiers no longer throw grenades mid-combat (this is arguably correct behavior — grenadiers should clear paths, then engage with rifles)
+
+### Solution B: Increase T8/T9 delays significantly
+
+Increase `DIRECT_SIGHT_DELAY` from 0.5s to 3.0s and `LOW_SUSPICION_DELAY` from 1.0s to 5.0s.
+
+**Cons:** Doesn't fully fix the issue (same problem, just delayed). Makes grenadier less reactive.
+
+### Solution C: Move grenade throw check AFTER state machine processing
+
+Put grenade throw logic inside each state's processing function instead of at the top of `_process_ai_state()`.
+
+**Cons:** Much larger refactor, risk of regression.
+
+---
+
+## Online Research Notes
+
+- The pattern of grenade-first, shoot-later is a common AI design issue in tactical games. Games like Rainbow Six Siege use "utility first" AI design where grenades/gadgets have high priority, which is intentional.
+- In this case, the grenadier's grenade priority was designed to make it tactically interesting, but the implementation makes it **exclusively** a grenade-thrower.
+- The Godot engine's physics-based AI (using `_physics_process`) processes frame-by-frame, and the early `return` pattern means state machines can be completely bypassed by higher-priority checks.
+- GDScript's `match` statement only runs if execution reaches it — any `return` before it bypasses the entire state machine.
+
+---
+
+## Fix Implementation
+
+See: [`scripts/objects/enemy.gd`](../../../../scripts/objects/enemy.gd) line 1322.
+
+The fix adds `and not (is_grenadier and _current_state == AIState.COMBAT)` to the grenade throw intercept condition.
+
+This allows:
+1. ✅ Grenadier shoots rifle during COMBAT state
+2. ✅ Grenadier still throws passage grenades during PURSUING state
+3. ✅ Grenadier can still throw grenades in other states (IDLE, FLANKING, etc.)
+4. ✅ Regular enemies (non-grenadier) are unaffected
+
+---
+
+## Verification
+
+To verify the fix works:
+1. Open Sewer level
+2. Trigger the grenadier (TopRoomGrenadier at Vector2(400, 280)) by approaching from below
+3. Observe that after engaging, the grenadier both throws grenades AND fires its rifle
+4. Confirm the grenadier enters COMBAT state and executes shooting phase
+
+---
+
+*Case study compiled by AI issue solver for Jhon-Crow/godot-topdown-MVP#1805*

--- a/scripts/objects/enemy.gd
+++ b/scripts/objects/enemy.gd
@@ -1319,7 +1319,9 @@ func _process_ai_state(delta: float) -> void:
 		if _has_valid_cover and _teleport_component.try_teleport(_cover_position): _transition_to_in_cover(); return
 	if _teleport_component and _teleport_component.is_ready() and not _can_see_player and _current_state == AIState.FLANKING: _teleport_component.try_teleport(_flank_target)  # #752: flank-teleport
 	# GRENADE THROW PRIORITY (Issue #363, #959, #1305): Non-pacifists check grenade triggers; respect combat toggle.
-	if _combat_allowed and _goap_world_state.get("ready_to_throw_grenade", false) and not (_pacifist and _pacifist.is_pacifist):
+	# Issue #1805: Grenadiers in COMBAT state should shoot their rifle, not only throw grenades.
+	# Grenade throws still happen during PURSUING (passage throws) and other non-COMBAT states.
+	if _combat_allowed and _goap_world_state.get("ready_to_throw_grenade", false) and not (_pacifist and _pacifist.is_pacifist) and not (is_grenadier and _current_state == AIState.COMBAT):
 		if try_throw_grenade():
 			return
 

--- a/tests/unit/test_grenadier_combat_shooting_1805.gd
+++ b/tests/unit/test_grenadier_combat_shooting_1805.gd
@@ -1,0 +1,265 @@
+extends GutTest
+## Unit tests for Issue #1805 fix: Grenadier should shoot its rifle during COMBAT state.
+##
+## The bug: The grenade throw priority check in _process_ai_state fires BEFORE the
+## state machine processes COMBAT state, causing grenadiers to always throw grenades
+## instead of shooting. Triggers T8 (direct sight, 0.5s) and T9 (low suspicion, 1.0s)
+## from GrenadierGrenadeComponent made ready_to_throw_grenade=true almost immediately,
+## causing the grenadier to never execute _process_combat_state (where shooting happens).
+##
+## The fix: When a grenadier is in COMBAT state, the grenade throw intercept is skipped,
+## allowing the state machine to reach _process_combat_state and execute the shooting phase.
+
+
+# ============================================================================
+# Mock classes for testing the COMBAT state grenade intercept logic
+# ============================================================================
+
+
+## Mirrors the grenade throw intercept logic from _process_ai_state (line 1322 of enemy.gd).
+class MockAIStateProcessor:
+	enum AIState { IDLE, COMBAT, SEEKING_COVER, IN_COVER, FLANKING, SUPPRESSED, RETREATING, PURSUING, ASSAULT, SEARCHING, EVADING_GRENADE, PACIFIST }
+
+	var is_grenadier: bool = false
+	var _current_state: int = AIState.IDLE
+	var _combat_allowed: bool = true
+	var ready_to_throw_grenade: bool = false
+	var is_pacifist: bool = false
+	var grenade_throw_attempted: bool = false
+	var combat_state_processed: bool = false
+
+	## Reset tracking flags between calls.
+	func reset_tracking() -> void:
+		grenade_throw_attempted = false
+		combat_state_processed = false
+
+	## Simulate try_throw_grenade returning true (grenade was thrown).
+	func try_throw_grenade_returns_true() -> bool:
+		grenade_throw_attempted = true
+		return true
+
+	## Simulate _process_combat_state being called.
+	func process_combat_state() -> void:
+		combat_state_processed = true
+
+	## Simulate the FIXED _process_ai_state grenade throw check (Issue #1805).
+	## Issue #1805: Grenadiers in COMBAT state should shoot their rifle.
+	## Grenade throws still happen in PURSUING and other non-COMBAT states.
+	func process_ai_state_fixed() -> void:
+		reset_tracking()
+		# Fixed condition: skip grenade throw for grenadiers in COMBAT state
+		if _combat_allowed and ready_to_throw_grenade and not is_pacifist and not (is_grenadier and _current_state == AIState.COMBAT):
+			if try_throw_grenade_returns_true():
+				return  # Early return - combat state not processed
+		# Simulate state machine reaching COMBAT
+		if _current_state == AIState.COMBAT:
+			process_combat_state()
+
+	## Simulate the BUGGY _process_ai_state grenade throw check (pre-fix).
+	func process_ai_state_buggy() -> void:
+		reset_tracking()
+		# Buggy condition: no grenadier/COMBAT exclusion
+		if _combat_allowed and ready_to_throw_grenade and not is_pacifist:
+			if try_throw_grenade_returns_true():
+				return  # Early return - combat state not processed
+		# Simulate state machine reaching COMBAT
+		if _current_state == AIState.COMBAT:
+			process_combat_state()
+
+
+# ============================================================================
+# Test Variables and Setup
+# ============================================================================
+
+
+var ai: MockAIStateProcessor
+
+
+func before_each() -> void:
+	ai = MockAIStateProcessor.new()
+
+
+func after_each() -> void:
+	ai = null
+
+
+# ============================================================================
+# Issue #1805: Grenadier in COMBAT should not be interrupted by grenade throw
+# ============================================================================
+
+
+func test_grenadier_combat_not_interrupted_when_grenade_ready_fixed() -> void:
+	ai.is_grenadier = true
+	ai._current_state = MockAIStateProcessor.AIState.COMBAT
+	ai.ready_to_throw_grenade = true
+
+	ai.process_ai_state_fixed()
+
+	assert_false(ai.grenade_throw_attempted,
+		"Fix: Grenadier in COMBAT should NOT throw grenade (allow shooting)")
+	assert_true(ai.combat_state_processed,
+		"Fix: COMBAT state should be processed (grenadier shoots rifle)")
+
+
+func test_grenadier_combat_interrupted_in_buggy_version() -> void:
+	ai.is_grenadier = true
+	ai._current_state = MockAIStateProcessor.AIState.COMBAT
+	ai.ready_to_throw_grenade = true
+
+	ai.process_ai_state_buggy()
+
+	assert_true(ai.grenade_throw_attempted,
+		"Bug: Grenadier in COMBAT incorrectly throws grenade (blocks shooting)")
+	assert_false(ai.combat_state_processed,
+		"Bug: COMBAT state is NOT processed (grenadier never shoots)")
+
+
+# ============================================================================
+# Non-grenadier in COMBAT should still be able to throw grenades
+# ============================================================================
+
+
+func test_non_grenadier_combat_can_throw_grenade_fixed() -> void:
+	ai.is_grenadier = false
+	ai._current_state = MockAIStateProcessor.AIState.COMBAT
+	ai.ready_to_throw_grenade = true
+
+	ai.process_ai_state_fixed()
+
+	assert_true(ai.grenade_throw_attempted,
+		"Non-grenadier in COMBAT should still be able to throw grenades")
+	assert_false(ai.combat_state_processed,
+		"Non-grenadier grenade throw early-returns (normal behavior)")
+
+
+# ============================================================================
+# Grenadier in non-COMBAT states should still throw grenades
+# ============================================================================
+
+
+func test_grenadier_in_pursuing_can_throw_grenade_fixed() -> void:
+	ai.is_grenadier = true
+	ai._current_state = MockAIStateProcessor.AIState.PURSUING
+	ai.ready_to_throw_grenade = true
+
+	ai.process_ai_state_fixed()
+
+	assert_true(ai.grenade_throw_attempted,
+		"Fix: Grenadier in PURSUING state can still throw grenades (passage throws)")
+
+
+func test_grenadier_in_idle_can_throw_grenade_fixed() -> void:
+	ai.is_grenadier = true
+	ai._current_state = MockAIStateProcessor.AIState.IDLE
+	ai.ready_to_throw_grenade = true
+
+	ai.process_ai_state_fixed()
+
+	assert_true(ai.grenade_throw_attempted,
+		"Fix: Grenadier in IDLE state can still throw grenades")
+
+
+func test_grenadier_in_flanking_can_throw_grenade_fixed() -> void:
+	ai.is_grenadier = true
+	ai._current_state = MockAIStateProcessor.AIState.FLANKING
+	ai.ready_to_throw_grenade = true
+
+	ai.process_ai_state_fixed()
+
+	assert_true(ai.grenade_throw_attempted,
+		"Fix: Grenadier in FLANKING state can still throw grenades")
+
+
+func test_grenadier_in_seeking_cover_can_throw_grenade_fixed() -> void:
+	ai.is_grenadier = true
+	ai._current_state = MockAIStateProcessor.AIState.SEEKING_COVER
+	ai.ready_to_throw_grenade = true
+
+	ai.process_ai_state_fixed()
+
+	assert_true(ai.grenade_throw_attempted,
+		"Fix: Grenadier in SEEKING_COVER state can still throw grenades")
+
+
+# ============================================================================
+# Grenadier in COMBAT without grenade ready should still shoot
+# ============================================================================
+
+
+func test_grenadier_combat_shoots_when_no_grenade_ready() -> void:
+	ai.is_grenadier = true
+	ai._current_state = MockAIStateProcessor.AIState.COMBAT
+	ai.ready_to_throw_grenade = false
+
+	ai.process_ai_state_fixed()
+
+	assert_false(ai.grenade_throw_attempted,
+		"No grenade ready — no throw attempted")
+	assert_true(ai.combat_state_processed,
+		"COMBAT state processed even without grenade ready")
+
+
+# ============================================================================
+# Pacifist grenadier should never throw
+# ============================================================================
+
+
+func test_pacifist_grenadier_does_not_throw() -> void:
+	ai.is_grenadier = true
+	ai.is_pacifist = true
+	ai._current_state = MockAIStateProcessor.AIState.PURSUING
+	ai.ready_to_throw_grenade = true
+
+	ai.process_ai_state_fixed()
+
+	assert_false(ai.grenade_throw_attempted,
+		"Pacifist grenadier should not throw grenades in any state")
+
+
+# ============================================================================
+# Combat disabled should prevent grenade throw
+# ============================================================================
+
+
+func test_combat_disabled_prevents_grenade_throw() -> void:
+	ai.is_grenadier = true
+	ai._current_state = MockAIStateProcessor.AIState.PURSUING
+	ai.ready_to_throw_grenade = true
+	ai._combat_allowed = false
+
+	ai.process_ai_state_fixed()
+
+	assert_false(ai.grenade_throw_attempted,
+		"Combat disabled should prevent grenade throw (respects #1305 combat toggle)")
+
+
+# ============================================================================
+# Verify the T8/T9 delay constants that cause the bug
+# ============================================================================
+
+
+class MockGrenadierTriggerDelays:
+	## These constants from GrenadierGrenadeComponent (grenadier_grenade_component.gd).
+	## T8 fires after 0.5s of seeing player at safe distance.
+	## T9 fires after 1.0s of any suspicion.
+	## Both are SHORT enough to always fire before COMBAT exposed phase (needs 2s approach).
+	const T8_DIRECT_SIGHT_DELAY := 0.5
+	const T9_LOW_SUSPICION_DELAY := 1.0
+	## COMBAT approach phase max time before exposed shooting begins.
+	const COMBAT_APPROACH_MAX_TIME := 2.0
+
+
+func test_t8_fires_before_combat_approach_completes() -> void:
+	var delays := MockGrenadierTriggerDelays.new()
+
+	assert_true(delays.T8_DIRECT_SIGHT_DELAY < delays.COMBAT_APPROACH_MAX_TIME,
+		"T8 fires (%.1fs) before COMBAT approach max time (%.1fs) — this is why grenadier never shoots" % [
+			delays.T8_DIRECT_SIGHT_DELAY, delays.COMBAT_APPROACH_MAX_TIME])
+
+
+func test_t9_fires_before_combat_approach_completes() -> void:
+	var delays := MockGrenadierTriggerDelays.new()
+
+	assert_true(delays.T9_LOW_SUSPICION_DELAY < delays.COMBAT_APPROACH_MAX_TIME,
+		"T9 fires (%.1fs) before COMBAT approach max time (%.1fs) — this is why grenadier never shoots" % [
+			delays.T9_LOW_SUSPICION_DELAY, delays.COMBAT_APPROACH_MAX_TIME])


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/godot-topdown-MVP#1805: Grenadier (гренадер) on the Канализация (Sewer) map was not shooting its rifle.

### Root Cause

The grenade throw priority check in `_process_ai_state()` fires **before** the state machine reaches `_process_combat_state()`:

```gdscript
# Line 1322 — fires before state machine
if _combat_allowed and ready_to_throw_grenade:
    if try_throw_grenade():
        return  # ← early return skips COMBAT state processing!

# Never reached when grenadier sees player:
match _current_state:
    AIState.COMBAT: _process_combat_state(delta)  # ← shooting happens here
```

Triggers T8 (direct sight, **0.5s delay**) and T9 (low suspicion, **1.0s delay**) added in Issue #657 made `ready_to_throw_grenade = true` almost immediately when the player is spotted. Since the COMBAT state's approach phase needs **2 seconds** to complete before the exposed shooting phase begins, the grenade throw always fires first — the grenadier never gets to shoot its rifle.

### Fix

Added `and not (is_grenadier and _current_state == AIState.COMBAT)` to the grenade throw condition in `enemy.gd`:

```gdscript
# Issue #1805: Grenadiers in COMBAT state should shoot their rifle, not only throw grenades.
# Grenade throws still happen during PURSUING (passage throws) and other non-COMBAT states.
if _combat_allowed and ready_to_throw_grenade and not (is_grenadier and _current_state == AIState.COMBAT):
```

**Behavior after fix:**
- ✅ Grenadier shoots its rifle during COMBAT state (exposed shooting phase works)
- ✅ Grenadier still throws passage grenades during PURSUING state (Issue #604 behavior preserved)
- ✅ Grenadier still throws grenades in IDLE, FLANKING, SEEKING_COVER, and other non-COMBAT states
- ✅ Regular (non-grenadier) enemies are completely unaffected
- ✅ Pacifist grenadiers remain unchanged

### Changes

| File | Change |
|------|--------|
| `scripts/objects/enemy.gd` | Add COMBAT state exclusion for grenadier grenade throw intercept |
| `tests/unit/test_grenadier_combat_shooting_1805.gd` | New unit tests verifying fix logic |
| `docs/case-studies/issue-1805/case-study.md` | Full root cause analysis with timeline |

### How to Reproduce (Before Fix)

1. Open Sewer level
2. Approach `TopRoomGrenadier` (at position `Vector2(400, 280)` in the top room)
3. Observe: grenadier only throws grenades, never fires rifle

### Verification (After Fix)

1. Open Sewer level
2. Approach `TopRoomGrenadier`
3. Observe: grenadier throws grenades during PURSUING approach, then fires rifle during COMBAT state

---

*This PR was created automatically by the AI issue solver*