### PR TITLE
update быстрый рестарт

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-15T17:23:16.825Z for PR creation at branch issue-1822-748feb4f7570 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1822

--- a/resources/translations/translations.csv
+++ b/resources/translations/translations.csv
@@ -240,7 +240,7 @@ HINT_FIRE_MODE_SWITCH,Switch fire mode,Переключи режим стрел�
 HINT_LAUNCHER_FIRE,Fire grenade launcher,Выстрели подствольным гранатомётом
 HINT_GRENADE_STEP0,Throw grenade,Брось гранату
 TUTORIAL_LEVEL_COMPLETE,LEVEL COMPLETE!,УРОВЕНЬ ПРОЙДЕН!
-TUTORIAL_RESTART_HINT,Press [Q] to quick restart,Нажми [Q] для быстрого перезапуска
+TUTORIAL_RESTART_HINT,Hold [Q] for 2 seconds to quick restart,Удерживай [Q] 2 секунды для быстрого перезапуска
 TUTORIAL_AMMO_LABEL,AMMO: %d/%d,ПАТРОНЫ: %d/%d
 ROGUELIKE_LEVEL_UP,"LEVEL %d\nEnemies got more dangerous!","УРОВЕНЬ %d\nВраги стали опаснее!"
 UNLOCK_COND_COMPLETE_LEVEL,Complete %s,Пройди %s

--- a/resources/translations/translations.csv
+++ b/resources/translations/translations.csv
@@ -240,7 +240,7 @@ HINT_FIRE_MODE_SWITCH,Switch fire mode,Переключи режим стрел�
 HINT_LAUNCHER_FIRE,Fire grenade launcher,Выстрели подствольным гранатомётом
 HINT_GRENADE_STEP0,Throw grenade,Брось гранату
 TUTORIAL_LEVEL_COMPLETE,LEVEL COMPLETE!,УРОВЕНЬ ПРОЙДЕН!
-TUTORIAL_RESTART_HINT,Hold [Q] for 2 seconds to quick restart,Удерживай [Q] 2 секунды для быстрого перезапуска
+TUTORIAL_RESTART_HINT,Hold [Q] for 1 second to quick restart,Удерживай [Q] 1 секунду для быстрого перезапуска
 TUTORIAL_AMMO_LABEL,AMMO: %d/%d,ПАТРОНЫ: %d/%d
 ROGUELIKE_LEVEL_UP,"LEVEL %d\nEnemies got more dangerous!","УРОВЕНЬ %d\nВраги стали опаснее!"
 UNLOCK_COND_COMPLETE_LEVEL,Complete %s,Пройди %s

--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -168,6 +168,18 @@ var _f8_spawn_triggered: bool = false
 ## Hold duration in seconds required to trigger F8 spawn (Issue #1112).
 const F8_HOLD_THRESHOLD: float = 0.2
 
+## Whether Q is currently being held down for quick restart (Issue #1822).
+var _q_restart_held: bool = false
+
+## Tracks how long Q has been held for quick restart (Issue #1822).
+var _q_restart_hold_time: float = 0.0
+
+## Whether quick restart already triggered during the current Q hold (Issue #1822).
+var _q_restart_triggered: bool = false
+
+## Hold duration in seconds required to trigger quick restart with Q (Issue #1822).
+const Q_RESTART_HOLD_THRESHOLD: float = 2.0
+
 ## ── Roguelike session state (Issue #1061) ─────────────────────────────────
 ## Persists across room-to-room scene reloads so the run can advance
 ## one room at a time (Binding of Isaac style).
@@ -285,12 +297,19 @@ func _ready() -> void:
 func _input(event: InputEvent) -> void:
 	# Handle quick restart with Q key
 	if event is InputEventKey:
-		if event.pressed and event.physical_keycode == KEY_Q:
+		if event.physical_keycode == KEY_Q:
 			# Block restart while the score screen animation is playing — the player
 			# may not have seen the Armory button yet (Issue #1589).
 			if score_screen_active:
+				if not event.pressed:
+					_reset_q_restart_hold()
 				return
-			restart_scene()
+			if event.pressed and not event.echo:
+				_q_restart_held = true
+				_q_restart_hold_time = 0.0
+				_q_restart_triggered = false
+			elif not event.pressed:
+				_reset_q_restart_hold()
 		# Handle invincibility toggle with F6 key (works in exported builds)
 		elif event.pressed and event.physical_keycode == KEY_F6:
 			toggle_invincibility()
@@ -310,6 +329,15 @@ func _input(event: InputEvent) -> void:
 
 
 func _process(delta: float) -> void:
+	if _q_restart_held and not _q_restart_triggered:
+		if score_screen_active:
+			_reset_q_restart_hold()
+		else:
+			_q_restart_hold_time += delta
+			if _q_restart_hold_time >= Q_RESTART_HOLD_THRESHOLD:
+				_q_restart_triggered = true
+				restart_scene()
+
 	# F8 hold-to-spawn: after holding F8 for 200ms outside a menu, spawn the selected enemy (Issue #1112).
 	if _f8_held and not _f8_spawn_triggered:
 		_f8_hold_time += delta
@@ -514,6 +542,12 @@ func restart_scene() -> void:
 ## Issue #1334: Deferred callback to clear the reload guard.
 func _reset_reloading() -> void:
 	_reloading = false
+
+
+func _reset_q_restart_hold() -> void:
+	_q_restart_held = false
+	_q_restart_hold_time = 0.0
+	_q_restart_triggered = false
 
 
 ## Sets the player reference and connects to the player's death signal.

--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -178,7 +178,7 @@ var _q_restart_hold_time: float = 0.0
 var _q_restart_triggered: bool = false
 
 ## Hold duration in seconds required to trigger quick restart with Q (Issue #1822).
-const Q_RESTART_HOLD_THRESHOLD: float = 2.0
+const Q_RESTART_HOLD_THRESHOLD: float = 1.0
 
 ## ── Roguelike session state (Issue #1061) ─────────────────────────────────
 ## Persists across room-to-room scene reloads so the run can advance

--- a/scripts/levels/tutorial_level.gd
+++ b/scripts/levels/tutorial_level.gd
@@ -11,7 +11,7 @@ extends Node2D
 ##    - Revolver: cylinder reload + hammer-cock hint from weapon pickup
 ## 3. Player throws a grenade — hint appears AFTER reload hint disappears (Bug fix #5)
 ##    (only shown if player actually has grenades, Bug fix #9)
-## 4. Shows completion message with Q restart hint
+## 4. Shows completion message with Q hold-to-restart hint
 ##
 ## Issue #808: Each hint shown independently; dismissed independently when action is done.
 ## Issue #945: (1) Reload hint shown after 2 shots. (2) Each hint has a unique color.

--- a/tests/unit/test_game_manager.gd
+++ b/tests/unit/test_game_manager.gd
@@ -18,6 +18,12 @@ class MockGameManager:
 	var player_alive: bool = true
 	var debug_mode_enabled: bool = false
 	var selected_weapon: String = "m16"
+	var score_screen_active: bool = false
+	var _q_restart_held: bool = false
+	var _q_restart_hold_time: float = 0.0
+	var _q_restart_triggered: bool = false
+
+	const Q_RESTART_HOLD_THRESHOLD: float = 2.0
 
 	const WEAPON_SCENES: Dictionary = {
 		"m16": "res://scenes/weapons/csharp/AssaultRifle.tscn",
@@ -78,6 +84,33 @@ class MockGameManager:
 		_reset_stats()
 		last_mouse_mode = Input.MOUSE_MODE_CONFINED_HIDDEN
 		scene_reload_requested = true
+
+	func handle_q_input(pressed: bool, echo: bool = false) -> void:
+		if score_screen_active:
+			if not pressed:
+				_reset_q_restart_hold()
+			return
+		if pressed and not echo:
+			_q_restart_held = true
+			_q_restart_hold_time = 0.0
+			_q_restart_triggered = false
+		elif not pressed:
+			_reset_q_restart_hold()
+
+	func process_restart_hold(delta: float) -> void:
+		if _q_restart_held and not _q_restart_triggered:
+			if score_screen_active:
+				_reset_q_restart_hold()
+				return
+			_q_restart_hold_time += delta
+			if _q_restart_hold_time >= Q_RESTART_HOLD_THRESHOLD:
+				_q_restart_triggered = true
+				restart_scene()
+
+	func _reset_q_restart_hold() -> void:
+		_q_restart_held = false
+		_q_restart_hold_time = 0.0
+		_q_restart_triggered = false
 
 
 var manager: MockGameManager
@@ -387,3 +420,48 @@ func test_restart_scene_triggers_scene_reload() -> void:
 	manager.restart_scene()
 
 	assert_true(manager.scene_reload_requested, "restart_scene() must trigger scene reload")
+
+
+# ============================================================================
+# Quick Restart Hold Tests (Issue #1822)
+# ============================================================================
+
+
+func test_q_tap_does_not_restart_scene() -> void:
+	manager.handle_q_input(true)
+	manager.process_restart_hold(0.5)
+	manager.handle_q_input(false)
+
+	assert_false(manager.scene_reload_requested,
+		"Quick restart must NOT trigger on a short Q tap")
+
+
+func test_q_hold_restarts_after_two_seconds() -> void:
+	manager.handle_q_input(true)
+	manager.process_restart_hold(1.0)
+	assert_false(manager.scene_reload_requested, "Quick restart must wait for the full hold duration")
+
+	manager.process_restart_hold(1.0)
+
+	assert_true(manager.scene_reload_requested,
+		"Quick restart must trigger after holding Q for 2 seconds")
+
+
+func test_q_release_before_threshold_cancels_restart() -> void:
+	manager.handle_q_input(true)
+	manager.process_restart_hold(1.9)
+	manager.handle_q_input(false)
+	manager.process_restart_hold(0.2)
+
+	assert_false(manager.scene_reload_requested,
+		"Releasing Q before 2 seconds must cancel quick restart")
+
+
+func test_q_hold_blocked_while_score_screen_active() -> void:
+	manager.score_screen_active = true
+	manager.handle_q_input(true)
+	manager.process_restart_hold(3.0)
+	manager.handle_q_input(false)
+
+	assert_false(manager.scene_reload_requested,
+		"Quick restart must remain blocked while the score screen animation is active")

--- a/tests/unit/test_game_manager.gd
+++ b/tests/unit/test_game_manager.gd
@@ -23,7 +23,7 @@ class MockGameManager:
 	var _q_restart_hold_time: float = 0.0
 	var _q_restart_triggered: bool = false
 
-	const Q_RESTART_HOLD_THRESHOLD: float = 2.0
+	const Q_RESTART_HOLD_THRESHOLD: float = 1.0
 
 	const WEAPON_SCENES: Dictionary = {
 		"m16": "res://scenes/weapons/csharp/AssaultRifle.tscn",
@@ -436,25 +436,25 @@ func test_q_tap_does_not_restart_scene() -> void:
 		"Quick restart must NOT trigger on a short Q tap")
 
 
-func test_q_hold_restarts_after_two_seconds() -> void:
+func test_q_hold_restarts_after_one_second() -> void:
 	manager.handle_q_input(true)
-	manager.process_restart_hold(1.0)
+	manager.process_restart_hold(0.5)
 	assert_false(manager.scene_reload_requested, "Quick restart must wait for the full hold duration")
 
-	manager.process_restart_hold(1.0)
+	manager.process_restart_hold(0.5)
 
 	assert_true(manager.scene_reload_requested,
-		"Quick restart must trigger after holding Q for 2 seconds")
+		"Quick restart must trigger after holding Q for 1 second")
 
 
 func test_q_release_before_threshold_cancels_restart() -> void:
 	manager.handle_q_input(true)
-	manager.process_restart_hold(1.9)
+	manager.process_restart_hold(0.9)
 	manager.handle_q_input(false)
 	manager.process_restart_hold(0.2)
 
 	assert_false(manager.scene_reload_requested,
-		"Releasing Q before 2 seconds must cancel quick restart")
+		"Releasing Q before 1 second must cancel quick restart")
 
 
 func test_q_hold_blocked_while_score_screen_active() -> void:


### PR DESCRIPTION
## Summary
Require holding `Q` for 1 second before triggering quick restart, instead of restarting on a tap.

## Changes
- changed `GameManager` quick-restart input handling to track `Q` press/release and restart only after a 1.0s hold
- preserved the existing score-screen guard so restart remains blocked while score-screen animation is active
- updated the tutorial restart hint text in English and Russian to describe the 1-second hold behavior
- added regression coverage for tap, full hold, early release cancellation, and score-screen blocking in `test_game_manager.gd`

## Testing
- current upstream CI before this follow-up change was green on commit `9109b937`
- local targeted Godot test is currently blocked in this workspace because the Godot binary referenced by the earlier draft is not present here

Fixes Jhon-Crow/godot-topdown-MVP#1822
