### PR TITLE
Fix sewer left wall thickness

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-16T19:36:09.504Z for PR creation at branch issue-1861-5ac815bd0ca1 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1861
+# Updated: 2026-04-16T21:24:03.626Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-16T19:36:09.504Z for PR creation at branch issue-1861-5ac815bd0ca1 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1861
-# Updated: 2026-04-16T21:24:03.626Z

--- a/scenes/levels/SewerLevel.tscn
+++ b/scenes/levels/SewerLevel.tscn
@@ -17,8 +17,8 @@ source_geometry_mode = 0
 source_geometry_group_name = &"navigation_source"
 agent_radius = 24.0
 
-[sub_resource type="RectangleShape2D" id="S_v3200"]
-size = Vector2(24, 3200)
+[sub_resource type="RectangleShape2D" id="S_left_wall"]
+size = Vector2(48, 3200)
 
 [sub_resource type="RectangleShape2D" id="S_h200"]
 size = Vector2(200, 24)
@@ -56,8 +56,8 @@ size = Vector2(40, 40)
 [sub_resource type="RectangleShape2D" id="S_pipe_v"]
 size = Vector2(24, 60)
 
-[sub_resource type="OccluderPolygon2D" id="O_v3200"]
-polygon = PackedVector2Array(-12, -1600, 12, -1600, 12, 1600, -12, 1600)
+[sub_resource type="OccluderPolygon2D" id="O_left_wall"]
+polygon = PackedVector2Array(-24, -1600, 24, -1600, 24, 1600, -24, 1600)
 
 [sub_resource type="OccluderPolygon2D" id="O_h200"]
 polygon = PackedVector2Array(-100, -12, 100, -12, 100, 12, -100, 12)
@@ -375,22 +375,22 @@ color = Color(0.11, 0.13, 0.11, 1)
 [node name="Walls" type="Node2D" parent="Environment"]
 
 [node name="WallLeft" type="StaticBody2D" parent="Environment/Walls"]
-position = Vector2(100, 1600)
+position = Vector2(88, 1600)
 collision_layer = 4
 collision_mask = 0
 
 [node name="ColorRect" type="ColorRect" parent="Environment/Walls/WallLeft"]
-offset_left = -12.0
+offset_left = -24.0
 offset_top = -1600.0
-offset_right = 12.0
+offset_right = 24.0
 offset_bottom = 1600.0
 color = Color(0.18, 0.22, 0.18, 1)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Environment/Walls/WallLeft"]
-shape = SubResource("S_v3200")
+shape = SubResource("S_left_wall")
 
 [node name="LightOccluder2D" type="LightOccluder2D" parent="Environment/Walls/WallLeft"]
-occluder = SubResource("O_v3200")
+occluder = SubResource("O_left_wall")
 
 [node name="WallBottom" type="StaticBody2D" parent="Environment/Walls"]
 position = Vector2(200, 3188)

--- a/tests/unit/test_sewer_level.gd
+++ b/tests/unit/test_sewer_level.gd
@@ -39,6 +39,10 @@ class MockSewerLevel:
 	var map_width: int = 1200
 	var map_height: int = 3200
 
+	## Far-left impassable wall bounds.
+	var left_wall_position: Vector2 = Vector2(88, 1600)
+	var left_wall_size: Vector2 = Vector2(48, 3200)
+
 	## Initialize with enemies.
 	func initialize(enemy_count: int) -> void:
 		_enemies.clear()
@@ -154,6 +158,17 @@ func test_player_exit_blocked_before_clear() -> void:
 func test_map_dimensions() -> void:
 	assert_eq(level.map_width, 1200, "Sewer map width should be 1200 (corridor + right branch)")
 	assert_eq(level.map_height, 3200, "Sewer map height should be 3200 (long corridor)")
+
+
+func test_left_wall_is_thickened_left_without_narrowing_corridor() -> void:
+	var left_edge := level.left_wall_position.x - level.left_wall_size.x / 2.0
+	var right_edge := level.left_wall_position.x + level.left_wall_size.x / 2.0
+	assert_eq(level.left_wall_size, Vector2(48, 3200),
+		"Far-left wall should be twice as thick to block illusion pathing")
+	assert_eq(left_edge, 64.0,
+		"Far-left wall should extend left from its old 24px footprint")
+	assert_eq(right_edge, 112.0,
+		"Far-left wall right edge should stay aligned with the corridor floor")
 
 
 func test_double_exit_prevented() -> void:


### PR DESCRIPTION
## Summary

Fixes #1806 by thickening the far-left impassable wall on the Sewer map.

## Changes

- Doubled `WallLeft` collision/visual/occluder width from 24px to 48px.
- Shifted the wall center from `x=100` to `x=88`, preserving the right edge at `x=112` so the playable corridor is not narrowed.
- Added a sewer unit regression assertion documenting the expected left wall bounds: `x=64..112`, height `3200`.

## Testing

- `python3 tests/test_icon_ico.py`
- `git diff --check`
- Custom structural scene check verifying `WallLeft` position, shape, visual offsets, and occluder bounds.

Full GUT tests were not run locally because no `godot`/`godot4` executable is installed in the workspace PATH.
