### PR TITLE
Adjust PM reload action audio

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-16T07:45:35.923Z for PR creation at branch issue-1820-afdf16e60b15 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1820

--- a/scripts/autoload/audio_manager.gd
+++ b/scripts/autoload/audio_manager.gd
@@ -120,7 +120,13 @@ const PM_RELOAD_ACTION_2: String = "res://assets/audio/второе действ
 ## Volume for PM shots.
 const VOLUME_PM_SHOT: float = -5.0
 ## Volume for PM reload actions.
-const VOLUME_PM_RELOAD: float = -3.0
+const VOLUME_PM_RELOAD_ACTION_1: float = -4.0
+const VOLUME_PM_RELOAD_ACTION_2: float = -1.5
+## Pitch for PM reload actions.
+const PITCH_PM_RELOAD_ACTION_1: float = 1.0
+const PITCH_PM_RELOAD_ACTION_2: float = 0.94
+## Legacy volume constant for compatibility with tests and older scripts.
+const VOLUME_PM_RELOAD: float = VOLUME_PM_RELOAD_ACTION_1
 
 ## Grenade sounds.
 ## Activation sound (pin pull) - played when grenade timer starts.
@@ -583,7 +589,7 @@ func play_sound(path: String, volume_db: float = 0.0) -> void:
 
 
 ## Plays a non-positional sound with specified priority.
-func play_sound_with_priority(path: String, volume_db: float, priority: SoundPriority) -> void:
+func play_sound_with_priority(path: String, volume_db: float, priority: SoundPriority, pitch_scale: float = 1.0) -> void:
 	var stream := _get_stream(path)
 	if stream == null:
 		push_warning("AudioManager: Could not load sound: " + path)
@@ -592,6 +598,7 @@ func play_sound_with_priority(path: String, volume_db: float, priority: SoundPri
 	var player := _get_available_player_with_priority(priority)
 	player.stream = stream
 	player.volume_db = volume_db
+	player.pitch_scale = pitch_scale
 	player.play()
 	_register_playing_sound(player, priority)
 
@@ -603,7 +610,7 @@ func play_sound_2d(path: String, position: Vector2, volume_db: float = 0.0) -> v
 
 ## Plays a positional 2D sound at the given position with specified priority.
 ## max_distance controls how far (in pixels) the sound is audible (default 2000.0).
-func play_sound_2d_with_priority(path: String, position: Vector2, volume_db: float, priority: SoundPriority, max_distance: float = 2000.0) -> void:
+func play_sound_2d_with_priority(path: String, position: Vector2, volume_db: float, priority: SoundPriority, max_distance: float = 2000.0, pitch_scale: float = 1.0) -> void:
 	var stream := _get_stream(path)
 	if stream == null:
 		push_warning("AudioManager: Could not load sound: " + path)
@@ -612,6 +619,7 @@ func play_sound_2d_with_priority(path: String, position: Vector2, volume_db: flo
 	var player := _get_available_player_2d_with_priority(priority)
 	player.stream = stream
 	player.volume_db = volume_db
+	player.pitch_scale = pitch_scale
 	player.max_distance = max_distance
 	player.global_position = position
 	player.play()
@@ -901,13 +909,13 @@ func play_pm_shot(position: Vector2) -> void:
 ## Plays the first PM reload action sound (eject magazine) at the given position.
 ## Uses CRITICAL priority for reload sounds.
 func play_pm_reload_action_1(position: Vector2) -> void:
-	play_sound_2d_with_priority(PM_RELOAD_ACTION_1, position, VOLUME_PM_RELOAD, SoundPriority.CRITICAL)
+	play_sound_2d_with_priority(PM_RELOAD_ACTION_1, position, VOLUME_PM_RELOAD_ACTION_1, SoundPriority.CRITICAL, 2000.0, PITCH_PM_RELOAD_ACTION_1)
 
 
 ## Plays the second PM reload action sound (insert magazine) at the given position.
 ## Uses CRITICAL priority for reload sounds.
 func play_pm_reload_action_2(position: Vector2) -> void:
-	play_sound_2d_with_priority(PM_RELOAD_ACTION_2, position, VOLUME_PM_RELOAD, SoundPriority.CRITICAL)
+	play_sound_2d_with_priority(PM_RELOAD_ACTION_2, position, VOLUME_PM_RELOAD_ACTION_2, SoundPriority.CRITICAL, 2000.0, PITCH_PM_RELOAD_ACTION_2)
 
 
 # ============================================================================
@@ -1016,10 +1024,10 @@ func play_ui_click() -> void:
 func play_weapon_reload_preview(weapon_id: String) -> void:
 	match weapon_id:
 		"makarov_pm":
-			play_sound_with_priority(PM_RELOAD_ACTION_1, VOLUME_PM_RELOAD, SoundPriority.LOW)
+			play_sound_with_priority(PM_RELOAD_ACTION_1, VOLUME_PM_RELOAD_ACTION_1, SoundPriority.LOW, PITCH_PM_RELOAD_ACTION_1)
 			await get_tree().create_timer(0.6).timeout
 			if not is_inside_tree(): return
-			play_sound_with_priority(PM_RELOAD_ACTION_2, VOLUME_PM_RELOAD, SoundPriority.LOW)
+			play_sound_with_priority(PM_RELOAD_ACTION_2, VOLUME_PM_RELOAD_ACTION_2, SoundPriority.LOW, PITCH_PM_RELOAD_ACTION_2)
 		"m16", "mini_uzi", "silenced_pistol", "ak_gl":
 			play_sound_with_priority(RELOAD_MAG_OUT, VOLUME_RELOAD, SoundPriority.LOW)
 			await get_tree().create_timer(0.8).timeout

--- a/tests/unit/test_audio_manager.gd
+++ b/tests/unit/test_audio_manager.gd
@@ -123,32 +123,33 @@ class MockAudioManager:
 			_audio_pool.append(false)  # false = not playing
 			_audio_2d_pool.append(false)
 
-	func play_sound(path: String, volume_db: float = 0.0) -> void:
+	func play_sound(path: String, volume_db: float = 0.0, pitch_scale: float = 1.0) -> void:
 		played_sounds.append(path)
 		var idx := _get_available_player_index()
 		_audio_pool[idx] = true  # Mark as playing
 
-	func play_sound_2d(path: String, position: Vector2, volume_db: float = 0.0, max_distance: float = 2000.0) -> void:
+	func play_sound_2d(path: String, position: Vector2, volume_db: float = 0.0, max_distance: float = 2000.0, pitch_scale: float = 1.0) -> void:
 		played_sounds_2d.append({
 			"path": path,
 			"position": position,
 			"volume": volume_db,
-			"max_distance": max_distance
+			"max_distance": max_distance,
+			"pitch": pitch_scale
 		})
 		var idx := _get_available_player_2d_index()
 		_audio_2d_pool[idx] = true
 
-	func play_random_sound(paths: Array, volume_db: float = 0.0) -> void:
+	func play_random_sound(paths: Array, volume_db: float = 0.0, pitch_scale: float = 1.0) -> void:
 		if paths.is_empty():
 			return
 		var path: String = paths[randi() % paths.size()]
-		play_sound(path, volume_db)
+		play_sound(path, volume_db, pitch_scale)
 
-	func play_random_sound_2d(paths: Array, position: Vector2, volume_db: float = 0.0, max_distance: float = 2000.0) -> void:
+	func play_random_sound_2d(paths: Array, position: Vector2, volume_db: float = 0.0, max_distance: float = 2000.0, pitch_scale: float = 1.0) -> void:
 		if paths.is_empty():
 			return
 		var path: String = paths[randi() % paths.size()]
-		play_sound_2d(path, position, volume_db, max_distance)
+		play_sound_2d(path, position, volume_db, max_distance, pitch_scale)
 
 	func cache_sound(path: String) -> void:
 		_audio_cache[path] = true
@@ -346,6 +347,25 @@ func test_reload_sound_uses_correct_volume() -> void:
 	audio.play_sound_2d("res://reload.wav", position, volume_reload)
 
 	assert_eq(audio.played_sounds_2d[0]["volume"], -3.0)
+
+
+func test_pm_second_reload_action_is_louder_and_lower_pitch_than_first() -> void:
+	# Issue #1820: the second PM reload action should be louder and slightly lower-pitched.
+	var pm_reload_action_1 := "res://assets/audio/первое действие перезарядки.mp3"
+	var pm_reload_action_2 := "res://assets/audio/второе действие перезарядки.mp3"
+	var volume_pm_reload_action_1 := -4.0
+	var volume_pm_reload_action_2 := -1.5
+	var pitch_pm_reload_action_1 := 1.0
+	var pitch_pm_reload_action_2 := 0.94
+	var position := Vector2(100, 100)
+
+	audio.play_sound_2d(pm_reload_action_1, position, volume_pm_reload_action_1, 2000.0, pitch_pm_reload_action_1)
+	audio.play_sound_2d(pm_reload_action_2, position, volume_pm_reload_action_2, 2000.0, pitch_pm_reload_action_2)
+
+	assert_gt(audio.played_sounds_2d[1]["volume"], audio.played_sounds_2d[0]["volume"],
+		"PM reload action 2 should be louder than action 1")
+	assert_lt(audio.played_sounds_2d[1]["pitch"], audio.played_sounds_2d[0]["pitch"],
+		"PM reload action 2 should have a slightly lower pitch than action 1")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Make the second Makarov PM reload action louder than the first action.
- Play the second PM reload action at a slightly lower pitch.
- Apply the same PM reload action tuning to armory reload previews.
- Add a focused AudioManager regression test for the volume/pitch relationship.

Fixes Jhon-Crow/godot-topdown-MVP#1820

## Testing
- PASS: dotnet build
- PASS: git diff --check
- NOT RUN: godot --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/unit/test_audio_manager.gd -gexit (godot binary is not installed in this environment)