### PR TITLE
добавь источники света на карту Двойной коридор

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-16T06:50:33.341Z for PR creation at branch issue-1828-a9759a81a9d6 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1828

--- a/scenes/levels/RevolverLevel.tscn
+++ b/scenes/levels/RevolverLevel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=3 uid="uid://revolver_level_scene"]
+[gd_scene load_steps=36 format=3 uid="uid://revolver_level_scene"]
 
 [ext_resource type="Script" path="res://scripts/levels/revolver_level.gd" id="1_revolver_level"]
 [ext_resource type="PackedScene" uid="uid://dv8nq2vj5r7p2" path="res://scenes/characters/csharp/Player.tscn" id="2_player"]
@@ -71,6 +71,18 @@ polygon = PackedVector2Array(-16, -48, 16, -48, 16, 48, -16, 48)
 
 [sub_resource type="OccluderPolygon2D" id="OccluderPolygon2D_cover_square"]
 polygon = PackedVector2Array(-32, -32, 32, -32, 32, 32, -32, 32)
+
+[sub_resource type="Gradient" id="Gradient_cold_store_lamp"]
+offsets = PackedFloat32Array(0, 0.55, 1)
+colors = PackedColorArray(1, 1, 1, 1, 0.72, 0.88, 1, 0.48, 0.45, 0.68, 1, 0)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_cold_store_lamp"]
+gradient = SubResource("Gradient_cold_store_lamp")
+width = 256
+height = 256
+fill = 1
+fill_from = Vector2(0.5, 0.5)
+fill_to = Vector2(1, 0.5)
 
 [sub_resource type="NavigationPolygon" id="NavigationPolygon_level"]
 vertices = PackedVector2Array(64, 64, 2064, 64, 2064, 1664, 64, 1664)
@@ -635,6 +647,71 @@ shape = SubResource("RectangleShape2D_cover_square")
 
 [node name="LightOccluder2D" type="LightOccluder2D" parent="Environment/Cover/FinalCover2"]
 occluder = SubResource("OccluderPolygon2D_cover_square")
+
+[node name="Lighting" type="Node2D" parent="Environment"]
+
+[node name="ColdStoreLamp_TopCorridor_W" type="PointLight2D" parent="Environment/Lighting"]
+position = Vector2(620, 550)
+color = Color(0.72, 0.88, 1, 1)
+energy = 0.9
+shadow_enabled = true
+shadow_filter = 2
+texture = SubResource("GradientTexture2D_cold_store_lamp")
+texture_scale = 3.25
+
+[node name="ColdStoreLamp_TopCorridor_E" type="PointLight2D" parent="Environment/Lighting"]
+position = Vector2(900, 550)
+color = Color(0.72, 0.88, 1, 1)
+energy = 0.9
+shadow_enabled = true
+shadow_filter = 2
+texture = SubResource("GradientTexture2D_cold_store_lamp")
+texture_scale = 3.25
+
+[node name="ColdStoreLamp_MiddleCorridor_W" type="PointLight2D" parent="Environment/Lighting"]
+position = Vector2(1180, 700)
+color = Color(0.72, 0.88, 1, 1)
+energy = 0.9
+shadow_enabled = true
+shadow_filter = 2
+texture = SubResource("GradientTexture2D_cold_store_lamp")
+texture_scale = 3.25
+
+[node name="ColdStoreLamp_MiddleCorridor_E" type="PointLight2D" parent="Environment/Lighting"]
+position = Vector2(1180, 1000)
+color = Color(0.72, 0.88, 1, 1)
+energy = 0.9
+shadow_enabled = true
+shadow_filter = 2
+texture = SubResource("GradientTexture2D_cold_store_lamp")
+texture_scale = 3.25
+
+[node name="ColdStoreLamp_BottomCorridor_W" type="PointLight2D" parent="Environment/Lighting"]
+position = Vector2(620, 1150)
+color = Color(0.72, 0.88, 1, 1)
+energy = 0.9
+shadow_enabled = true
+shadow_filter = 2
+texture = SubResource("GradientTexture2D_cold_store_lamp")
+texture_scale = 3.25
+
+[node name="ColdStoreLamp_BottomCorridor_E" type="PointLight2D" parent="Environment/Lighting"]
+position = Vector2(900, 1150)
+color = Color(0.72, 0.88, 1, 1)
+energy = 0.9
+shadow_enabled = true
+shadow_filter = 2
+texture = SubResource("GradientTexture2D_cold_store_lamp")
+texture_scale = 3.25
+
+[node name="ColdStoreLamp_Exit" type="PointLight2D" parent="Environment/Lighting"]
+position = Vector2(1900, 800)
+color = Color(0.72, 0.88, 1, 1)
+energy = 0.95
+shadow_enabled = true
+shadow_filter = 2
+texture = SubResource("GradientTexture2D_cold_store_lamp")
+texture_scale = 3.5
 
 [node name="Enemies" type="Node2D" parent="Environment"]
 

--- a/tests/unit/test_revolver_level_cold_lights.gd
+++ b/tests/unit/test_revolver_level_cold_lights.gd
@@ -1,0 +1,75 @@
+extends GutTest
+## Tests cold white store-style lamp placement on the Double Corridor map.
+
+
+const REVOLVER_LEVEL_SCENE := preload("res://scenes/levels/RevolverLevel.tscn")
+const EXPECTED_LIGHTS := {
+	"ColdStoreLamp_TopCorridor_W": Vector2(620, 550),
+	"ColdStoreLamp_TopCorridor_E": Vector2(900, 550),
+	"ColdStoreLamp_MiddleCorridor_W": Vector2(1180, 700),
+	"ColdStoreLamp_MiddleCorridor_E": Vector2(1180, 1000),
+	"ColdStoreLamp_BottomCorridor_W": Vector2(620, 1150),
+	"ColdStoreLamp_BottomCorridor_E": Vector2(900, 1150),
+	"ColdStoreLamp_Exit": Vector2(1900, 800),
+}
+
+
+var level: Node2D = null
+var lighting: Node2D = null
+
+
+func before_each() -> void:
+	level = REVOLVER_LEVEL_SCENE.instantiate()
+	add_child_autofree(level)
+	lighting = level.get_node_or_null("Environment/Lighting")
+
+
+func test_has_lighting_container() -> void:
+	assert_not_null(lighting, "Double Corridor should have an Environment/Lighting container")
+
+
+func test_has_expected_cold_store_lamp_count() -> void:
+	assert_not_null(lighting, "Lighting container is required")
+	assert_eq(lighting.get_child_count(), 7,
+		"Double Corridor should have 7 cold store lamps: 2 top, 2 middle, 2 bottom, 1 exit")
+
+
+func test_lamps_are_at_requested_corridor_and_exit_positions() -> void:
+	assert_not_null(lighting, "Lighting container is required")
+
+	for light_name in EXPECTED_LIGHTS:
+		var light := lighting.get_node_or_null(light_name) as PointLight2D
+		assert_not_null(light, "Missing cold store lamp '%s'" % light_name)
+		if light == null:
+			continue
+		assert_eq(light.position, EXPECTED_LIGHTS[light_name],
+			"Cold store lamp '%s' should be at the requested map position" % light_name)
+
+
+func test_lamps_use_cold_white_light_color() -> void:
+	assert_not_null(lighting, "Lighting container is required")
+
+	for child in lighting.get_children():
+		var light := child as PointLight2D
+		assert_not_null(light, "Lighting children should be PointLight2D nodes")
+		if light == null:
+			continue
+		assert_true(light.color.b >= light.color.g and light.color.g > light.color.r,
+			"Cold white lamp '%s' should be blue-green dominant, got %s" % [light.name, str(light.color)])
+		assert_true(light.color.r >= 0.7 and light.color.g >= 0.85 and light.color.b >= 0.95,
+			"Cold white lamp '%s' should stay near white, got %s" % [light.name, str(light.color)])
+
+
+func test_lamps_have_shadows_and_soft_radial_texture() -> void:
+	assert_not_null(lighting, "Lighting container is required")
+
+	for child in lighting.get_children():
+		var light := child as PointLight2D
+		if light == null:
+			continue
+		assert_true(light.shadow_enabled,
+			"Cold store lamp '%s' should cast shadows like other map lamps" % light.name)
+		assert_not_null(light.texture,
+			"Cold store lamp '%s' should use a soft radial texture" % light.name)
+		assert_true(light.texture_scale >= 3.0 and light.texture_scale <= 4.0,
+			"Cold store lamp '%s' should cover a corridor without excessive bleed" % light.name)


### PR DESCRIPTION
## Summary

Adds cold white store-style lamp sources to the Double Corridor map.

## Changes

- Added an `Environment/Lighting` container to `RevolverLevel.tscn`.
- Added 7 cold white `PointLight2D` lamps:
  - 2 in the top corridor
  - 2 in the middle corridor/reload passage area
  - 2 in the bottom corridor
  - 1 near the exit point on the right side of the map
- Added a shared soft radial gradient texture for the lamps.
- Added a GUT regression test that verifies lamp count, placement, cold-white color, shadows, and texture scale.

## Testing

- `git diff --check` passed.
- Static scene check confirmed 7 references to the shared cold lamp texture.
- GUT command-line tests were not run locally because no `godot` executable is available on PATH in this environment.

Fixes Jhon-Crow/godot-topdown-MVP#1828
