### PR TITLE
fix выбор сложности при первом запуске

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-15T21:48:59.534Z for PR creation at branch issue-1812-d0aa9bea16ed for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1812

--- a/scripts/autoload/persist_manager.gd
+++ b/scripts/autoload/persist_manager.gd
@@ -135,6 +135,7 @@ func _show_first_launch_difficulty_menu() -> void:
 	_first_launch_menu = packed.instantiate()
 	_first_launch_menu.first_launch_mode = true
 	_first_launch_menu.difficulty_selected_first_launch.connect(_on_first_launch_difficulty_selected)
+	get_tree().paused = true
 	get_tree().root.add_child(_first_launch_menu)
 	_log_to_file("First-launch difficulty menu shown")
 
@@ -146,7 +147,12 @@ func _on_first_launch_difficulty_selected() -> void:
 	if _first_launch_menu != null:
 		_first_launch_menu.queue_free()
 		_first_launch_menu = null
-	_do_navigate_to_last_level()
+	get_tree().paused = false
+	var game_manager: Node = get_node_or_null("/root/GameManager")
+	if game_manager and game_manager.has_method("restart_scene"):
+		game_manager.restart_scene()
+	else:
+		_do_navigate_to_last_level()
 
 
 ## Connect to manager signals to auto-save on changes.

--- a/tests/unit/test_difficulty_menu.gd
+++ b/tests/unit/test_difficulty_menu.gd
@@ -74,6 +74,12 @@ class MockDifficultyMenu:
 	## 0 = default, 1 = CONFINED (cursor shown), 2 = CONFINED_HIDDEN (cursor hidden).
 	var mouse_mode_on_enter: int = 0
 	var mouse_mode_on_exit: int = 0
+	## Tracks pause state changes caused by restart flow.
+	var tree_paused: bool = true
+	## Tracks whether restart would be requested.
+	var restart_requested: bool = false
+	## Simulated player presence for restart gating.
+	var has_player: bool = false
 
 	## Simulate entering first-launch mode (_ready logic) (Issue #1734).
 	func simulate_enter_first_launch() -> void:
@@ -92,6 +98,13 @@ class MockDifficultyMenu:
 			first_launch_signal_emitted = true
 			return true
 		return false
+
+	## Simulate _restart_if_in_game() including unpausing before restart.
+	func simulate_restart_if_in_game() -> void:
+		if not has_player:
+			return
+		tree_paused = false
+		restart_requested = true
 
 	## Whether the back button would be visible (Issue #1734).
 	func is_back_button_visible() -> bool:
@@ -500,3 +513,27 @@ func test_cursor_restored_regardless_of_difficulty_chosen() -> void:
 
 		assert_eq(m.mouse_mode_on_exit, 2,
 			"Mouse mode should be CONFINED_HIDDEN after choosing difficulty %d" % diff)
+
+
+func test_restart_unpauses_tree_before_restart_when_player_exists() -> void:
+	menu.has_player = true
+	menu.tree_paused = true
+
+	menu.simulate_restart_if_in_game()
+
+	assert_false(menu.tree_paused,
+		"Difficulty change restart should unpause the tree before restarting (Issue #1812)")
+	assert_true(menu.restart_requested,
+		"Difficulty change restart should request scene restart when player exists")
+
+
+func test_restart_without_player_leaves_tree_pause_state_unchanged() -> void:
+	menu.has_player = false
+	menu.tree_paused = true
+
+	menu.simulate_restart_if_in_game()
+
+	assert_true(menu.tree_paused,
+		"Difficulty change should not alter pause state when no player exists")
+	assert_false(menu.restart_requested,
+		"Difficulty change should not request restart when no player exists")

--- a/tests/unit/test_persist_manager.gd
+++ b/tests/unit/test_persist_manager.gd
@@ -563,18 +563,29 @@ class MockPersistManagerFirstLaunch:
 	var navigation_performed: bool = false
 	## Whether navigation was deferred until after difficulty selection.
 	var navigation_deferred: bool = false
+	## Whether the tree would be paused while waiting for the choice (Issue #1812).
+	var tree_paused: bool = false
+	## Whether quick restart was requested after the choice (Issue #1812).
+	var restart_requested: bool = false
+	## Whether GameManager is available for quick restart.
+	var has_game_manager: bool = true
 
 	func simulate_navigate_to_last_level() -> void:
 		if _is_first_launch:
 			first_launch_menu_shown = true
 			navigation_deferred = true
+			tree_paused = true
 			return
 		navigation_performed = true
 
 	func simulate_difficulty_selected() -> void:
 		first_launch_menu_shown = false
 		navigation_deferred = false
-		navigation_performed = true
+		tree_paused = false
+		if has_game_manager:
+			restart_requested = true
+		else:
+			navigation_performed = true
 
 
 func test_first_launch_shows_difficulty_menu_not_level() -> void:
@@ -633,3 +644,32 @@ func test_first_launch_menu_closed_after_difficulty_selected() -> void:
 
 	assert_false(mock.first_launch_menu_shown,
 		"First-launch menu must be closed after difficulty is selected (Issue #1734)")
+
+
+func test_first_launch_pauses_tree_until_difficulty_selected() -> void:
+	var mock := MockPersistManagerFirstLaunch.new()
+	mock._is_first_launch = true
+
+	mock.simulate_navigate_to_last_level()
+
+	assert_true(mock.tree_paused,
+		"Game tree must be paused while first-launch difficulty selection is open (Issue #1812)")
+
+	mock.simulate_difficulty_selected()
+
+	assert_false(mock.tree_paused,
+		"Game tree must be unpaused after first-launch difficulty selection completes (Issue #1812)")
+
+
+func test_first_launch_selection_requests_quick_restart_when_game_manager_exists() -> void:
+	var mock := MockPersistManagerFirstLaunch.new()
+	mock._is_first_launch = true
+	mock.has_game_manager = true
+
+	mock.simulate_navigate_to_last_level()
+	mock.simulate_difficulty_selected()
+
+	assert_true(mock.restart_requested,
+		"First-launch difficulty selection must trigger quick restart when GameManager is available (Issue #1812)")
+	assert_false(mock.navigation_performed,
+		"Fallback navigation should not run when quick restart is available (Issue #1812)")


### PR DESCRIPTION
## Summary
- pause the game tree while the first-launch difficulty menu is open
- trigger a quick scene restart after the first difficulty choice so the selected mode applies immediately
- add regression tests for the pause and quick-restart flow

## Reproduction
1. Start the game with no existing difficulty settings save.
2. Observe that the startup level begins running before difficulty is chosen.
3. Choose a difficulty.
4. Observe that the game should stay paused until selection, then immediately restart with the chosen mode.

## Tests
- Added unit regression coverage in `tests/unit/test_persist_manager.gd`
- Added unit regression coverage in `tests/unit/test_difficulty_menu.gd`
- Local execution of Godot/GUT tests was not possible in this environment because the `godot` binary is not installed

Fixes #1812