### PR TITLE
fix обучение зарядке револьвера

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-16T00:33:38.925Z for PR creation at branch issue-1851-7ed8a05311aa for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1851

--- a/scripts/levels/tutorial_level.gd
+++ b/scripts/levels/tutorial_level.gd
@@ -1216,8 +1216,9 @@ func _get_shotgun_shells_to_load() -> int:
 
 ## Build BBCode for the revolver reload hint with step-based highlighting (Bug fix round 4).
 ## step=1: cylinder opened → highlight insert-cartridge action
-## step=2: cartridge inserted → highlight scroll action
-## step=3: cylinder rotated after insert → highlight close action
+## step=2: first cartridge inserted → remove insert highlight, keep scroll active without
+##         visually completing the insert step yet
+## step=3: enough cartridges inserted / cylinder full → highlight close action
 ## step=4: cylinder closed → all grey (done)
 ## Issue #944: Strikethrough is now animated via Line2D, not BBCode [s] tags.
 func _build_revolver_reload_hint_bbcode(step: int) -> String:
@@ -1234,11 +1235,12 @@ func _build_revolver_reload_hint_bbcode(step: int) -> String:
 			_extend_hint_strikethrough(HINT_RELOAD, 0.15)  # ~15% for first segment
 			return "[color=#888888][%s][/color] [color=#ff4444][%s][/color] [color=#888888][%s] [%s][/color]" % [k_open, k_bullet, k_scroll, k_close]
 		2:
-			# Cartridge inserted: next is scroll/rotate cylinder
-			_extend_hint_strikethrough(HINT_RELOAD, 0.35)  # open + insert completed
-			return "[color=#888888][%s] [%s][/color] [color=#ff4444][%s][/color] [color=#888888][%s][/color]" % [k_open, k_bullet, k_scroll, k_close]
+			# First cartridge inserted: open is completed, but insert should no longer be highlighted
+			# without looking fully completed yet. Keep scroll highlighted on its own.
+			_extend_hint_strikethrough(HINT_RELOAD, 0.15)
+			return "[color=#888888][%s][/color] [%s] [color=#ff4444][%s][/color] [color=#888888][%s][/color]" % [k_open, k_bullet, k_scroll, k_close]
 		3:
-			# Cylinder rotated after insertion: next is close cylinder
+			# Tutorial quota satisfied: insert + scroll are now treated as completed.
 			_extend_hint_strikethrough(HINT_RELOAD, 0.55)  # open + insert + scroll completed
 			return "[color=#888888][%s] [%s] [%s][/color] [color=#ff4444][%s][/color]" % [k_open, k_bullet, k_scroll, k_close]
 		_:
@@ -1431,8 +1433,9 @@ func _on_revolver_hammer_cocked() -> void:
 ## RevolverReloadState: 0=NotReloading, 1=CylinderOpen, 2=Loading, 3=ClosingCylinder.
 ## Maps actual reload state to the next tutorial action:
 ##   state=1 (CylinderOpen): highlight [ПКМ↑ патрон] (step=1)
-##   state=2 (Loading) with another insert possible: highlight [скролл] (step=2)
-##   state=2 (Loading) but insertion blocked or chamber occupied: highlight [R закрыть] (step=3)
+##   state=2 (Loading) after first insert: highlight [скролл] without visually completing
+##           [ПКМ↑ патрон] yet (step=2)
+##   state=2 (Loading) after enough inserts / full cylinder: highlight [R закрыть] (step=3)
 ##   state=0/3 (not reloading/closing): all grey (done)
 func _on_revolver_reload_state_changed(new_state: int) -> void:
 	if not _hint_labels.has(HINT_RELOAD):

--- a/tests/unit/test_tutorial_level.gd
+++ b/tests/unit/test_tutorial_level.gd
@@ -208,7 +208,7 @@ class MockTutorialLevel:
 			1:
 				return "[color=#888888][R открыть][/color] [color=#ff4444][ПКМ↑ патрон][/color] [color=#888888][скролл] [R закрыть][/color]"
 			2:
-				return "[color=#888888][R открыть] [ПКМ↑ патрон][/color] [color=#ff4444][скролл][/color] [color=#888888][R закрыть][/color]"
+				return "[color=#888888][R открыть][/color] [ПКМ↑ патрон] [color=#ff4444][скролл][/color] [color=#888888][R закрыть][/color]"
 			3:
 				return "[color=#888888][R открыть] [ПКМ↑ патрон] [скролл][/color] [color=#ff4444][R закрыть][/color]"
 			_:
@@ -1081,6 +1081,10 @@ func test_revolver_reload_hint_shows_scroll_as_separate_step_after_insert() -> v
 	var hint_text: String = tutorial.get_active_hints()[MockTutorialLevel.HINT_RELOAD]
 	assert_true(hint_text.contains("[color=#ff4444][скролл][/color]"),
 		"After inserting a cartridge, scroll must be the separate highlighted step")
+	assert_true(hint_text.contains("[ПКМ↑ патрон]"),
+		"The insert step should remain visible after the first cartridge is loaded")
+	assert_false(hint_text.contains("[color=#888888][ПКМ↑ патрон][/color]"),
+		"The first insert must not look completed before the second cartridge is loaded")
 	assert_false(hint_text.contains("[color=#ff4444][R закрыть][/color]"),
 		"Close cylinder must not be highlighted before the scroll step is done")
 


### PR DESCRIPTION
## Summary
- keep the first revolver cartridge insert visible without showing it as completed
- move the visual completion of `[ПКМ↑ патрон]` and `[скролл]` to the second insert / completed tutorial quota
- add a regression test that covers the first-insert state so the half-struck step is not highlighted

## Reproduction
- start the tutorial with the revolver
- begin reloading and insert the first cartridge with `ПКМ↑`
- observe the reload hint after the first insert

## Expected
- `[ПКМ↑ патрон]` is no longer highlighted after the first insert
- `[ПКМ↑ патрон]` is still visible and does not look completed yet
- `[скролл]` is the only highlighted next step
- both `[ПКМ↑ патрон]` and `[скролл]` become visually completed only after the second insert / tutorial quota is satisfied

## Tests
- added a unit regression test in `tests/unit/test_tutorial_level.gd` for the first-insert revolver hint state
- local Godot/GUT execution could not be run in this environment because the `godot` binary is not installed; CI uses `.github/workflows/test.yml`

Fixes Jhon-Crow/godot-topdown-MVP#1851
