### PR TITLE
Fix pacifist drone operators leaving aggressive drones

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-17T20:51:43.605Z for PR creation at branch issue-1868-abf320d995bd for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1868

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-17T20:51:43.605Z for PR creation at branch issue-1868-abf320d995bd for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1868

--- a/docs/case-studies/issue-1868/README.md
+++ b/docs/case-studies/issue-1868/README.md
@@ -1,0 +1,42 @@
+# Issue 1868 Case Study
+
+## Source Data
+
+- `game_log_20260418_010143.txt`: user-provided exported Windows build log, 3,239 lines.
+- `game_log_20260418_010323.txt`: user-provided exported Windows build log, 1,718 lines.
+
+## Timeline Reconstruction
+
+### Log `game_log_20260418_010323.txt`
+
+- 01:03:23: the save restores the Loudspeaker active item at level 7.
+- 01:03:24: the labyrinth level starts and all initial enemies transition to `PACIFIST`.
+- 01:03:25: the railway-station level loads and creates four `Exit_DroneOperator*` enemies.
+- 01:03:25: the level-7 loudspeaker victory state runs again and transitions the railway-station enemies, including all four drone operators, to `PACIFIST`.
+- 01:03:26: despite those pacifist transitions, the drone-operator component reports `Reached cover, deploying drone in 0.5s` for all four operators.
+- 01:03:26: all four operators instantiate drones and enter `Phase: CONTROLLING (defenseless)`.
+
+### Log `game_log_20260418_010143.txt`
+
+- 01:02:21-01:02:24: ordinary enemies continue logging `state=PACIFIST` while drone operators repeatedly log `FLANKING corner check`, showing they are no longer following the pacifist state machine.
+- 01:02:25: `Exit_DroneOperator2` logs `state=FLANKING`, then `State: FLANKING -> COMBAT`.
+- 01:02:26: `Exit_DroneOperator2` emits enemy gunshot sounds.
+- 01:02:27-01:02:30: `Exit_DroneOperator1`, `Exit_DroneOperator3`, and `Exit_DroneOperator4` also transition through `FLANKING`/`COMBAT` and emit enemy gunshot sounds.
+
+## Root Cause
+
+The previous fix neutralized a drone after its linked operator was already pacifist, but the operator component still ran its normal DEPLOYING/CONTROLLING loop before normal pacifist processing in `enemy.gd`. In the level-7 victory state, newly spawned railway-station drone operators became pacifist, but their `DroneOperatorComponent` still sought cover, deployed drones, and later allowed ACTIVE/operator combat behavior to resume.
+
+A secondary risk is that pacifism did not explicitly clear an existing aggression component state. If an enemy had aggression/combat residue before becoming pacifist, later AI ticks could observe stale aggressive state.
+
+## Implemented Solution
+
+- `DroneOperatorComponent.update()` now returns immediately when its parent is pacifist. If a controlled drone still exists, it is neutralized before returning.
+- `enemy.gd` now checks the pacifist drone-operator case before the normal drone-operator phase-control branch, so pacifist operators cannot seek cover or deploy drones.
+- `_transition_to_pacifist()` clears the aggression component state to prevent stale aggressive behavior after pacification.
+
+## Verification Added
+
+- `tests/unit/test_drone_operator.gd` checks that `DroneOperatorComponent.update()` has the pacifist early return.
+- `tests/unit/test_drone_operator.gd` checks that `enemy.gd` runs the Issue #1868 pacifist guard before normal Issue #1397 drone-operator phase control.
+- Existing `tests/unit/test_drone.gd` still covers spawned drones dying when their operator becomes pacifist.

--- a/docs/case-studies/issue-1868/game_log_20260418_010143.txt
+++ b/docs/case-studies/issue-1868/game_log_20260418_010143.txt
@@ -1,0 +1,3239 @@
+[01:01:43] [INFO] ============================================================
+[01:01:43] [INFO] GAME LOG STARTED
+[01:01:43] [INFO] ============================================================
+[01:01:43] [INFO] Timestamp: 2026-04-18T01:01:43
+[01:01:43] [INFO] Log file: I:/Загрузки/godot exe/АКТИВНЫЙ ПРЕДМЕТ/game_log_20260418_010143.txt
+[01:01:43] [INFO] Executable: I:/Загрузки/godot exe/АКТИВНЫЙ ПРЕДМЕТ/Godot-Top-Down-Template.exe
+[01:01:43] [INFO] OS: Windows
+[01:01:43] [INFO] Debug build: false
+[01:01:43] [INFO] Engine version: 4.3-stable (official)
+[01:01:43] [INFO] Project: Godot Top-Down Template
+[01:01:43] [INFO] Build info: not available (build_info.cfg not found)
+[01:01:43] [INFO] ------------------------------------------------------------
+[01:01:43] [INFO] [GameManager] GameManager ready
+[01:01:43] [INFO] [ScoreManager] ScoreManager ready
+[01:01:43] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[01:01:43] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[01:01:43] [INFO] [DifficultyManager] Loaded difficulty: Normal (value: 1)
+[01:01:43] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[01:01:43] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[01:01:43] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[01:01:43] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[01:01:43] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[01:01:43] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[01:01:43] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[01:01:43] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[01:01:43] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[01:01:43] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[01:01:43] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[01:01:43] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[01:01:43] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[01:01:43] [INFO] [LastChance] Resetting all effects (scene change detected)
+[01:01:43] [INFO] [LastChance] Last chance shader loaded successfully
+[01:01:43] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[01:01:43] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[01:01:43] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[01:01:43] [INFO] [LastChance]   Sepia intensity: 0.70
+[01:01:43] [INFO] [LastChance]   Brightness: 0.60
+[01:01:43] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[01:01:43] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[01:01:43] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[01:01:43] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[01:01:43] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DroneGrenade.tscn
+[01:01:43] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: true, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: false, FPS drop logging: true, All weapons unlocked: false, All maps unlocked: true, Global stuck max time: 20.0s, Nav mesh visible: false, Search path visible: false, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false, Enemy path visible: false, Cover raycast visible: false, Tactical group: false, Cover infinite rays: true, Cover sector rays: true, Roguelike unlocked: true
+[01:01:43] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[01:01:43] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.50, music: 1.00
+[01:01:43] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true, revolver_aim_assist: true, combo_font_size: 140
+[01:01:43] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[01:01:43] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[01:01:43] [INFO] [CinemaEffects] Created effects layer at layer 99
+[01:01:43] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[01:01:43] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[01:01:43] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[01:01:43] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[01:01:43] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[01:01:43] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[01:01:43] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[01:01:43] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[01:01:43] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[01:01:43] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[01:01:43] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[01:01:43] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[01:01:43] [INFO] [GrenadeTimerHelper] Autoload ready
+[01:01:43] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[01:01:43] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[01:01:43] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[01:01:43] [INFO] [PowerFantasy]   Kill effect duration: 600ms
+[01:01:43] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[01:01:43] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[01:01:43] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[01:01:43] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[01:01:43] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[01:01:43] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[01:01:43] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[01:01:43] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[01:01:43] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[01:01:43] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[01:01:43] [INFO] [ProgressManager] ProgressManager ready, loaded 14 entries
+[01:01:43] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[01:01:43] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[01:01:43] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[01:01:43] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[01:01:43] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[01:01:43] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[01:01:43] [INFO] [SceneLoader] SceneLoader initialized
+[01:01:43] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[01:01:43] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[01:01:43] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[01:01:43] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[01:01:43] [INFO] [PersistManager] Restored kills_without_laser_sight: 396
+[01:01:43] [INFO] [PersistManager] Restored shots_fired_special_weapons: 735
+[01:01:43] [INFO] [PersistManager] Restored total_deaths: 109
+[01:01:43] [INFO] [PersistManager] Restored no_damage_levels_completed: 8
+[01:01:43] [INFO] [PersistManager] Restored levels_completed_rank_a_or_higher: 5
+[01:01:43] [INFO] [PersistManager] Restored kills_through_wall: 1
+[01:01:43] [INFO] [PersistManager] Restored levels_completed_with_silenced_pistol: 0
+[01:01:43] [INFO] [GameManager] Weapon selected: ak_gl
+[01:01:43] [INFO] [PersistManager] Restored selected weapon: ak_gl
+[01:01:43] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[01:01:43] [INFO] [PersistManager] Restored selected grenade type: 0
+[01:01:43] [INFO] [PersistManager] Restored unlocked active item type: 0
+[01:01:43] [INFO] [PersistManager] Restored unlocked active item type: 11
+[01:01:43] [INFO] [ActiveItemManager] Active item changed from None to Loudspeaker
+[01:01:43] [INFO] [PersistManager] Restored selected active item type: 11
+[01:01:43] [INFO] [PersistManager] Loudspeaker progress restored: level 7, levels_completed=11
+[01:01:43] [INFO] [PersistManager] State loaded successfully
+[01:01:43] [INFO] [PersistManager] PersistManager ready
+[01:01:43] [INFO] [UnlockManager] UnlockManager ready
+[01:01:43] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["makarov_pm", "mini_uzi", "shotgun", "sniper", "revolver", "m16", "silenced_pistol", "ak_gl"]
+[01:01:43] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, warm_lights: true, ai: true
+[01:01:43] [INFO] [LocalizationSettings] Loaded 2 translation(s)
+[01:01:43] [INFO] [LocalizationSettings] LocalizationSettings initialized — locale: en
+[01:01:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:43] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[01:01:43] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[01:01:43] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[01:01:43] [ENEMY] [Enemy1] Death animation component initialized
+[01:01:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:43] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[01:01:43] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[01:01:43] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[01:01:43] [ENEMY] [Enemy2] Death animation component initialized
+[01:01:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:43] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[01:01:43] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[01:01:43] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[01:01:43] [ENEMY] [Enemy3] Death animation component initialized
+[01:01:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:43] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[01:01:43] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[01:01:43] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[01:01:43] [ENEMY] [Enemy4] Death animation component initialized
+[01:01:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:43] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[01:01:43] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[01:01:43] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[01:01:43] [ENEMY] [Enemy5] Death animation component initialized
+[01:01:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:43] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[01:01:43] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[01:01:43] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[01:01:43] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[01:01:43] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[01:01:43] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[01:01:43] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[01:01:43] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[01:01:43] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[01:01:43] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[01:01:43] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[01:01:43] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[01:01:43] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[01:01:43] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[01:01:43] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[01:01:43] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[01:01:43] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[01:01:43] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[01:01:43] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[01:01:43] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[01:01:43] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[01:01:43] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[01:01:43] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[01:01:43] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[01:01:43] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[01:01:43] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[01:01:43] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[01:01:43] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[01:01:43] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[01:01:43] [INFO] [Player.ItemVisual] Visual applied for item type: 11
+[01:01:43] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[01:01:43] [INFO] [Player.Loudspeaker] Loudspeaker selected, initializing...
+[01:01:43] [INFO] [Player.Loudspeaker] Loudspeaker equipped, level: 7, charges: 0/unlimited, effect: 90%, used_this_level: False, all_charges_used: False
+[01:01:43] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[01:01:43] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[01:01:43] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[01:01:43] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[01:01:43] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[01:01:43] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[01:01:43] [INFO] [Player.Jammer] JammerHUD initialized
+[01:01:43] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[01:01:43] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[01:01:43] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[01:01:43] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[01:01:43] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[01:01:43] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[01:01:43] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[01:01:43] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[01:01:43] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[01:01:43] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[01:01:43] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[01:01:43] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[01:01:43] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[01:01:43] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/30
+[01:01:43] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[01:01:43] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/30
+[01:01:43] [INFO] [GameManager] set_player() called with: <CharacterBody2D#86486550283> (class: CharacterBody2D)
+[01:01:43] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[01:01:43] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[01:01:43] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[01:01:43] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[01:01:43] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[01:01:43] [INFO] [ScoreManager] Level started with 5 enemies
+[01:01:43] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[01:01:43] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[01:01:43] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[01:01:43] [INFO] [ReplayManager] Replay data cleared
+[01:01:43] [INFO] [LabyrinthLevel] Previous replay data cleared
+[01:01:43] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[01:01:43] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[01:01:43] [INFO] [ReplayManager] Level: LabyrinthLevel
+[01:01:43] [INFO] [ReplayManager] Player: Player (valid: True)
+[01:01:43] [INFO] [ReplayManager] Enemies count: 5
+[01:01:43] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[01:01:43] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[01:01:43] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[01:01:43] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[01:01:43] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[01:01:43] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[01:01:43] [INFO] [LabyrinthLevel] Replay recording started successfully
+[01:01:43] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[01:01:44] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[01:01:44] [INFO] [CinemaEffects] Found player node: Player
+[01:01:44] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[01:01:44] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/RevolverLevel.tscn
+[01:01:44] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/RevolverLevel.tscn
+[01:01:44] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[01:01:44] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[01:01:44] [INFO] [UnlockManager] Restored saved unlock for weapon: ak_gl
+[01:01:44] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[01:01:44] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[01:01:44] [ENEMY] [Enemy1] Registered as sound listener
+[01:01:44] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 2, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[01:01:44] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[01:01:44] [ENEMY] [Enemy2] Registered as sound listener
+[01:01:44] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[01:01:44] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[01:01:44] [ENEMY] [Enemy3] Registered as sound listener
+[01:01:44] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 2, behavior: PATROL
+[01:01:44] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[01:01:44] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[01:01:44] [ENEMY] [Enemy4] Registered as sound listener
+[01:01:44] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[01:01:44] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[01:01:44] [ENEMY] [Enemy5] Registered as sound listener
+[01:01:44] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 4, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[01:01:44] [INFO] [Player.Loudspeaker] Level 7 victory state — all enemies start as pacifists!
+[01:01:44] [ENEMY] [Enemy1] Transitioned to PACIFIST
+[01:01:44] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:01:44] [ENEMY] [Enemy2] Transitioned to PACIFIST
+[01:01:44] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:01:44] [ENEMY] [Enemy3] Transitioned to PACIFIST
+[01:01:44] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:01:44] [ENEMY] [Enemy4] Transitioned to PACIFIST
+[01:01:44] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:01:44] [ENEMY] [Enemy5] Transitioned to PACIFIST
+[01:01:44] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:01:44] [INFO] [Player.Loudspeaker] Victory message shown (Level 7)
+[01:01:44] [ENEMY] [Enemy1] Found cover at (386.9966, 474.5157) (distance: 175.0, player at (150, 1000))
+[01:01:44] [ENEMY] [Enemy2] Found cover at (699.5566, 1128) (distance: 268.1, player at (150, 1000))
+[01:01:44] [ENEMY] [Enemy3] Found cover at (708.7476, 1128) (distance: 507.7, player at (150, 1000))
+[01:01:44] [ENEMY] [Enemy4] Found cover at (701.3369, 1128) (distance: 1062.3, player at (150, 1000))
+[01:01:44] [ENEMY] [Enemy5] Found cover at (484.2751, 480.5201) (distance: 1031.6, player at (150, 1000))
+[01:01:44] [ENEMY] [Enemy1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=94.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:01:44] [ENEMY] [Enemy2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=138.4°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:01:44] [ENEMY] [Enemy3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=165.4°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:01:44] [ENEMY] [Enemy4] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=153.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:01:44] [ENEMY] [Enemy5] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=169.9°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:01:44] [INFO] [Player] Detecting weapon pose (frame 3)...
+[01:01:44] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[01:01:44] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[01:01:44] [INFO] [PenultimateHit] Shader warmup complete in 1279 ms
+[01:01:44] [INFO] [LastChance] Shader warmup complete in 1278 ms
+[01:01:44] [INFO] [CinemaEffects] Cinema shader warmup complete in 1154 ms
+[01:01:44] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1145 ms
+[01:01:44] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[01:01:44] [INFO] [FlashbangPlayer] Shader warmup complete in 1142 ms
+[01:01:44] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[01:01:44] [INFO] [SceneLoader] ERROR: Invalid resource (falling back to sync): res://scenes/levels/RevolverLevel.tscn
+[01:01:44] [INFO] [SceneLoader] Using synchronous load fallback
+[01:01:44] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[01:01:44] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[01:01:44] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[01:01:44] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[01:01:44] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[01:01:44] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:01:44] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:TopEnemy1] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:TopEnemy1] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:TopEnemy1] BloodyFeetComponent ready on TopEnemy1
+[01:01:44] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[01:01:44] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:01:44] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[01:01:44] [INFO] [LastChance] Resetting all effects (scene change detected)
+[01:01:44] [INFO] [CinemaEffects] Scene changed to: RevolverLevel
+[01:01:44] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[01:01:44] [INFO] [BlackMetalEffectsManager] Scene changed to: RevolverLevel
+[01:01:44] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[01:01:44] [INFO] [PersistManager] Startup navigation complete — arrived at: res://scenes/levels/RevolverLevel.tscn
+[01:01:44] [INFO] [PersistManager] State saved to user://game_state.cfg
+[01:01:44] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RevolverLevel.tscn
+[01:01:44] [ENEMY] [TopEnemy1] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:TopEnemy2] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:TopEnemy2] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:TopEnemy2] BloodyFeetComponent ready on TopEnemy2
+[01:01:44] [ENEMY] [TopEnemy2] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:TopEnemy3] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:TopEnemy3] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:TopEnemy3] BloodyFeetComponent ready on TopEnemy3
+[01:01:44] [ENEMY] [TopEnemy3] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy1] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy1] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy1] BloodyFeetComponent ready on BottomEnemy1
+[01:01:44] [ENEMY] [BottomEnemy1] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy2] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy2] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy2] BloodyFeetComponent ready on BottomEnemy2
+[01:01:44] [ENEMY] [BottomEnemy2] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy3] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy3] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy3] BloodyFeetComponent ready on BottomEnemy3
+[01:01:44] [ENEMY] [BottomEnemy3] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard1] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard1] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard1] BloodyFeetComponent ready on ReloadGuard1
+[01:01:44] [ENEMY] [ReloadGuard1] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard2] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard2] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard2] BloodyFeetComponent ready on ReloadGuard2
+[01:01:44] [ENEMY] [ReloadGuard2] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard3] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard3] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard3] BloodyFeetComponent ready on ReloadGuard3
+[01:01:44] [ENEMY] [ReloadGuard3] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard4] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard4] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard4] BloodyFeetComponent ready on ReloadGuard4
+[01:01:44] [ENEMY] [ReloadGuard4] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:FinalEnemy1] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:FinalEnemy1] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:FinalEnemy1] BloodyFeetComponent ready on FinalEnemy1
+[01:01:44] [ENEMY] [FinalEnemy1] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:FinalEnemy2] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:FinalEnemy2] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:FinalEnemy2] BloodyFeetComponent ready on FinalEnemy2
+[01:01:44] [ENEMY] [FinalEnemy2] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:ForceFieldEnemy] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:ForceFieldEnemy] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:ForceFieldEnemy] BloodyFeetComponent ready on ForceFieldEnemy
+[01:01:44] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:01:44] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:01:44] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:01:44] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:01:44] [ENEMY] [ForceFieldEnemy] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:ArmoredSkinEnemy] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:ArmoredSkinEnemy] Found EnemyModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:ArmoredSkinEnemy] BloodyFeetComponent ready on ArmoredSkinEnemy
+[01:01:44] [INFO] [EnemyArmoredSkin] Armor shader applied to 4 sprites
+[01:01:44] [ENEMY] [ArmoredSkinEnemy] Death animation component initialized
+[01:01:44] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:44] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[01:01:44] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[01:01:44] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[01:01:44] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[01:01:44] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[01:01:44] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[01:01:44] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[01:01:44] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[01:01:44] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[01:01:44] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[01:01:44] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[01:01:44] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[01:01:44] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[01:01:44] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[01:01:44] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[01:01:44] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[01:01:44] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[01:01:44] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[01:01:44] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[01:01:44] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[01:01:44] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[01:01:44] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[01:01:44] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[01:01:44] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[01:01:44] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[01:01:44] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[01:01:44] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[01:01:44] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[01:01:44] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[01:01:44] [INFO] [Player.ItemVisual] Visual applied for item type: 11
+[01:01:44] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[01:01:44] [INFO] [Player.Loudspeaker] Loudspeaker selected, initializing...
+[01:01:44] [INFO] [Player.Loudspeaker] Loudspeaker equipped, level: 7, charges: 0/unlimited, effect: 90%, used_this_level: False, all_charges_used: False
+[01:01:44] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[01:01:44] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[01:01:44] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[01:01:44] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[01:01:44] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[01:01:44] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[01:01:44] [INFO] [Player.Jammer] JammerHUD initialized
+[01:01:44] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[01:01:44] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[01:01:44] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[01:01:44] [INFO] [RevolverLevel] Found Environment/Enemies node with 14 children
+[01:01:44] [INFO] [RevolverLevel] Enemy tracking complete: 14 enemies registered
+[01:01:44] [INFO] [GameManager] set_player() called with: <CharacterBody2D#209866198586> (class: CharacterBody2D)
+[01:01:44] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[01:01:44] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[01:01:44] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[01:01:44] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[01:01:44] [INFO] [RevolverLevel] Camera2D limits set — top=64 bottom=1664 left=64 right=2064 — Issue #1682
+[01:01:44] [INFO] [ScoreManager] Level started with 14 enemies
+[01:01:44] [INFO] [RevolverLevel] ReplayManager found as C# autoload - verified OK
+[01:01:44] [INFO] [RevolverLevel] Starting replay recording - Player: Player, Enemies count: 14
+[01:01:44] [INFO] [ReplayManager] Replay data cleared
+[01:01:44] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[01:01:44] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[01:01:44] [INFO] [ReplayManager] Level: RevolverLevel
+[01:01:44] [INFO] [ReplayManager] Player: Player (valid: True)
+[01:01:44] [INFO] [ReplayManager] Enemies count: 14
+[01:01:44] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[01:01:44] [INFO] [ReplayManager]   Enemy 0: TopEnemy1
+[01:01:44] [INFO] [ReplayManager]   Enemy 1: TopEnemy2
+[01:01:44] [INFO] [ReplayManager]   Enemy 2: TopEnemy3
+[01:01:44] [INFO] [ReplayManager]   Enemy 3: BottomEnemy1
+[01:01:44] [INFO] [ReplayManager]   Enemy 4: BottomEnemy2
+[01:01:44] [INFO] [ReplayManager]   Enemy 5: BottomEnemy3
+[01:01:44] [INFO] [ReplayManager]   Enemy 6: ReloadGuard1
+[01:01:44] [INFO] [ReplayManager]   Enemy 7: ReloadGuard2
+[01:01:44] [INFO] [ReplayManager]   Enemy 8: ReloadGuard3
+[01:01:44] [INFO] [ReplayManager]   Enemy 9: ReloadGuard4
+[01:01:44] [INFO] [ReplayManager]   Enemy 10: FinalEnemy1
+[01:01:44] [INFO] [ReplayManager]   Enemy 11: FinalEnemy2
+[01:01:44] [INFO] [ReplayManager]   Enemy 12: ForceFieldEnemy
+[01:01:44] [INFO] [ReplayManager]   Enemy 13: ArmoredSkinEnemy
+[01:01:44] [INFO] [RevolverLevel] Replay recording started successfully
+[01:01:44] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[01:01:44] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[01:01:44] [INFO] [BloodyFeet:TopEnemy1] Blood detector created and attached to TopEnemy1
+[01:01:44] [INFO] [CinemaEffects] Found player node: Player
+[01:01:44] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[01:01:44] [INFO] [SoundPropagation] Registered listener: TopEnemy1 (total: 1)
+[01:01:44] [ENEMY] [TopEnemy1] Registered as sound listener
+[01:01:44] [ENEMY] [TopEnemy1] Spawned at (620, 550), hp: 3, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:TopEnemy2] Blood detector created and attached to TopEnemy2
+[01:01:44] [INFO] [SoundPropagation] Registered listener: TopEnemy2 (total: 2)
+[01:01:44] [ENEMY] [TopEnemy2] Registered as sound listener
+[01:01:44] [ENEMY] [TopEnemy2] Spawned at (740, 550), hp: 3, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:TopEnemy3] Blood detector created and attached to TopEnemy3
+[01:01:44] [INFO] [SoundPropagation] Registered listener: TopEnemy3 (total: 3)
+[01:01:44] [ENEMY] [TopEnemy3] Registered as sound listener
+[01:01:44] [ENEMY] [TopEnemy3] Spawned at (860, 550), hp: 2, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy1] Blood detector created and attached to BottomEnemy1
+[01:01:44] [INFO] [SoundPropagation] Registered listener: BottomEnemy1 (total: 4)
+[01:01:44] [ENEMY] [BottomEnemy1] Registered as sound listener
+[01:01:44] [ENEMY] [BottomEnemy1] Spawned at (620, 1150), hp: 4, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy2] Blood detector created and attached to BottomEnemy2
+[01:01:44] [INFO] [SoundPropagation] Registered listener: BottomEnemy2 (total: 5)
+[01:01:44] [ENEMY] [BottomEnemy2] Registered as sound listener
+[01:01:44] [ENEMY] [BottomEnemy2] Spawned at (740, 1150), hp: 4, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:BottomEnemy3] Blood detector created and attached to BottomEnemy3
+[01:01:44] [INFO] [SoundPropagation] Registered listener: BottomEnemy3 (total: 6)
+[01:01:44] [ENEMY] [BottomEnemy3] Registered as sound listener
+[01:01:44] [ENEMY] [BottomEnemy3] Spawned at (860, 1150), hp: 2, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard1] Blood detector created and attached to ReloadGuard1
+[01:01:44] [INFO] [SoundPropagation] Registered listener: ReloadGuard1 (total: 7)
+[01:01:44] [ENEMY] [ReloadGuard1] Registered as sound listener
+[01:01:44] [ENEMY] [ReloadGuard1] Spawned at (1180, 500), hp: 3, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard2] Blood detector created and attached to ReloadGuard2
+[01:01:44] [INFO] [SoundPropagation] Registered listener: ReloadGuard2 (total: 8)
+[01:01:44] [ENEMY] [ReloadGuard2] Registered as sound listener
+[01:01:44] [ENEMY] [ReloadGuard2] Spawned at (1180, 600), hp: 3, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard3] Blood detector created and attached to ReloadGuard3
+[01:01:44] [INFO] [SoundPropagation] Registered listener: ReloadGuard3 (total: 9)
+[01:01:44] [ENEMY] [ReloadGuard3] Registered as sound listener
+[01:01:44] [ENEMY] [ReloadGuard3] Spawned at (1180, 1100), hp: 3, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:ReloadGuard4] Blood detector created and attached to ReloadGuard4
+[01:01:44] [INFO] [SoundPropagation] Registered listener: ReloadGuard4 (total: 10)
+[01:01:44] [ENEMY] [ReloadGuard4] Registered as sound listener
+[01:01:44] [ENEMY] [ReloadGuard4] Spawned at (1180, 1200), hp: 2, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:FinalEnemy1] Blood detector created and attached to FinalEnemy1
+[01:01:44] [INFO] [SoundPropagation] Registered listener: FinalEnemy1 (total: 11)
+[01:01:44] [ENEMY] [FinalEnemy1] Registered as sound listener
+[01:01:44] [ENEMY] [FinalEnemy1] Spawned at (1850, 700), hp: 4, behavior: PATROL
+[01:01:44] [INFO] [BloodyFeet:FinalEnemy2] Blood detector created and attached to FinalEnemy2
+[01:01:44] [INFO] [SoundPropagation] Registered listener: FinalEnemy2 (total: 12)
+[01:01:44] [ENEMY] [FinalEnemy2] Registered as sound listener
+[01:01:44] [ENEMY] [FinalEnemy2] Spawned at (1850, 1000), hp: 3, behavior: PATROL
+[01:01:44] [INFO] [BloodyFeet:ForceFieldEnemy] Blood detector created and attached to ForceFieldEnemy
+[01:01:44] [INFO] [SoundPropagation] Registered listener: ForceFieldEnemy (total: 13)
+[01:01:44] [ENEMY] [ForceFieldEnemy] Registered as sound listener
+[01:01:44] [ENEMY] [ForceFieldEnemy] Spawned at (1600, 850), hp: 4, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:ArmoredSkinEnemy] Blood detector created and attached to ArmoredSkinEnemy
+[01:01:44] [INFO] [SoundPropagation] Registered listener: ArmoredSkinEnemy (total: 14)
+[01:01:44] [ENEMY] [ArmoredSkinEnemy] Registered as sound listener
+[01:01:44] [ENEMY] [ArmoredSkinEnemy] Spawned at (1700, 1050), hp: 4, behavior: GUARD
+[01:01:44] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[01:01:44] [INFO] [Player.Loudspeaker] Level 7 victory state — all enemies start as pacifists!
+[01:01:44] [ENEMY] [TopEnemy1] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [TopEnemy2] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [TopEnemy3] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [BottomEnemy1] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [BottomEnemy2] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [BottomEnemy3] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [ReloadGuard1] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [ReloadGuard2] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [ReloadGuard3] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [ReloadGuard4] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [FinalEnemy1] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [FinalEnemy2] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [ForceFieldEnemy] Transitioned to PACIFIST
+[01:01:44] [ENEMY] [ArmoredSkinEnemy] Transitioned to PACIFIST
+[01:01:44] [INFO] [Player.Loudspeaker] Victory message shown (Level 7)
+[01:01:44] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 14) - skipping fallback
+[01:01:44] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=14
+[01:01:44] [ENEMY] [TopEnemy1] Found cover at (658.015, 644) (distance: 101.4, player at (200, 850))
+[01:01:44] [ENEMY] [TopEnemy2] Found cover at (745.7833, 644) (distance: 94.2, player at (200, 850))
+[01:01:44] [ENEMY] [TopEnemy3] Found cover at (847.811, 644) (distance: 94.8, player at (200, 850))
+[01:01:44] [ENEMY] [BottomEnemy1] Found cover at (604.7142, 1039.009) (distance: 112.0, player at (200, 850))
+[01:01:44] [ENEMY] [BottomEnemy2] Found cover at (745.7838, 1042.101) (distance: 108.1, player at (200, 850))
+[01:01:44] [ENEMY] [BottomEnemy3] Found cover at (847.8107, 1031.121) (distance: 119.5, player at (200, 850))
+[01:01:44] [ENEMY] [ReloadGuard1] Found cover at (1124, 674.6619) (distance: 183.4, player at (200, 850))
+[01:01:44] [ENEMY] [ReloadGuard2] Found cover at (1124, 684.0201) (distance: 101.0, player at (200, 850))
+[01:01:44] [ENEMY] [ReloadGuard3] Found cover at (1092.979, 1015.98) (distance: 121.0, player at (200, 850))
+[01:01:44] [ENEMY] [ReloadGuard4] Found cover at (1116.521, 1025.338) (distance: 185.8, player at (200, 850))
+[01:01:45] [ENEMY] [FinalEnemy1] Found cover at (1944, 600.579) (distance: 136.8, player at (200, 850))
+[01:01:45] [ENEMY] [FinalEnemy2] Found cover at (1944, 1099.421) (distance: 136.8, player at (200, 850))
+[01:01:45] [ENEMY] [ForceFieldEnemy] Found cover at (1407.994, 1037.515) (distance: 268.4, player at (200, 850))
+[01:01:45] [ENEMY] [ArmoredSkinEnemy] Found cover at (1944, 1095.25) (distance: 248.2, player at (200, 850))
+[01:01:45] [ENEMY] [TopEnemy1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=0.0°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [TopEnemy2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=86.5°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [TopEnemy3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=97.4°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [BottomEnemy1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-97.8°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [BottomEnemy2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-86.9°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [BottomEnemy3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-95.9°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [ReloadGuard1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=180.0°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [ReloadGuard2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=90.0°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [ReloadGuard3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-112.8°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [ReloadGuard4] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=0.0°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [FinalEnemy1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-46.6°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [FinalEnemy2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=46.6°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [ForceFieldEnemy] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=135.7°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [ENEMY] [ArmoredSkinEnemy] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=10.5°, current=0.0°, player=(200,850), corner_timer=0.00
+[01:01:45] [INFO] [Player] Detecting weapon pose (frame 3)...
+[01:01:45] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[01:01:45] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[01:01:45] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[01:01:45] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[01:01:45] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[01:01:45] [INFO] [LastChance] Found player: Player
+[01:01:45] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[01:01:45] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[01:01:45] [INFO] [LastChance] Connected to player Died signal (C#)
+[01:01:45] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[01:01:45] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 2057 ms
+[01:01:45] [INFO] [SceneLoader] Background load started successfully
+[01:01:45] [WARN] [FPS] Drop detected: 14 fps (threshold: 30)
+[01:01:45] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=14
+[01:01:46] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=14
+[01:01:47] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=14
+[01:01:48] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=14
+[01:01:49] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=14
+[01:01:50] [INFO] [PersistManager] State saved to user://game_state.cfg
+[01:01:50] [INFO] [PersistManager] Last level saved: res://scenes/levels/RailwayStationLevel.tscn
+[01:01:50] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/RailwayStationLevel.tscn
+[01:01:50] [INFO] [SceneLoader] Background load started successfully
+[01:01:50] [INFO] [SceneLoader] Background load complete: res://scenes/levels/RailwayStationLevel.tscn
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: ArmoredSkinEnemy (remaining: 13)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: ForceFieldEnemy (remaining: 12)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: FinalEnemy2 (remaining: 11)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: FinalEnemy1 (remaining: 10)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: ReloadGuard4 (remaining: 9)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: ReloadGuard3 (remaining: 8)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: ReloadGuard2 (remaining: 7)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: ReloadGuard1 (remaining: 6)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: BottomEnemy3 (remaining: 5)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: BottomEnemy2 (remaining: 4)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: BottomEnemy1 (remaining: 3)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: TopEnemy3 (remaining: 2)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: TopEnemy2 (remaining: 1)
+[01:01:50] [INFO] [SoundPropagation] Unregistered listener: TopEnemy1 (remaining: 0)
+[01:01:50] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:01:50] [INFO] [SceneLoader] Scene changed successfully
+[01:01:50] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] BloodyFeetComponent ready on NearTracks_MachineGunnerLeft
+[01:01:50] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[01:01:50] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:01:50] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[01:01:50] [INFO] [LastChance] Resetting all effects (scene change detected)
+[01:01:50] [INFO] [CinemaEffects] Scene changed to: RailwayStationLevel
+[01:01:50] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[01:01:50] [INFO] [BlackMetalEffectsManager] Scene changed to: RailwayStationLevel
+[01:01:50] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[01:01:50] [INFO] [PersistManager] State saved to user://game_state.cfg
+[01:01:50] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RailwayStationLevel.tscn
+[01:01:50] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] BloodyFeetComponent ready on NearTracks_MachineGunnerRight
+[01:01:50] [ENEMY] [NearTracks_MachineGunnerRight] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] BloodyFeetComponent ready on FarTracks_MachineGunnerLeft
+[01:01:50] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] BloodyFeetComponent ready on FarTracks_MachineGunnerRight
+[01:01:50] [ENEMY] [FarTracks_MachineGunnerRight] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] BloodyFeetComponent ready on CentralWalkway_ForceFieldLeft
+[01:01:50] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:01:50] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:01:50] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:01:50] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:01:50] [ENEMY] [CentralWalkway_ForceFieldLeft] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] BloodyFeetComponent ready on CentralWalkway_ForceFieldRight
+[01:01:50] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:01:50] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:01:50] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:01:50] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:01:50] [ENEMY] [CentralWalkway_ForceFieldRight] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator1] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator1] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator1] BloodyFeetComponent ready on Exit_DroneOperator1
+[01:01:50] [ENEMY] [Exit_DroneOperator1] Death animation component initialized
+[01:01:50] [INFO] [DroneOperator] VR headset visual created
+[01:01:50] [INFO] [DroneOperator] Tablet visual created
+[01:01:50] [INFO] [DroneOperator] Setup complete
+[01:01:50] [ENEMY] [Exit_DroneOperator1] Found cover at (721.5328, 1640) (distance: 540.4, player at (2000, 3100))
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator2] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator2] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator2] BloodyFeetComponent ready on Exit_DroneOperator2
+[01:01:50] [ENEMY] [Exit_DroneOperator2] Death animation component initialized
+[01:01:50] [INFO] [DroneOperator] VR headset visual created
+[01:01:50] [INFO] [DroneOperator] Tablet visual created
+[01:01:50] [INFO] [DroneOperator] Setup complete
+[01:01:50] [ENEMY] [Exit_DroneOperator2] Found cover at (1602.407, 1640) (distance: 540.0, player at (2000, 3100))
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator3] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator3] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator3] BloodyFeetComponent ready on Exit_DroneOperator3
+[01:01:50] [ENEMY] [Exit_DroneOperator3] Death animation component initialized
+[01:01:50] [INFO] [DroneOperator] VR headset visual created
+[01:01:50] [INFO] [DroneOperator] Tablet visual created
+[01:01:50] [INFO] [DroneOperator] Setup complete
+[01:01:50] [ENEMY] [Exit_DroneOperator3] Found cover at (2040, 1640) (distance: 709.4, player at (2000, 3100))
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator4] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator4] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Exit_DroneOperator4] BloodyFeetComponent ready on Exit_DroneOperator4
+[01:01:50] [ENEMY] [Exit_DroneOperator4] Death animation component initialized
+[01:01:50] [INFO] [DroneOperator] VR headset visual created
+[01:01:50] [INFO] [DroneOperator] Tablet visual created
+[01:01:50] [INFO] [DroneOperator] Setup complete
+[01:01:50] [ENEMY] [Exit_DroneOperator4] Found cover at (2040, 1640) (distance: 1370.8, player at (2000, 3100))
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] BloodyFeetComponent ready on Spawn_GasMaskEnemy
+[01:01:50] [ENEMY] [Spawn_GasMaskEnemy] Death animation component initialized
+[01:01:50] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterLeft1] BloodyFeetComponent ready on Platform_TeleporterLeft1
+[01:01:50] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft1
+[01:01:50] [ENEMY] [Platform_TeleporterLeft1] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterLeft2] BloodyFeetComponent ready on Platform_TeleporterLeft2
+[01:01:50] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft2
+[01:01:50] [ENEMY] [Platform_TeleporterLeft2] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterLeft3] BloodyFeetComponent ready on Platform_TeleporterLeft3
+[01:01:50] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft3
+[01:01:50] [ENEMY] [Platform_TeleporterLeft3] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterRight1] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterRight1] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterRight1] BloodyFeetComponent ready on Platform_TeleporterRight1
+[01:01:50] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight1
+[01:01:50] [ENEMY] [Platform_TeleporterRight1] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterRight2] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterRight2] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterRight2] BloodyFeetComponent ready on Platform_TeleporterRight2
+[01:01:50] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight2
+[01:01:50] [ENEMY] [Platform_TeleporterRight2] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterRight3] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterRight3] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Platform_TeleporterRight3] BloodyFeetComponent ready on Platform_TeleporterRight3
+[01:01:50] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight3
+[01:01:50] [ENEMY] [Platform_TeleporterRight3] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Platform_ShieldRight] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Platform_ShieldRight] Found EnemyModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Platform_ShieldRight] BloodyFeetComponent ready on Platform_ShieldRight
+[01:01:50] [INFO] [EnemyShield] SWAT riot shield visual created with collision area (top-down view)
+[01:01:50] [INFO] [EnemyShield] Setup complete (shield_hp=20, stun=1.0s)
+[01:01:50] [ENEMY] [Platform_ShieldRight] Death animation component initialized
+[01:01:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:01:50] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[01:01:50] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[01:01:50] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[01:01:50] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[01:01:50] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[01:01:50] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[01:01:50] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[01:01:50] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[01:01:50] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[01:01:50] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[01:01:50] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[01:01:50] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[01:01:50] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[01:01:50] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[01:01:50] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[01:01:50] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[01:01:50] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[01:01:50] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[01:01:50] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[01:01:50] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[01:01:50] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[01:01:50] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[01:01:50] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[01:01:50] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[01:01:50] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[01:01:50] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[01:01:50] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[01:01:50] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[01:01:50] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[01:01:50] [INFO] [Player.ItemVisual] Visual applied for item type: 11
+[01:01:50] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[01:01:50] [INFO] [Player.Loudspeaker] Loudspeaker selected, initializing...
+[01:01:50] [INFO] [Player.Loudspeaker] Loudspeaker equipped, level: 7, charges: 0/unlimited, effect: 90%, used_this_level: False, all_charges_used: False
+[01:01:50] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[01:01:50] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[01:01:50] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[01:01:50] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[01:01:50] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[01:01:50] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[01:01:50] [INFO] [Player.Jammer] JammerHUD initialized
+[01:01:50] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[01:01:50] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[01:01:50] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[01:01:50] [INFO] [RailwayStationLevel] Found Environment/Enemies node with 18 children
+[01:01:50] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldLeft': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldRight': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator1': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator2': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator3': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator4': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Spawn_GasMaskEnemy': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft1': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft2': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft3': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight1': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight2': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight3': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Child 'Platform_ShieldRight': script=true, has_died_signal=true
+[01:01:50] [INFO] [RailwayStationLevel] Enemy tracking complete: 18 enemies registered
+[01:01:50] [INFO] [RailwayStationLevel] Setting up weapon: ak_gl
+[01:01:50] [INFO] [RailwayStationLevel] AKGL already equipped by C# Player - skipping GDScript weapon swap
+[01:01:50] [INFO] [GameManager] set_player() called with: <CharacterBody2D#475600525835> (class: CharacterBody2D)
+[01:01:50] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[01:01:50] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[01:01:50] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[01:01:50] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[01:01:50] [INFO] [ScoreManager] Level started with 18 enemies
+[01:01:50] [INFO] [RailwayStationLevel] ReplayManager found as C# autoload
+[01:01:50] [INFO] [ReplayManager] Replay data cleared
+[01:01:50] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[01:01:50] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[01:01:50] [INFO] [ReplayManager] Level: RailwayStationLevel
+[01:01:50] [INFO] [ReplayManager] Player: Player (valid: True)
+[01:01:50] [INFO] [ReplayManager] Enemies count: 18
+[01:01:50] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[01:01:50] [INFO] [ReplayManager]   Enemy 0: NearTracks_MachineGunnerLeft
+[01:01:50] [INFO] [ReplayManager]   Enemy 1: NearTracks_MachineGunnerRight
+[01:01:50] [INFO] [ReplayManager]   Enemy 2: FarTracks_MachineGunnerLeft
+[01:01:50] [INFO] [ReplayManager]   Enemy 3: FarTracks_MachineGunnerRight
+[01:01:50] [INFO] [ReplayManager]   Enemy 4: CentralWalkway_ForceFieldLeft
+[01:01:50] [INFO] [ReplayManager]   Enemy 5: CentralWalkway_ForceFieldRight
+[01:01:50] [INFO] [ReplayManager]   Enemy 6: Exit_DroneOperator1
+[01:01:50] [INFO] [ReplayManager]   Enemy 7: Exit_DroneOperator2
+[01:01:50] [INFO] [ReplayManager]   Enemy 8: Exit_DroneOperator3
+[01:01:50] [INFO] [ReplayManager]   Enemy 9: Exit_DroneOperator4
+[01:01:50] [INFO] [ReplayManager]   Enemy 10: Spawn_GasMaskEnemy
+[01:01:50] [INFO] [ReplayManager]   Enemy 11: Platform_TeleporterLeft1
+[01:01:50] [INFO] [ReplayManager]   Enemy 12: Platform_TeleporterLeft2
+[01:01:50] [INFO] [ReplayManager]   Enemy 13: Platform_TeleporterLeft3
+[01:01:50] [INFO] [ReplayManager]   Enemy 14: Platform_TeleporterRight1
+[01:01:50] [INFO] [ReplayManager]   Enemy 15: Platform_TeleporterRight2
+[01:01:50] [INFO] [ReplayManager]   Enemy 16: Platform_TeleporterRight3
+[01:01:50] [INFO] [ReplayManager]   Enemy 17: Platform_ShieldRight
+[01:01:50] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[01:01:50] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[01:01:51] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 18) - skipping fallback
+[01:01:51] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Blood detector created and attached to NearTracks_MachineGunnerLeft
+[01:01:51] [INFO] [CinemaEffects] Found player node: Player
+[01:01:51] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[01:01:51] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerLeft (total: 1)
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerLeft] Registered as sound listener
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerLeft] Spawned at (300, 2670), hp: 3, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Blood detector created and attached to NearTracks_MachineGunnerRight
+[01:01:51] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerRight (total: 2)
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerRight] Registered as sound listener
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerRight] Spawned at (3700, 2670), hp: 4, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Blood detector created and attached to FarTracks_MachineGunnerLeft
+[01:01:51] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerLeft (total: 3)
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerLeft] Registered as sound listener
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerLeft] Spawned at (300, 1890), hp: 3, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Blood detector created and attached to FarTracks_MachineGunnerRight
+[01:01:51] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerRight (total: 4)
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerRight] Registered as sound listener
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerRight] Spawned at (3700, 1890), hp: 2, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Blood detector created and attached to CentralWalkway_ForceFieldLeft
+[01:01:51] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldLeft (total: 5)
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldLeft] Registered as sound listener
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldLeft] Spawned at (1700, 2300), hp: 2, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Blood detector created and attached to CentralWalkway_ForceFieldRight
+[01:01:51] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldRight (total: 6)
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldRight] Registered as sound listener
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldRight] Spawned at (2300, 2300), hp: 2, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Exit_DroneOperator1] Blood detector created and attached to Exit_DroneOperator1
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator1 (total: 7)
+[01:01:51] [ENEMY] [Exit_DroneOperator1] Registered as sound listener
+[01:01:51] [ENEMY] [Exit_DroneOperator1] Spawned at (700, 1100), hp: 2, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Exit_DroneOperator2] Blood detector created and attached to Exit_DroneOperator2
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator2 (total: 8)
+[01:01:51] [ENEMY] [Exit_DroneOperator2] Registered as sound listener
+[01:01:51] [ENEMY] [Exit_DroneOperator2] Spawned at (1600, 1100), hp: 2, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Exit_DroneOperator3] Blood detector created and attached to Exit_DroneOperator3
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator3 (total: 9)
+[01:01:51] [ENEMY] [Exit_DroneOperator3] Registered as sound listener
+[01:01:51] [ENEMY] [Exit_DroneOperator3] Spawned at (2500, 1100), hp: 3, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Exit_DroneOperator4] Blood detector created and attached to Exit_DroneOperator4
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator4 (total: 10)
+[01:01:51] [ENEMY] [Exit_DroneOperator4] Registered as sound listener
+[01:01:51] [ENEMY] [Exit_DroneOperator4] Spawned at (3300, 1100), hp: 3, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Blood detector created and attached to Spawn_GasMaskEnemy
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Spawn_GasMaskEnemy (total: 11)
+[01:01:51] [ENEMY] [Spawn_GasMaskEnemy] Registered as sound listener
+[01:01:51] [ENEMY] [Spawn_GasMaskEnemy] Spawned at (900, 3075), hp: 2, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Blood detector created and attached to Platform_TeleporterLeft1
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft1 (total: 12)
+[01:01:51] [ENEMY] [Platform_TeleporterLeft1] Registered as sound listener
+[01:01:51] [ENEMY] [Platform_TeleporterLeft1] Spawned at (200, 3500), hp: 4, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Blood detector created and attached to Platform_TeleporterLeft2
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft2 (total: 13)
+[01:01:51] [ENEMY] [Platform_TeleporterLeft2] Registered as sound listener
+[01:01:51] [ENEMY] [Platform_TeleporterLeft2] Spawned at (400, 3500), hp: 2, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Blood detector created and attached to Platform_TeleporterLeft3
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft3 (total: 14)
+[01:01:51] [ENEMY] [Platform_TeleporterLeft3] Registered as sound listener
+[01:01:51] [ENEMY] [Platform_TeleporterLeft3] Spawned at (600, 3500), hp: 4, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Platform_TeleporterRight1] Blood detector created and attached to Platform_TeleporterRight1
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight1 (total: 15)
+[01:01:51] [ENEMY] [Platform_TeleporterRight1] Registered as sound listener
+[01:01:51] [ENEMY] [Platform_TeleporterRight1] Spawned at (3400, 3500), hp: 3, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Platform_TeleporterRight2] Blood detector created and attached to Platform_TeleporterRight2
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight2 (total: 16)
+[01:01:51] [ENEMY] [Platform_TeleporterRight2] Registered as sound listener
+[01:01:51] [ENEMY] [Platform_TeleporterRight2] Spawned at (3600, 3500), hp: 3, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Platform_TeleporterRight3] Blood detector created and attached to Platform_TeleporterRight3
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight3 (total: 17)
+[01:01:51] [ENEMY] [Platform_TeleporterRight3] Registered as sound listener
+[01:01:51] [ENEMY] [Platform_TeleporterRight3] Spawned at (3800, 3500), hp: 3, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Platform_ShieldRight] Blood detector created and attached to Platform_ShieldRight
+[01:01:51] [INFO] [SoundPropagation] Registered listener: Platform_ShieldRight (total: 18)
+[01:01:51] [ENEMY] [Platform_ShieldRight] Registered as sound listener
+[01:01:51] [ENEMY] [Platform_ShieldRight] Spawned at (3600, 3650), hp: 4, behavior: GUARD
+[01:01:51] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[01:01:51] [INFO] [Player.Loudspeaker] Level 7 victory state — all enemies start as pacifists!
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldLeft] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldRight] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Exit_DroneOperator1] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Exit_DroneOperator2] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Exit_DroneOperator3] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Exit_DroneOperator4] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Spawn_GasMaskEnemy] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Platform_TeleporterLeft1] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Platform_TeleporterLeft2] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Platform_TeleporterLeft3] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Platform_TeleporterRight1] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Platform_TeleporterRight2] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Platform_TeleporterRight3] Transitioned to PACIFIST
+[01:01:51] [ENEMY] [Platform_ShieldRight] Transitioned to PACIFIST
+[01:01:51] [INFO] [Player.Loudspeaker] Victory message shown (Level 7)
+[01:01:51] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=18
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerLeft] Found cover at (259.6942, 1640) (distance: 1030.8, player at (2000, 3100))
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerRight] Found cover at (2040, 1640) (distance: 1953.6, player at (2000, 3100))
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerLeft] Found cover at (283.8475, 1640) (distance: 250.5, player at (2000, 3100))
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerRight] Found cover at (2040, 1640) (distance: 1678.7, player at (2000, 3100))
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldLeft] Found cover at (1702.349, 1640) (distance: 660.0, player at (2000, 3100))
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldRight] Found cover at (2040, 1640) (distance: 709.4, player at (2000, 3100))
+[01:01:51] [ENEMY] [Exit_DroneOperator1] Found cover at (721.5328, 1640) (distance: 540.4, player at (2000, 3100))
+[01:01:51] [ENEMY] [Exit_DroneOperator2] Found cover at (1602.407, 1640) (distance: 540.0, player at (2000, 3100))
+[01:01:51] [ENEMY] [Exit_DroneOperator3] Found cover at (2040, 1640) (distance: 709.4, player at (2000, 3100))
+[01:01:51] [ENEMY] [Exit_DroneOperator4] Found cover at (2040, 1640) (distance: 1370.8, player at (2000, 3100))
+[01:01:51] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (915.174, 1640) (distance: 1435.1, player at (2000, 3100))
+[01:01:51] [ENEMY] [Platform_TeleporterLeft1] Found cover at (142.7924, 1640) (distance: 1860.9, player at (2000, 3100))
+[01:01:51] [ENEMY] [Platform_TeleporterLeft2] Found cover at (371.5359, 1640) (distance: 1860.2, player at (2000, 3100))
+[01:01:51] [ENEMY] [Platform_TeleporterLeft3] Found cover at (553.3558, 1640) (distance: 1860.6, player at (2000, 3100))
+[01:01:51] [ENEMY] [Platform_TeleporterRight1] Found cover at (2040, 1640) (distance: 2304.2, player at (2000, 3100))
+[01:01:51] [ENEMY] [Platform_TeleporterRight2] Found cover at (2040, 1640) (distance: 2427.6, player at (2000, 3100))
+[01:01:51] [ENEMY] [Platform_TeleporterRight3] Found cover at (2040, 1640) (distance: 2560.7, player at (2000, 3100))
+[01:01:51] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[01:01:51] [ENEMY] [Platform_ShieldRight] Found cover at (2040, 1640) (distance: 2544.3, player at (2000, 3100))
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-69.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-116.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-70.5°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-134.4°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-89.8°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-111.5°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-89.6°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-91.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-90.9°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-91.4°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-126.2°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-130.0°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-133.4°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: none -> P4:shield_delayed, state=PACIFIST, target=-161.0°, current=-90.0°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [INFO] [Player] Detecting weapon pose (frame 3)...
+[01:01:51] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[01:01:51] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[01:01:51] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=2.4°, current=-5.7°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[01:01:51] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[01:01:51] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[01:01:51] [INFO] [LastChance] Found player: Player
+[01:01:51] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[01:01:51] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[01:01:51] [INFO] [LastChance] Connected to player Died signal (C#)
+[01:01:51] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[01:01:51] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-11.3°, current=-28.6°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-11.7°, current=-51.6°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:01:51] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:01:51] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:01:51] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:01:51] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-89.4°, current=7.9°, player=(2000,3100), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-169.4°, current=-120.3°, player=(2000,3098), corner_timer=0.00
+[01:01:51] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=10.1°, current=-26.5°, player=(2000,3095), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-170.4°, current=-126.1°, player=(2000,3095), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-130.0°, current=-137.5°, player=(2000,3085), corner_timer=0.00
+[01:01:51] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-133.4°, current=-143.2°, player=(2000,3078), corner_timer=0.00
+[01:01:51] [INFO] [Drone] _ready started
+[01:01:51] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:01:51] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:01:51] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:01:51] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:01:51] [INFO] [Drone] Initialized by operator: Exit_DroneOperator1
+[01:01:51] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:01:51] [INFO] [DroneOperator] Connected to drone.died signal
+[01:01:51] [INFO] [DroneOperator] Drone deployed at (700, 1084)
+[01:01:51] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:01:52] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:01:52] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:01:52] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:01:52] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:01:52] [INFO] [Teleporter] Component initialized on Exit_DroneOperator1
+[01:01:52] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:01:52] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:01:52] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:01:52] [ENEMY] [Exit_DroneOperator1] State: IN_COVER -> PURSUING
+[01:01:52] [INFO] [Drone] _ready started
+[01:01:52] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:01:52] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:01:52] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:01:52] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:01:52] [INFO] [Drone] Initialized by operator: Exit_DroneOperator2
+[01:01:52] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:01:52] [INFO] [DroneOperator] Connected to drone.died signal
+[01:01:52] [INFO] [DroneOperator] Drone deployed at (1600, 1060)
+[01:01:52] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:01:52] [INFO] [Drone] _ready started
+[01:01:52] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:01:52] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:01:52] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:01:52] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:01:52] [INFO] [Drone] Initialized by operator: Exit_DroneOperator3
+[01:01:52] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:01:52] [INFO] [DroneOperator] Connected to drone.died signal
+[01:01:52] [INFO] [DroneOperator] Drone deployed at (2500, 1084)
+[01:01:52] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:01:52] [INFO] [Drone] _ready started
+[01:01:52] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:01:52] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:01:52] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:01:52] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:01:52] [INFO] [Drone] Initialized by operator: Exit_DroneOperator4
+[01:01:52] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:01:52] [INFO] [DroneOperator] Connected to drone.died signal
+[01:01:52] [INFO] [DroneOperator] Drone deployed at (3300, 1084)
+[01:01:52] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:01:52] [ENEMY] [Exit_DroneOperator1] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=56.1°, current=0.0°, player=(2000,3060), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-169.0°, current=-130.0°, player=(2000,3060), corner_timer=0.00
+[01:01:52] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:01:52] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:01:52] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:01:52] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:01:52] [INFO] [Teleporter] Component initialized on Exit_DroneOperator2
+[01:01:52] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:01:52] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:01:52] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:01:52] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:01:52] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:01:52] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:01:52] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:01:52] [INFO] [Teleporter] Component initialized on Exit_DroneOperator3
+[01:01:52] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:01:52] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:01:52] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:01:52] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:01:52] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:01:52] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:01:52] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:01:52] [INFO] [Teleporter] Component initialized on Exit_DroneOperator4
+[01:01:52] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:01:52] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:01:52] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:01:52] [ENEMY] [Exit_DroneOperator2] State: IN_COVER -> PURSUING
+[01:01:52] [ENEMY] [Exit_DroneOperator3] State: IN_COVER -> PURSUING
+[01:01:52] [ENEMY] [Exit_DroneOperator4] State: IN_COVER -> PURSUING
+[01:01:52] [ENEMY] [Exit_DroneOperator2] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=78.4°, current=0.0°, player=(2000,3049), corner_timer=0.00
+[01:01:52] [ENEMY] [Exit_DroneOperator3] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=104.6°, current=0.0°, player=(2000,3049), corner_timer=0.00
+[01:01:52] [ENEMY] [Exit_DroneOperator4] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=124.0°, current=0.0°, player=(2000,3049), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-169.8°, current=-133.4°, player=(2000,3049), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-91.8°, current=-7.7°, player=(2000,3038), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-167.3°, current=-126.2°, player=(2000,3038), corner_timer=0.00
+[01:01:52] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=18
+[01:01:52] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-90.9°, current=-8.8°, player=(2000,3027), corner_timer=0.00
+[01:01:52] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-46.9°, current=9.4°, player=(2000,3016), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-8.1°, current=-24.9°, player=(1999,3005), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-9.2°, current=-26.0°, player=(1996,2995), corner_timer=0.00
+[01:01:52] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=8.2°, current=0.0°, player=(1993,2985), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-133.4°, current=-168.3°, player=(1975,2960), corner_timer=0.00
+[01:01:52] [WARN] [FPS] Drop detected: 17 fps (threshold: 30)
+[01:01:52] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-91.8°, current=-8.5°, player=(1968,2952), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-90.9°, current=-9.6°, player=(1960,2944), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-130.0°, current=-167.1°, player=(1960,2944), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-167.9°, current=-133.9°, player=(1929,2913), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-8.8°, current=-42.8°, player=(1921,2905), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-126.2°, current=-165.6°, player=(1921,2905), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-10.0°, current=-44.0°, player=(1913,2897), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -158.6° (interval=1.5s)
+[01:01:52] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-166.9°, current=-130.0°, player=(1887,2881), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-133.4°, current=-167.8°, player=(1878,2877), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-91.8°, current=-8.7°, player=(1867,2875), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-90.9°, current=-9.7°, player=(1857,2875), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-8.0°, current=-25.9°, player=(1835,2875), corner_timer=0.00
+[01:01:52] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-167.0°, current=-126.2°, player=(1835,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-8.3°, current=-44.1°, player=(1791,2875), corner_timer=0.00
+[01:01:53] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=18
+[01:01:53] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-91.8°, current=-5.6°, player=(1703,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-90.9°, current=-6.2°, player=(1692,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-7.7°, current=-57.1°, player=(1681,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-4.7°, current=-22.7°, player=(1670,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-126.2°, current=-171.2°, player=(1670,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Exit_DroneOperator1] FLANKING started: target=(1426.273, 2867.842), side=left, pos=(700, 1124.58)
+[01:01:53] [ENEMY] [Exit_DroneOperator1] State: PURSUING -> FLANKING
+[01:01:53] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-4.3°, current=-40.5°, player=(1626,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 156.1°
+[01:01:53] [ENEMY] [Exit_DroneOperator2] FLANKING started: target=(1441.084, 2834), side=left, pos=(1600, 1100.462)
+[01:01:53] [ENEMY] [Exit_DroneOperator2] State: PURSUING -> FLANKING
+[01:01:53] [ENEMY] [Exit_DroneOperator3] FLANKING started: target=(1814.828, 2864.124), side=right, pos=(2500, 1124.53)
+[01:01:53] [ENEMY] [Exit_DroneOperator3] State: PURSUING -> FLANKING
+[01:01:53] [ENEMY] [Exit_DroneOperator4] FLANKING started: target=(1809.272, 2923.292), side=right, pos=(3300, 1124.53)
+[01:01:53] [ENEMY] [Exit_DroneOperator4] State: PURSUING -> FLANKING
+[01:01:53] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:01:53] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -22.4°
+[01:01:53] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 24.7°
+[01:01:53] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-173.7°, current=-126.2°, player=(1571,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-128.7°, current=-172.3°, player=(1560,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-173.8°, current=-133.4°, player=(1549,2875), corner_timer=0.00
+[01:01:53] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 132.6°
+[01:01:53] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P4:shield_delayed -> P1:shield_delayed, state=PACIFIST, target=-158.6°, current=-158.6°, player=(1507,2868), corner_timer=0.00
+[01:01:53] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:01:53] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:01:53] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:01:54] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-103.6°, current=-175.3°, player=(1482,2851), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-173.4°, current=-128.7°, player=(1473,2844), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-133.5°, current=-174.3°, player=(1465,2837), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-175.3°, current=-158.1°, player=(1457,2829), corner_timer=0.00
+[01:01:54] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=18
+[01:01:54] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -164.0° (interval=1.5s)
+[01:01:54] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:01:54] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-128.7°, current=-163.1°, player=(1420,2826), corner_timer=0.00
+[01:01:54] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:01:54] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:01:54] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:01:54] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-175.5°, current=-133.5°, player=(1376,2826), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-175.1°, current=-128.7°, player=(1355,2823), corner_timer=0.00
+[01:01:54] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:01:54] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:01:54] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:01:54] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:01:54] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-2.5°, player=(1344,2793), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-128.7°, current=-163.1°, player=(1344,2793), corner_timer=0.00
+[01:01:54] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=4.0°, current=-9.5°, player=(1349,2786), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-4.0°, player=(1349,2786), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-133.5°, current=-175.7°, player=(1349,2786), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-2.7°, player=(1354,2779), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-150.2°, current=-177.2°, player=(1354,2779), corner_timer=0.00
+[01:01:54] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P1:shield_delayed -> P4:shield_delayed, state=PACIFIST, target=-164.0°, current=-164.0°, player=(1354,2779), corner_timer=0.00
+[01:01:54] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:01:54] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:01:54] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:01:54] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:01:54] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=3.8°, current=0.0°, player=(1361,2710), corner_timer=0.00
+[01:01:54] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=178.8°, current=-180.0°, player=(1362,2699), corner_timer=0.00
+[01:01:55] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=18
+[01:01:55] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:01:55] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:01:55] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:01:55] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:01:55] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:01:55] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 4.3°
+[01:01:55] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -19.3°
+[01:01:55] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 38.3°
+[01:01:55] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -160.7° (interval=1.5s)
+[01:01:55] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:01:55] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.6°
+[01:01:55] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -155.3°
+[01:01:55] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -119.1°
+[01:01:56] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=18
+[01:01:56] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 13.3°
+[01:01:56] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -169.9°
+[01:01:56] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 40.8°
+[01:01:56] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -32.1°
+[01:01:56] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.1°
+[01:01:56] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -70.4°
+[01:01:56] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-1.6°, player=(1853,2613), corner_timer=0.00
+[01:01:56] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.1°
+[01:01:56] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=-178.4°, player=(1853,2604), corner_timer=0.00
+[01:01:56] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 8.0°
+[01:01:56] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -18.4°
+[01:01:57] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:01:57] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=18
+[01:01:57] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -153.9° (interval=1.5s)
+[01:01:57] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.3°
+[01:01:57] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:01:57] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:01:57] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:01:57] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -169.9°
+[01:01:57] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:01:57] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -87.8°
+[01:01:57] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.1°
+[01:01:57] [ENEMY] [Exit_DroneOperator3] FLANKING stuck (2.0s), pos=(2836.786, 1725.933), fail=1
+[01:01:57] [ENEMY] [Exit_DroneOperator3] State: FLANKING -> PURSUING
+[01:01:57] [ENEMY] [Exit_DroneOperator3] State: PURSUING -> COMBAT
+[01:01:58] [ENEMY] [Exit_DroneOperator3] Found cover at (2819.151, 1906) (distance: 180.8, player at (2064.629, 2286.243))
+[01:01:58] [INFO] [ForceFieldEffect] Activated! Charge: 5.0s/8.0s
+[01:01:58] [INFO] [EnemyForceField] Activated
+[01:01:58] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=45.6°, current=0.0°, player=(2080,2270), corner_timer=0.00
+[01:01:58] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=18
+[01:01:58] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:01:58] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -87.0°
+[01:01:58] [WARN] [FPS] Drop detected: 29 fps (threshold: 30)
+[01:01:58] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -20.1°
+[01:01:58] [ENEMY] [Exit_DroneOperator3] State: COMBAT -> PURSUING
+[01:01:58] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:01:58] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -134.8° (interval=1.5s)
+[01:01:58] [ENEMY] [Exit_DroneOperator4] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=127.2°, current=120.7°, player=(2267,2085), corner_timer=-0.02
+[01:01:58] [ENEMY] [Exit_DroneOperator4] State: FLANKING -> COMBAT
+[01:01:58] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:01:58] [ENEMY] [Exit_DroneOperator4] Found cover at (2335.115, 1954.018) (distance: 42.0, player at (2271.265, 2081.35))
+[01:01:59] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=18
+[01:01:59] [INFO] [WeaponHintsComponent] Auto-dismiss timer: clearing all remaining hints for ak_gl
+[01:01:59] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:01:59] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-6.0°, player=(2345,1998), corner_timer=0.00
+[01:01:59] [ENEMY] [Exit_DroneOperator4] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-21.1°, current=46.2°, player=(2345,1998), corner_timer=-0.02
+[01:01:59] [ENEMY] [Exit_DroneOperator4] State: COMBAT -> PURSUING
+[01:01:59] [ENEMY] [Exit_DroneOperator4] PURSUING: close/visible unhittable target, attempting FLANKING before pursuit cover
+[01:01:59] [ENEMY] [Exit_DroneOperator4] Warning: No LOS-positive flank position, falling back to nav-reachable side
+[01:01:59] [ENEMY] [Exit_DroneOperator4] FLANKING started: target=(2435.34, 2166.749), side=left, pos=(2336.011, 2002.705)
+[01:01:59] [ENEMY] [Exit_DroneOperator4] State: PURSUING -> FLANKING
+[01:01:59] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 133.3°
+[01:01:59] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:01:59] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=1.4°, current=0.0°, player=(2346,1922), corner_timer=0.00
+[01:01:59] [ENEMY] [Exit_DroneOperator2] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=3.5°, current=0.7°, player=(2346,1922), corner_timer=-0.02
+[01:01:59] [ENEMY] [Exit_DroneOperator2] State: FLANKING -> COMBAT
+[01:01:59] [ENEMY] [Exit_DroneOperator2] Found cover at (1674.877, 1726) (distance: 155.1, player at (2346.857, 1916.952))
+[01:01:59] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=174.8°, current=-180.0°, player=(2347,1911), corner_timer=0.00
+[01:01:59] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 140.0°
+[01:01:59] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:00] [ENEMY] [Exit_DroneOperator4] State: FLANKING -> COMBAT
+[01:02:00] [ENEMY] [Exit_DroneOperator4] Found cover at (2425.801, 2104.023) (distance: 47.9, player at (2451.055, 1866.067))
+[01:02:00] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=18
+[01:02:00] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1863.33, 1890.474), source=ENEMY (Exit_DroneOperator2), range=800, listeners=18
+[01:02:00] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[01:02:00] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:00] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -116.2° (interval=1.5s)
+[01:02:00] [ENEMY] [Exit_DroneOperator3] PURSUING corner check: angle -119.9°
+[01:02:00] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1884.724, 1905.914), source=NEUTRAL (null), range=900, listeners=18
+[01:02:00] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (1884.724, 1905.914), intensity=0.00, dist=815
+[01:02:00] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1884.724, 1905.914), intensity=0.11, dist=148
+[01:02:00] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (1884.724, 1905.914), intensity=0.02, dist=364
+[01:02:00] [ENEMY] [Exit_DroneOperator1] Heard CASING_KICK at (1884.724, 1905.914), intensity=0.01, dist=601
+[01:02:00] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (1884.724, 1905.914), intensity=1.00, dist=27
+[01:02:00] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (1884.724, 1905.914), intensity=0.00, dist=741
+[01:02:00] [ENEMY] [Exit_DroneOperator4] Heard CASING_KICK at (1884.724, 1905.914), intensity=0.01, dist=581
+[01:02:00] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (1884.724, 1905.914), intensity=0.00, dist=885
+[01:02:00] [INFO] [SoundPropagation] Sound result: notified=8, out_of_range=10, self=0
+[01:02:00] [INFO] [ScoreManager] Damage taken: 1 (total: 1)
+[01:02:00] [INFO] [Player] Spawning blood effect at (2594.055, 1866.0665), dir=(0.999189, -0.04026791), lethal=False (C#)
+[01:02:00] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:00] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[01:02:00] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[01:02:00] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:00] [ENEMY] [Exit_DroneOperator4] State: COMBAT -> PURSUING
+[01:02:00] [ENEMY] [Exit_DroneOperator4] PURSUING: close/visible unhittable target, attempting FLANKING before pursuit cover
+[01:02:00] [ENEMY] [Exit_DroneOperator4] FLANKING started: target=(2423.998, 1874), side=right, pos=(2432.725, 2099.541)
+[01:02:00] [ENEMY] [Exit_DroneOperator4] State: PURSUING -> FLANKING
+[01:02:00] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 116.9°
+[01:02:00] [ENEMY] [FarTracks_MachineGunnerRight] Hit: dmg=1, hp=2/2->1/2
+[01:02:00] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:00] [ENEMY] [FarTracks_MachineGunnerRight] [#959] Pacifist hit - retaliates in PACIFIST state (attacker only)
+[01:02:00] [INFO] [ScoreManager] Damage taken: 1 (total: 2)
+[01:02:00] [INFO] [Player] Spawning blood effect at (2665.555, 1866.0665), dir=(0.9990963, -0.042506874), lethal=False (C#)
+[01:02:00] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:00] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[01:02:00] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[01:02:00] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[01:02:00] [INFO] [PenultimateHit]   - Time scale: 0.10
+[01:02:00] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[01:02:00] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[01:02:00] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[01:02:00] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[01:02:00] [INFO] [PenultimateHit] Applying saturation to 18 enemies
+[01:02:00] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[01:02:00] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[01:02:00] [INFO] [BloodDecal] Blood puddle created at (2652.257, 1909.226) (added to group)
+[01:02:00] [INFO] [BloodDecal] Blood puddle created at (2647.596, 1881.683) (added to group)
+[01:02:00] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=-176.7°, player=(2676,1866), corner_timer=0.00
+[01:02:00] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[01:02:00] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2009.884, 1909.476), source=NEUTRAL (null), range=900, listeners=18
+[01:02:00] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (2009.884, 1909.476), intensity=0.01, dist=650
+[01:02:00] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2009.884, 1909.476), intensity=0.06, dist=197
+[01:02:00] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2009.884, 1909.476), intensity=0.04, dist=253
+[01:02:00] [ENEMY] [Exit_DroneOperator1] Heard CASING_KICK at (2009.884, 1909.476), intensity=0.00, dist=724
+[01:02:00] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2009.884, 1909.476), intensity=1.00, dist=24
+[01:02:00] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2009.884, 1909.476), intensity=0.01, dist=558
+[01:02:00] [ENEMY] [Exit_DroneOperator4] Heard CASING_KICK at (2009.884, 1909.476), intensity=0.01, dist=420
+[01:02:00] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (2009.884, 1909.476), intensity=0.00, dist=822
+[01:02:00] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2009.884, 1909.476), intensity=0.00, dist=843
+[01:02:00] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2009.884, 1909.476), intensity=0.00, dist=867
+[01:02:00] [INFO] [SoundPropagation] Sound result: notified=10, out_of_range=8, self=0
+[01:02:01] [INFO] [ReplayManager] Recording frame 600 (9,7s): player_valid=True, enemies=18
+[01:02:01] [INFO] [BloodDecal] Blood puddle created at (2700.682, 1929.71) (added to group)
+[01:02:01] [INFO] [BloodDecal] Blood puddle created at (2660.652, 1898.351) (added to group)
+[01:02:02] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 6.1°
+[01:02:02] [ENEMY] [FarTracks_MachineGunnerRight] Hit: dmg=1, hp=1/2->0/2
+[01:02:02] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[01:02:02] [ENEMY] [FarTracks_MachineGunnerRight] Enemy died (ricochet: false, penetration: false, player_kill: false)
+[01:02:02] [INFO] [GameManager] register_kill: skipping non-player kill (enemy-vs-enemy or ally-vs-enemy)
+[01:02:02] [INFO] [ScoreManager] Kill registered. Combo: 1 (points: 500)
+[01:02:02] [ENEMY] [Exit_DroneOperator3] [AllyDeath] Witnessed at (2634.069, 1874.066), entering SEARCHING
+[01:02:02] [ENEMY] [Exit_DroneOperator3] SEARCHING started (spiral): center=(2634.069, 1874.066), radius=100, waypoints=3
+[01:02:02] [ENEMY] [FarTracks_MachineGunnerRight] [AllyDeath] Notified 3 enemies
+[01:02:02] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerRight (remaining: 17)
+[01:02:02] [INFO] [DeathAnim] Started - Angle: -2.8 deg, Index: 11
+[01:02:02] [ENEMY] [FarTracks_MachineGunnerRight] Death animation started with hit direction: (0.998777, -0.049446)
+[01:02:02] [INFO] [ReplayManager] Recording frame 660 (9,8s): player_valid=True, enemies=18
+[01:02:02] [INFO] [BloodDecal] Blood puddle created at (2717.313, 1886.581) (added to group)
+[01:02:02] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[01:02:02] [INFO] [BloodDecal] Blood puddle created at (2673.139, 1890.903) (added to group)
+[01:02:02] [INFO] [BloodDecal] Blood puddle created at (2725.167, 1887.557) (added to group)
+[01:02:02] [INFO] [BloodDecal] Blood puddle created at (2744.751, 1861.809) (added to group)
+[01:02:02] [INFO] [BloodDecal] Blood puddle created at (2711.427, 1871.665) (added to group)
+[01:02:03] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 170.6°
+[01:02:03] [INFO] [ReplayManager] Recording frame 720 (9,9s): player_valid=True, enemies=18
+[01:02:03] [ENEMY] [Exit_DroneOperator3] SEARCHING corner check: angle -89.1°
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2748.505, 1901.791) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2768.464, 1907.805) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2789.658, 1903.511) (added to group)
+[01:02:03] [INFO] [PenultimateHit] Effect duration expired after 3.01 real seconds
+[01:02:03] [INFO] [PenultimateHit] Ending penultimate hit effect
+[01:02:03] [INFO] [PenultimateHit] Starting visual effects fade-out over 400ms
+[01:02:03] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2108.575, 1892.068), source=ENEMY (Exit_DroneOperator2), range=800, listeners=17
+[01:02:03] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=12, self=1
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2771.234, 1889.541) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2726.217, 1905.037) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2737.644, 1883.968) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2744.387, 1864.15) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2761.497, 1870.582) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2752.733, 1907.524) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2749.263, 1879.082) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2762.339, 1920.684) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2748.01, 1867.884) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2779.954, 1866.117) (added to group)
+[01:02:03] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2124.392, 1907.442), source=NEUTRAL (null), range=900, listeners=17
+[01:02:03] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2124.392, 1907.442), intensity=0.03, dist=288
+[01:02:03] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2124.392, 1907.442), intensity=0.08, dist=174
+[01:02:03] [ENEMY] [Exit_DroneOperator1] Heard CASING_KICK at (2124.392, 1907.442), intensity=0.00, dist=836
+[01:02:03] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2124.392, 1907.442), intensity=1.00, dist=32
+[01:02:03] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2124.392, 1907.442), intensity=0.01, dist=535
+[01:02:03] [ENEMY] [Exit_DroneOperator4] Heard CASING_KICK at (2124.392, 1907.442), intensity=0.04, dist=245
+[01:02:03] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (2124.392, 1907.442), intensity=0.00, dist=782
+[01:02:03] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2124.392, 1907.442), intensity=0.00, dist=797
+[01:02:03] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2124.392, 1907.442), intensity=0.00, dist=815
+[01:02:03] [INFO] [SoundPropagation] Sound result: notified=9, out_of_range=8, self=0
+[01:02:03] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 6.9°
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2733.069, 1889.715) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2694.777, 1874.026) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2715.782, 1925.613) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2684.303, 1878.502) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2698.038, 1912.608) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2771.017, 1884.579) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2760.358, 1922.569) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2751.192, 1928.966) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2698.879, 1907.692) (added to group)
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2721.215, 1891.882) (added to group)
+[01:02:03] [ENEMY] [Exit_DroneOperator3] SEARCHING corner check: angle -89.1°
+[01:02:03] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 119.0°
+[01:02:03] [INFO] [BloodDecal] Blood puddle created at (2779.867, 1924.129) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2730.12, 1865.842) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2701.475, 1913.036) (added to group)
+[01:02:04] [INFO] [ScoreManager] Damage taken: 1 (total: 3)
+[01:02:04] [INFO] [Player] Spawning blood effect at (2874.5637, 1866.0665), dir=(0.99941134, -0.03430762), lethal=True (C#)
+[01:02:04] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[01:02:04] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[01:02:04] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[01:02:04] [INFO] [GameManager] Player Died signal received — starting safety net timer
+[01:02:04] [INFO] [GameManager] Disabled dead player collision from GameManager signal handler
+[01:02:04] [INFO] [GameManager] Disabled dead player collision (safety net)
+[01:02:04] [INFO] [GameManager] Safety net deadline set (1.5 real seconds, wall-clock based)
+[01:02:04] [INFO] [CinemaEffects] Player died - triggering death effects
+[01:02:04] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn, expanding spots, and end of reel (top-right)
+[01:02:04] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[01:02:04] [INFO] [LastChance] Player died
+[01:02:04] [INFO] [GameManager] POLL DETECTED: Player collision_layer is 0 (confirming death already flagged)
+[01:02:04] [INFO] [GameManager] Disabled dead player collision (safety net)
+[01:02:04] [ENEMY] [FarTracks_MachineGunnerRight] Ragdoll activated
+[01:02:04] [INFO] [DeathAnim] Ragdoll activated at 60% fall progress
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2830.125, 1906.738) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2770.119, 1912.45) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2791.483, 1929.548) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2865.767, 1876.662) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2718.886, 1891.14) (added to group)
+[01:02:04] [INFO] [ReplayManager] Recording frame 780 (10,3s): player_valid=True, enemies=18
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2878.042, 1891.316) (added to group)
+[01:02:04] [INFO] [PenultimateHit] Visual effects fade-out complete
+[01:02:04] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[01:02:04] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2835.658, 1908.523) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2805.204, 1906.553) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2799.959, 1893.596) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2939.162, 1895.279) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2928.52, 1902.049) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2915.372, 1866.512) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2967.73, 1865.754) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2926.958, 1902.943) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2971.57, 1866.349) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2981.856, 1904.52) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2951.757, 1922.774) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (3003.877, 1914.007) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2944.282, 1913.918) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2958.237, 1892.653) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2960.386, 1928.451) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2935.915, 1924.208) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2942.531, 1928.09) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2997.921, 1922.021) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2956.358, 1924.091) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (2995.859, 1863.063) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (3021.411, 1851.471) (added to group)
+[01:02:04] [INFO] [GameManager] on_player_death() called (legacy entry point)
+[01:02:04] [INFO] [PersistManager] State saved to user://game_state.cfg
+[01:02:04] [INFO] [UnlockManager] Death condition met — Armored Skin now available to unlock in armory
+[01:02:04] [INFO] [GameManager] total_deaths: 110
+[01:02:04] [INFO] [GameManager] restart_scene() — starting scene reload
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Platform_ShieldRight (remaining: 16)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight3 (remaining: 15)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight2 (remaining: 14)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight1 (remaining: 13)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft3 (remaining: 12)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft2 (remaining: 11)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft1 (remaining: 10)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Spawn_GasMaskEnemy (remaining: 9)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator4 (remaining: 8)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator3 (remaining: 7)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator2 (remaining: 6)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator1 (remaining: 5)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: CentralWalkway_ForceFieldRight (remaining: 4)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: CentralWalkway_ForceFieldLeft (remaining: 3)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerLeft (remaining: 2)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerRight (remaining: 1)
+[01:02:04] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerLeft (remaining: 0)
+[01:02:04] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:02:04] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] BloodyFeetComponent ready on NearTracks_MachineGunnerLeft
+[01:02:04] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[01:02:04] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:02:04] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[01:02:04] [INFO] [LastChance] Resetting all effects (scene change detected)
+[01:02:04] [INFO] [CinemaEffects] Scene changed to: RailwayStationLevel
+[01:02:04] [INFO] [CinemaEffects] Death effects reset
+[01:02:04] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[01:02:04] [INFO] [BlackMetalEffectsManager] Scene changed to: RailwayStationLevel
+[01:02:04] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[01:02:04] [INFO] [PersistManager] State saved to user://game_state.cfg
+[01:02:04] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RailwayStationLevel.tscn
+[01:02:04] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] BloodyFeetComponent ready on NearTracks_MachineGunnerRight
+[01:02:04] [ENEMY] [NearTracks_MachineGunnerRight] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] BloodyFeetComponent ready on FarTracks_MachineGunnerLeft
+[01:02:04] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] BloodyFeetComponent ready on FarTracks_MachineGunnerRight
+[01:02:04] [ENEMY] [FarTracks_MachineGunnerRight] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] BloodyFeetComponent ready on CentralWalkway_ForceFieldLeft
+[01:02:04] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:02:04] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:02:04] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:02:04] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:02:04] [ENEMY] [CentralWalkway_ForceFieldLeft] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] BloodyFeetComponent ready on CentralWalkway_ForceFieldRight
+[01:02:04] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:02:04] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:02:04] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:02:04] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:02:04] [ENEMY] [CentralWalkway_ForceFieldRight] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator1] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator1] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator1] BloodyFeetComponent ready on Exit_DroneOperator1
+[01:02:04] [ENEMY] [Exit_DroneOperator1] Death animation component initialized
+[01:02:04] [INFO] [DroneOperator] VR headset visual created
+[01:02:04] [INFO] [DroneOperator] Tablet visual created
+[01:02:04] [INFO] [DroneOperator] Setup complete
+[01:02:04] [ENEMY] [Exit_DroneOperator1] Found cover at (0, 0) (distance: 1303.8, player at (2000, 3100))
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator2] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator2] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator2] BloodyFeetComponent ready on Exit_DroneOperator2
+[01:02:04] [ENEMY] [Exit_DroneOperator2] Death animation component initialized
+[01:02:04] [INFO] [DroneOperator] VR headset visual created
+[01:02:04] [INFO] [DroneOperator] Tablet visual created
+[01:02:04] [INFO] [DroneOperator] Setup complete
+[01:02:04] [ENEMY] [Exit_DroneOperator2] Found cover at (0, 0) (distance: 1941.6, player at (2000, 3100))
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator3] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator3] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator3] BloodyFeetComponent ready on Exit_DroneOperator3
+[01:02:04] [ENEMY] [Exit_DroneOperator3] Death animation component initialized
+[01:02:04] [INFO] [DroneOperator] VR headset visual created
+[01:02:04] [INFO] [DroneOperator] Tablet visual created
+[01:02:04] [INFO] [DroneOperator] Setup complete
+[01:02:04] [ENEMY] [Exit_DroneOperator3] Found cover at (0, 0) (distance: 2731.3, player at (2000, 3100))
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator4] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator4] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator4] BloodyFeetComponent ready on Exit_DroneOperator4
+[01:02:04] [ENEMY] [Exit_DroneOperator4] Death animation component initialized
+[01:02:04] [INFO] [DroneOperator] VR headset visual created
+[01:02:04] [INFO] [DroneOperator] Tablet visual created
+[01:02:04] [INFO] [DroneOperator] Setup complete
+[01:02:04] [ENEMY] [Exit_DroneOperator4] Found cover at (0, 0) (distance: 3478.5, player at (2000, 3100))
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] BloodyFeetComponent ready on Spawn_GasMaskEnemy
+[01:02:04] [ENEMY] [Spawn_GasMaskEnemy] Death animation component initialized
+[01:02:04] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft1] BloodyFeetComponent ready on Platform_TeleporterLeft1
+[01:02:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft1
+[01:02:04] [ENEMY] [Platform_TeleporterLeft1] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft2] BloodyFeetComponent ready on Platform_TeleporterLeft2
+[01:02:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft2
+[01:02:04] [ENEMY] [Platform_TeleporterLeft2] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft3] BloodyFeetComponent ready on Platform_TeleporterLeft3
+[01:02:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft3
+[01:02:04] [ENEMY] [Platform_TeleporterLeft3] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight1] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight1] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight1] BloodyFeetComponent ready on Platform_TeleporterRight1
+[01:02:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight1
+[01:02:04] [ENEMY] [Platform_TeleporterRight1] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight2] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight2] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight2] BloodyFeetComponent ready on Platform_TeleporterRight2
+[01:02:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight2
+[01:02:04] [ENEMY] [Platform_TeleporterRight2] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight3] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight3] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight3] BloodyFeetComponent ready on Platform_TeleporterRight3
+[01:02:04] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight3
+[01:02:04] [ENEMY] [Platform_TeleporterRight3] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Platform_ShieldRight] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Platform_ShieldRight] Found EnemyModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Platform_ShieldRight] BloodyFeetComponent ready on Platform_ShieldRight
+[01:02:04] [INFO] [EnemyShield] SWAT riot shield visual created with collision area (top-down view)
+[01:02:04] [INFO] [EnemyShield] Setup complete (shield_hp=20, stun=1.0s)
+[01:02:04] [ENEMY] [Platform_ShieldRight] Death animation component initialized
+[01:02:04] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:04] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[01:02:04] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[01:02:04] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[01:02:04] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[01:02:04] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[01:02:04] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[01:02:04] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[01:02:04] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[01:02:04] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[01:02:04] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[01:02:04] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[01:02:04] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[01:02:04] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[01:02:04] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[01:02:04] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[01:02:04] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[01:02:04] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[01:02:04] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[01:02:04] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[01:02:04] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[01:02:04] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[01:02:04] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[01:02:04] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[01:02:04] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[01:02:04] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[01:02:04] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[01:02:04] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[01:02:04] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[01:02:04] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[01:02:04] [INFO] [Player.ItemVisual] Visual applied for item type: 11
+[01:02:04] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[01:02:04] [INFO] [Player.Loudspeaker] Loudspeaker selected, initializing...
+[01:02:04] [INFO] [Player.Loudspeaker] Loudspeaker equipped, level: 7, charges: 0/unlimited, effect: 90%, used_this_level: False, all_charges_used: False
+[01:02:04] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[01:02:04] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[01:02:04] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[01:02:04] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[01:02:04] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[01:02:04] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[01:02:04] [INFO] [Player.Jammer] JammerHUD initialized
+[01:02:04] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[01:02:04] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[01:02:04] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[01:02:04] [INFO] [RailwayStationLevel] Found Environment/Enemies node with 18 children
+[01:02:04] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldLeft': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldRight': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator1': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator2': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator3': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator4': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Spawn_GasMaskEnemy': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft1': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft2': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft3': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight1': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight2': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight3': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Child 'Platform_ShieldRight': script=true, has_died_signal=true
+[01:02:04] [INFO] [RailwayStationLevel] Enemy tracking complete: 18 enemies registered
+[01:02:04] [INFO] [RailwayStationLevel] Setting up weapon: ak_gl
+[01:02:04] [INFO] [RailwayStationLevel] AKGL already equipped by C# Player - skipping GDScript weapon swap
+[01:02:04] [INFO] [GameManager] set_player() called with: <CharacterBody2D#1048508898735> (class: CharacterBody2D)
+[01:02:04] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[01:02:04] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[01:02:04] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[01:02:04] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[01:02:04] [INFO] [ScoreManager] Level started with 18 enemies
+[01:02:04] [INFO] [RailwayStationLevel] ReplayManager found as C# autoload
+[01:02:04] [INFO] [ReplayManager] Replay data cleared
+[01:02:04] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[01:02:04] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[01:02:04] [INFO] [ReplayManager] Level: RailwayStationLevel
+[01:02:04] [INFO] [ReplayManager] Player: Player (valid: True)
+[01:02:04] [INFO] [ReplayManager] Enemies count: 18
+[01:02:04] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[01:02:04] [INFO] [ReplayManager]   Enemy 0: NearTracks_MachineGunnerLeft
+[01:02:04] [INFO] [ReplayManager]   Enemy 1: NearTracks_MachineGunnerRight
+[01:02:04] [INFO] [ReplayManager]   Enemy 2: FarTracks_MachineGunnerLeft
+[01:02:04] [INFO] [ReplayManager]   Enemy 3: FarTracks_MachineGunnerRight
+[01:02:04] [INFO] [ReplayManager]   Enemy 4: CentralWalkway_ForceFieldLeft
+[01:02:04] [INFO] [ReplayManager]   Enemy 5: CentralWalkway_ForceFieldRight
+[01:02:04] [INFO] [ReplayManager]   Enemy 6: Exit_DroneOperator1
+[01:02:04] [INFO] [ReplayManager]   Enemy 7: Exit_DroneOperator2
+[01:02:04] [INFO] [ReplayManager]   Enemy 8: Exit_DroneOperator3
+[01:02:04] [INFO] [ReplayManager]   Enemy 9: Exit_DroneOperator4
+[01:02:04] [INFO] [ReplayManager]   Enemy 10: Spawn_GasMaskEnemy
+[01:02:04] [INFO] [ReplayManager]   Enemy 11: Platform_TeleporterLeft1
+[01:02:04] [INFO] [ReplayManager]   Enemy 12: Platform_TeleporterLeft2
+[01:02:04] [INFO] [ReplayManager]   Enemy 13: Platform_TeleporterLeft3
+[01:02:04] [INFO] [ReplayManager]   Enemy 14: Platform_TeleporterRight1
+[01:02:04] [INFO] [ReplayManager]   Enemy 15: Platform_TeleporterRight2
+[01:02:04] [INFO] [ReplayManager]   Enemy 16: Platform_TeleporterRight3
+[01:02:04] [INFO] [ReplayManager]   Enemy 17: Platform_ShieldRight
+[01:02:04] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[01:02:04] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (3000.647, 1927.752) (added to group)
+[01:02:04] [INFO] [BloodDecal] Blood puddle created at (3010.59, 1860.719) (added to group)
+[01:02:04] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 18) - skipping fallback
+[01:02:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Blood detector created and attached to NearTracks_MachineGunnerLeft
+[01:02:04] [INFO] [CinemaEffects] Found player node: Player
+[01:02:04] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[01:02:04] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerLeft (total: 1)
+[01:02:04] [ENEMY] [NearTracks_MachineGunnerLeft] Registered as sound listener
+[01:02:04] [ENEMY] [NearTracks_MachineGunnerLeft] Spawned at (300, 2670), hp: 3, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Blood detector created and attached to NearTracks_MachineGunnerRight
+[01:02:04] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerRight (total: 2)
+[01:02:04] [ENEMY] [NearTracks_MachineGunnerRight] Registered as sound listener
+[01:02:04] [ENEMY] [NearTracks_MachineGunnerRight] Spawned at (3700, 2670), hp: 3, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Blood detector created and attached to FarTracks_MachineGunnerLeft
+[01:02:04] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerLeft (total: 3)
+[01:02:04] [ENEMY] [FarTracks_MachineGunnerLeft] Registered as sound listener
+[01:02:04] [ENEMY] [FarTracks_MachineGunnerLeft] Spawned at (300, 1890), hp: 3, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Blood detector created and attached to FarTracks_MachineGunnerRight
+[01:02:04] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerRight (total: 4)
+[01:02:04] [ENEMY] [FarTracks_MachineGunnerRight] Registered as sound listener
+[01:02:04] [ENEMY] [FarTracks_MachineGunnerRight] Spawned at (3700, 1890), hp: 4, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Blood detector created and attached to CentralWalkway_ForceFieldLeft
+[01:02:04] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldLeft (total: 5)
+[01:02:04] [ENEMY] [CentralWalkway_ForceFieldLeft] Registered as sound listener
+[01:02:04] [ENEMY] [CentralWalkway_ForceFieldLeft] Spawned at (1700, 2300), hp: 3, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Blood detector created and attached to CentralWalkway_ForceFieldRight
+[01:02:04] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldRight (total: 6)
+[01:02:04] [ENEMY] [CentralWalkway_ForceFieldRight] Registered as sound listener
+[01:02:04] [ENEMY] [CentralWalkway_ForceFieldRight] Spawned at (2300, 2300), hp: 3, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator1] Blood detector created and attached to Exit_DroneOperator1
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator1 (total: 7)
+[01:02:04] [ENEMY] [Exit_DroneOperator1] Registered as sound listener
+[01:02:04] [ENEMY] [Exit_DroneOperator1] Spawned at (700, 1100), hp: 4, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator2] Blood detector created and attached to Exit_DroneOperator2
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator2 (total: 8)
+[01:02:04] [ENEMY] [Exit_DroneOperator2] Registered as sound listener
+[01:02:04] [ENEMY] [Exit_DroneOperator2] Spawned at (1600, 1100), hp: 4, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator3] Blood detector created and attached to Exit_DroneOperator3
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator3 (total: 9)
+[01:02:04] [ENEMY] [Exit_DroneOperator3] Registered as sound listener
+[01:02:04] [ENEMY] [Exit_DroneOperator3] Spawned at (2500, 1100), hp: 4, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Exit_DroneOperator4] Blood detector created and attached to Exit_DroneOperator4
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator4 (total: 10)
+[01:02:04] [ENEMY] [Exit_DroneOperator4] Registered as sound listener
+[01:02:04] [ENEMY] [Exit_DroneOperator4] Spawned at (3300, 1100), hp: 2, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Blood detector created and attached to Spawn_GasMaskEnemy
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Spawn_GasMaskEnemy (total: 11)
+[01:02:04] [ENEMY] [Spawn_GasMaskEnemy] Registered as sound listener
+[01:02:04] [ENEMY] [Spawn_GasMaskEnemy] Spawned at (900, 3075), hp: 2, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Blood detector created and attached to Platform_TeleporterLeft1
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft1 (total: 12)
+[01:02:04] [ENEMY] [Platform_TeleporterLeft1] Registered as sound listener
+[01:02:04] [ENEMY] [Platform_TeleporterLeft1] Spawned at (200, 3500), hp: 3, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Blood detector created and attached to Platform_TeleporterLeft2
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft2 (total: 13)
+[01:02:04] [ENEMY] [Platform_TeleporterLeft2] Registered as sound listener
+[01:02:04] [ENEMY] [Platform_TeleporterLeft2] Spawned at (400, 3500), hp: 3, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Blood detector created and attached to Platform_TeleporterLeft3
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft3 (total: 14)
+[01:02:04] [ENEMY] [Platform_TeleporterLeft3] Registered as sound listener
+[01:02:04] [ENEMY] [Platform_TeleporterLeft3] Spawned at (600, 3500), hp: 3, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight1] Blood detector created and attached to Platform_TeleporterRight1
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight1 (total: 15)
+[01:02:04] [ENEMY] [Platform_TeleporterRight1] Registered as sound listener
+[01:02:04] [ENEMY] [Platform_TeleporterRight1] Spawned at (3400, 3500), hp: 4, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight2] Blood detector created and attached to Platform_TeleporterRight2
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight2 (total: 16)
+[01:02:04] [ENEMY] [Platform_TeleporterRight2] Registered as sound listener
+[01:02:04] [ENEMY] [Platform_TeleporterRight2] Spawned at (3600, 3500), hp: 3, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Platform_TeleporterRight3] Blood detector created and attached to Platform_TeleporterRight3
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight3 (total: 17)
+[01:02:04] [ENEMY] [Platform_TeleporterRight3] Registered as sound listener
+[01:02:04] [ENEMY] [Platform_TeleporterRight3] Spawned at (3800, 3500), hp: 2, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Platform_ShieldRight] Blood detector created and attached to Platform_ShieldRight
+[01:02:04] [INFO] [SoundPropagation] Registered listener: Platform_ShieldRight (total: 18)
+[01:02:04] [ENEMY] [Platform_ShieldRight] Registered as sound listener
+[01:02:04] [ENEMY] [Platform_ShieldRight] Spawned at (3600, 3650), hp: 2, behavior: GUARD
+[01:02:04] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[01:02:04] [INFO] [Player.Loudspeaker] Level 7 victory state — all enemies start as pacifists!
+[01:02:04] [ENEMY] [NearTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [NearTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [FarTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [FarTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [CentralWalkway_ForceFieldLeft] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [CentralWalkway_ForceFieldRight] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Exit_DroneOperator1] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Exit_DroneOperator2] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Exit_DroneOperator3] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Exit_DroneOperator4] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Spawn_GasMaskEnemy] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Platform_TeleporterLeft1] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Platform_TeleporterLeft2] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Platform_TeleporterLeft3] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Platform_TeleporterRight1] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Platform_TeleporterRight2] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Platform_TeleporterRight3] Transitioned to PACIFIST
+[01:02:04] [ENEMY] [Platform_ShieldRight] Transitioned to PACIFIST
+[01:02:04] [INFO] [Player.Loudspeaker] Victory message shown (Level 7)
+[01:02:05] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=18
+[01:02:05] [ENEMY] [NearTracks_MachineGunnerLeft] Found cover at (0, 0) (distance: 2686.8, player at (2000, 3100))
+[01:02:05] [ENEMY] [NearTracks_MachineGunnerRight] Found cover at (0, 0) (distance: 4562.8, player at (2000, 3100))
+[01:02:05] [ENEMY] [FarTracks_MachineGunnerLeft] Found cover at (0, 0) (distance: 1913.7, player at (2000, 3100))
+[01:02:05] [ENEMY] [FarTracks_MachineGunnerRight] Found cover at (0, 0) (distance: 4154.8, player at (2000, 3100))
+[01:02:05] [ENEMY] [CentralWalkway_ForceFieldLeft] Found cover at (0, 0) (distance: 2860.1, player at (2000, 3100))
+[01:02:05] [ENEMY] [CentralWalkway_ForceFieldRight] Found cover at (0, 0) (distance: 3252.7, player at (2000, 3100))
+[01:02:05] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: none -> P1:visible, state=PACIFIST, target=1.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (0, 0) (distance: 3204.0, player at (2000, 3100))
+[01:02:05] [ENEMY] [Platform_TeleporterLeft1] Found cover at (0, 0) (distance: 3505.7, player at (2000, 3100))
+[01:02:05] [ENEMY] [Platform_TeleporterLeft2] Found cover at (0, 0) (distance: 3522.8, player at (2000, 3100))
+[01:02:05] [ENEMY] [Platform_TeleporterLeft3] Found cover at (0, 0) (distance: 3551.1, player at (2000, 3100))
+[01:02:05] [ENEMY] [Platform_TeleporterRight1] Found cover at (0, 0) (distance: 4879.5, player at (2000, 3100))
+[01:02:05] [ENEMY] [Platform_TeleporterRight2] Found cover at (0, 0) (distance: 5021.0, player at (2000, 3100))
+[01:02:05] [ENEMY] [Platform_TeleporterRight3] Found cover at (0, 0) (distance: 5166.2, player at (2000, 3100))
+[01:02:05] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[01:02:05] [ENEMY] [Platform_ShieldRight] Found cover at (0, 0) (distance: 5126.6, player at (2000, 3100))
+[01:02:05] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-73.2°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-113.6°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-75.8°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-119.2°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-126.5°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-135.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-93.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-96.5°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-99.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-134.2°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-135.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-137.4°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: none -> P4:shield_delayed, state=PACIFIST, target=-161.0°, current=-90.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [INFO] [Player] Detecting weapon pose (frame 3)...
+[01:02:05] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[01:02:05] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[01:02:05] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[01:02:05] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[01:02:05] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[01:02:05] [INFO] [LastChance] Found player: Player
+[01:02:05] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[01:02:05] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[01:02:05] [INFO] [LastChance] Connected to player Died signal (C#)
+[01:02:05] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[01:02:05] [INFO] [BloodDecal] Blood puddle created at (3048.632, 1878.071) (added to group)
+[01:02:05] [INFO] [BloodDecal] Blood puddle created at (3075.07, 1920.739) (added to group)
+[01:02:05] [INFO] [BloodDecal] Blood puddle created at (2980.023, 1892.38) (added to group)
+[01:02:05] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-11.6°, current=-20.1°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-11.2°, current=-60.2°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:02:05] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:02:05] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:02:05] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:02:05] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-106.4°, current=8.0°, player=(2000,3100), corner_timer=0.00
+[01:02:05] [WARN] [FPS] Drop detected: 16 fps (threshold: 30)
+[01:02:05] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-169.2°, current=-128.9°, player=(2000,3099), corner_timer=0.00
+[01:02:05] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=9.9°, current=-26.4°, player=(2000,3096), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-170.3°, current=-134.6°, player=(2000,3096), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-135.8°, current=-146.1°, player=(2000,3088), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-137.4°, current=-151.8°, player=(2000,3081), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-168.8°, current=-135.8°, player=(2000,3065), corner_timer=0.00
+[01:02:05] [INFO] [Drone] _ready started
+[01:02:05] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:02:05] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:02:05] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:02:05] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:02:05] [INFO] [Drone] Initialized by operator: Exit_DroneOperator1
+[01:02:05] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:02:05] [INFO] [DroneOperator] Connected to drone.died signal
+[01:02:05] [INFO] [DroneOperator] Drone deployed at (700, 1084)
+[01:02:05] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:02:05] [INFO] [Drone] _ready started
+[01:02:05] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:02:05] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:02:05] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:02:05] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:02:05] [INFO] [Drone] Initialized by operator: Exit_DroneOperator2
+[01:02:05] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:02:05] [INFO] [DroneOperator] Connected to drone.died signal
+[01:02:05] [INFO] [DroneOperator] Drone deployed at (1600, 1060)
+[01:02:05] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:02:05] [INFO] [Drone] _ready started
+[01:02:05] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:02:05] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:02:05] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:02:05] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:02:05] [INFO] [Drone] Initialized by operator: Exit_DroneOperator3
+[01:02:05] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:02:05] [INFO] [DroneOperator] Connected to drone.died signal
+[01:02:05] [INFO] [DroneOperator] Drone deployed at (2500, 1084)
+[01:02:05] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:02:05] [INFO] [Drone] _ready started
+[01:02:05] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:02:05] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:02:05] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:02:05] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:02:05] [INFO] [Drone] Initialized by operator: Exit_DroneOperator4
+[01:02:05] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:02:05] [INFO] [DroneOperator] Connected to drone.died signal
+[01:02:05] [INFO] [DroneOperator] Drone deployed at (3300, 1084)
+[01:02:05] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:02:05] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=18
+[01:02:05] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-169.7°, current=-137.4°, player=(2000,3054), corner_timer=0.00
+[01:02:05] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:02:05] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:02:05] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:02:05] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:02:05] [INFO] [Teleporter] Component initialized on Exit_DroneOperator1
+[01:02:05] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:02:05] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:02:05] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:02:05] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:02:05] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:02:05] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:02:05] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:02:05] [INFO] [Teleporter] Component initialized on Exit_DroneOperator2
+[01:02:05] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:02:05] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:02:05] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:02:05] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:02:05] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:02:05] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:02:05] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:02:05] [INFO] [Teleporter] Component initialized on Exit_DroneOperator3
+[01:02:05] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:02:05] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:02:05] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:02:05] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:02:05] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:02:05] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:02:05] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:02:05] [INFO] [Teleporter] Component initialized on Exit_DroneOperator4
+[01:02:05] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:02:05] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:02:05] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:02:05] [ENEMY] [Exit_DroneOperator1] State: IN_COVER -> PURSUING
+[01:02:05] [ENEMY] [Exit_DroneOperator2] State: IN_COVER -> PURSUING
+[01:02:05] [ENEMY] [Exit_DroneOperator3] State: IN_COVER -> PURSUING
+[01:02:05] [ENEMY] [Exit_DroneOperator4] State: IN_COVER -> PURSUING
+[01:02:05] [ENEMY] [Exit_DroneOperator1] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=55.9°, current=0.0°, player=(2000,3043), corner_timer=0.00
+[01:02:05] [ENEMY] [Exit_DroneOperator2] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=78.4°, current=0.0°, player=(2000,3043), corner_timer=0.00
+[01:02:05] [ENEMY] [Exit_DroneOperator3] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=104.6°, current=0.0°, player=(2000,3043), corner_timer=0.00
+[01:02:05] [ENEMY] [Exit_DroneOperator4] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=124.1°, current=0.0°, player=(2000,3043), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-93.3°, current=-7.2°, player=(2000,3043), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-167.0°, current=-122.7°, player=(2000,3043), corner_timer=0.00
+[01:02:05] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-96.5°, current=-8.1°, player=(2000,3032), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-7.5°, current=-24.3°, player=(2000,3010), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-8.6°, current=-25.3°, player=(2000,2999), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-137.4°, current=-167.7°, player=(2000,2955), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-93.3°, current=-8.2°, player=(2000,2944), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-96.5°, current=-9.2°, player=(2000,2933), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-135.8°, current=-165.7°, player=(2000,2933), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-8.6°, current=-25.4°, player=(2000,2911), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-134.3°, current=-163.5°, player=(2000,2911), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-166.1°, current=-137.4°, player=(1996,2890), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -156.6° (interval=1.5s)
+[01:02:06] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-9.9°, current=-43.6°, player=(1988,2872), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-93.3°, current=-9.0°, player=(1975,2855), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-96.5°, current=-26.4°, player=(1968,2847), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-9.2°, current=-26.2°, player=(1952,2832), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-10.3°, current=-43.6°, player=(1944,2826), corner_timer=0.00
+[01:02:06] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-163.7°, current=-135.8°, player=(1944,2826), corner_timer=0.00
+[01:02:06] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=18
+[01:02:07] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-93.3°, current=-7.2°, player=(1826,2826), corner_timer=0.00
+[01:02:07] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-96.5°, current=-7.9°, player=(1815,2826), corner_timer=0.00
+[01:02:07] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-6.5°, current=-24.4°, player=(1793,2826), corner_timer=0.00
+[01:02:07] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-6.3°, current=-42.2°, player=(1749,2826), corner_timer=0.00
+[01:02:07] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-137.4°, current=-169.2°, player=(1738,2826), corner_timer=0.00
+[01:02:07] [ENEMY] [Exit_DroneOperator1] FLANKING started: target=(1494.98, 2834), side=left, pos=(700, 1124.58)
+[01:02:07] [ENEMY] [Exit_DroneOperator1] State: PURSUING -> FLANKING
+[01:02:07] [ENEMY] [Exit_DroneOperator2] Warning: No LOS-positive flank position, falling back to nav-reachable side
+[01:02:07] [ENEMY] [Exit_DroneOperator2] FLANKING started: target=(1516.538, 2686), side=left, pos=(1600, 1100.512)
+[01:02:07] [ENEMY] [Exit_DroneOperator2] State: PURSUING -> FLANKING
+[01:02:07] [ENEMY] [Exit_DroneOperator3] FLANKING started: target=(1894.31, 2834), side=right, pos=(2500, 1124.58)
+[01:02:07] [ENEMY] [Exit_DroneOperator3] State: PURSUING -> FLANKING
+[01:02:07] [ENEMY] [Exit_DroneOperator4] FLANKING started: target=(1889.586, 2872.175), side=right, pos=(3300, 1124.58)
+[01:02:07] [ENEMY] [Exit_DroneOperator4] State: PURSUING -> FLANKING
+[01:02:07] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 156.1°
+[01:02:07] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:07] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -22.4°
+[01:02:07] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.1°
+[01:02:07] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-169.4°, current=-134.3°, player=(1661,2826), corner_timer=0.00
+[01:02:07] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 132.6°
+[01:02:07] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:07] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:07] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.1°
+[01:02:07] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=18
+[01:02:07] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-173.4°, current=-134.6°, player=(1540,2826), corner_timer=0.00
+[01:02:07] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -162.3° (interval=1.5s)
+[01:02:08] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-137.7°, current=-151.8°, player=(1507,2826), corner_timer=0.00
+[01:02:08] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:08] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:08] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:08] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.1°
+[01:02:08] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-0.5°, current=-36.7°, player=(1441,2826), corner_timer=0.00
+[01:02:08] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-174.9°, current=-137.7°, player=(1441,2826), corner_timer=0.00
+[01:02:08] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P4:shield_delayed -> P1:shield_delayed, state=PACIFIST, target=-162.3°, current=-162.3°, player=(1430,2826), corner_timer=0.00
+[01:02:08] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-112.5°, current=-174.1°, player=(1419,2826), corner_timer=0.00
+[01:02:08] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:08] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:08] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:08] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.1°
+[01:02:08] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-175.7°, current=-139.7°, player=(1355,2822), corner_timer=0.00
+[01:02:08] [WARN] [FPS] Drop detected: 29 fps (threshold: 30)
+[01:02:08] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-1.9°, player=(1343,2795), corner_timer=0.00
+[01:02:08] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-134.2°, current=-175.6°, player=(1343,2795), corner_timer=0.00
+[01:02:08] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=6.5°, current=-2.4°, player=(1347,2788), corner_timer=0.00
+[01:02:08] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-136.0°, current=-174.1°, player=(1347,2788), corner_timer=0.00
+[01:02:08] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-3.6°, current=-5.4°, player=(1352,2781), corner_timer=0.00
+[01:02:08] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=2.4°, current=-3.7°, player=(1352,2781), corner_timer=0.00
+[01:02:08] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-137.7°, current=-175.9°, player=(1352,2781), corner_timer=0.00
+[01:02:08] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P1:shield_delayed -> P4:shield_delayed, state=PACIFIST, target=-162.3°, current=-162.3°, player=(1358,2773), corner_timer=0.00
+[01:02:08] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:08] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:08] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:08] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.1°
+[01:02:08] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=18
+[01:02:08] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=3.3°, current=0.0°, player=(1362,2701), corner_timer=0.00
+[01:02:08] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=179.0°, current=-180.0°, player=(1363,2691), corner_timer=0.00
+[01:02:09] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:09] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:09] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:09] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.1°
+[01:02:09] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:09] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 4.3°
+[01:02:09] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -19.3°
+[01:02:09] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 36.2°
+[01:02:09] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -159.9° (interval=1.5s)
+[01:02:09] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:09] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -16.1°
+[01:02:09] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -152.4°
+[01:02:09] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -119.1°
+[01:02:09] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=18
+[01:02:10] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 13.3°
+[01:02:10] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -37.0°
+[01:02:10] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 40.8°
+[01:02:10] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -82.6°
+[01:02:10] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -32.1°
+[01:02:10] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -18.3°
+[01:02:10] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-178.2°, current=-143.3°, player=(1835,2644), corner_timer=0.00
+[01:02:10] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.1°
+[01:02:10] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-171.4°, current=-176.6°, player=(1852,2613), corner_timer=0.00
+[01:02:10] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-2.1°, player=(1852,2603), corner_timer=0.00
+[01:02:10] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 8.0°
+[01:02:10] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:02:10] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=-178.1°, player=(1852,2592), corner_timer=0.00
+[01:02:10] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=18
+[01:02:10] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:02:10] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -153.5° (interval=1.5s)
+[01:02:11] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.3°
+[01:02:11] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -169.9°
+[01:02:11] [INFO] [ForceFieldEffect] Activated! Charge: 5.0s/8.0s
+[01:02:11] [INFO] [EnemyForceField] Activated
+[01:02:11] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=47.3°, current=0.0°, player=(1901,2448), corner_timer=0.00
+[01:02:11] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:11] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:02:11] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.1°
+[01:02:11] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:11] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -87.8°
+[01:02:11] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -18.3°
+[01:02:11] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=18
+[01:02:12] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:12] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -83.6°
+[01:02:12] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:02:12] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -22.0°
+[01:02:12] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:12] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -169.9°
+[01:02:12] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -134.3° (interval=1.5s)
+[01:02:12] [INFO] [ForceFieldEffect] Activated! Charge: 5.0s/8.0s
+[01:02:12] [INFO] [EnemyForceField] Activated
+[01:02:12] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=37.6°, current=-9.8°, player=(2230,2181), corner_timer=0.00
+[01:02:12] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 60.1°
+[01:02:12] [ENEMY] [Exit_DroneOperator4] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=116.7°, current=120.7°, player=(2242,2169), corner_timer=0.30
+[01:02:12] [ENEMY] [Exit_DroneOperator4] State: FLANKING -> COMBAT
+[01:02:12] [ENEMY] [Exit_DroneOperator4] Found cover at (2329.542, 1906) (distance: 88.7, player at (2246.342, 2166.079))
+[01:02:12] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:12] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.1°
+[01:02:12] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=18
+[01:02:12] [INFO] [WeaponHintsComponent] Auto-dismiss timer: clearing all remaining hints for ak_gl
+[01:02:13] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:13] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -18.3°
+[01:02:13] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2332.068, 1997.361), source=ENEMY (Exit_DroneOperator4), range=800, listeners=18
+[01:02:13] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=10, self=1
+[01:02:13] [INFO] [ScoreManager] Damage taken: 1 (total: 1)
+[01:02:13] [INFO] [Player] Spawning blood effect at (2379.9238, 2046.0651), dir=(0.6873852, 0.72629297), lethal=False (C#)
+[01:02:13] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:13] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[01:02:13] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[01:02:13] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2335.722, 2024.979), source=NEUTRAL (null), range=900, listeners=18
+[01:02:13] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2335.722, 2024.979), intensity=0.00, dist=799
+[01:02:13] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2335.722, 2024.979), intensity=0.03, dist=273
+[01:02:13] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2335.722, 2024.979), intensity=0.01, dist=661
+[01:02:13] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2335.722, 2024.979), intensity=0.01, dist=579
+[01:02:13] [ENEMY] [Exit_DroneOperator4] Heard CASING_KICK at (2335.722, 2024.979), intensity=1.00, dist=19
+[01:02:13] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (2335.722, 2024.979), intensity=0.00, dist=741
+[01:02:13] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2335.722, 2024.979), intensity=0.01, dist=659
+[01:02:13] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2335.722, 2024.979), intensity=0.01, dist=629
+[01:02:13] [INFO] [SoundPropagation] Sound result: notified=8, out_of_range=10, self=0
+[01:02:13] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:13] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:02:13] [INFO] [ScoreManager] Damage taken: 1 (total: 2)
+[01:02:13] [INFO] [Player] Spawning blood effect at (2399.4019, 2046.0652), dir=(0.8735073, 0.486811), lethal=False (C#)
+[01:02:13] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:13] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[01:02:13] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[01:02:13] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[01:02:13] [INFO] [PenultimateHit]   - Time scale: 0.10
+[01:02:13] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[01:02:13] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[01:02:13] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[01:02:13] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[01:02:13] [INFO] [PenultimateHit] Applying saturation to 18 enemies
+[01:02:13] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[01:02:13] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[01:02:13] [INFO] [BloodDecal] Blood puddle created at (2421.696, 2097.357) (added to group)
+[01:02:13] [INFO] [BloodDecal] Blood puddle created at (2422.39, 2090.182) (added to group)
+[01:02:13] [INFO] [ReplayManager] Recording frame 540 (8,7s): player_valid=True, enemies=18
+[01:02:14] [INFO] [BloodDecal] Blood puddle created at (2415.835, 2103.103) (added to group)
+[01:02:14] [INFO] [BloodDecal] Blood puddle created at (2442.203, 2104.594) (added to group)
+[01:02:14] [WARN] [FPS] Drop detected: 29 fps (threshold: 30)
+[01:02:14] [INFO] [BloodDecal] Blood puddle created at (2407.365, 2144.612) (added to group)
+[01:02:14] [INFO] [BloodDecal] Blood puddle created at (2446.837, 2127.411) (added to group)
+[01:02:14] [INFO] [ReplayManager] Recording frame 600 (8,8s): player_valid=True, enemies=18
+[01:02:15] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2332.066, 2009.369), source=ENEMY (Exit_DroneOperator4), range=800, listeners=18
+[01:02:15] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=10, self=1
+[01:02:15] [INFO] [ScoreManager] Damage taken: 1 (total: 3)
+[01:02:15] [INFO] [Player] Spawning blood effect at (2376.5164, 2046.0652), dir=(0.7776715, 0.6286709), lethal=True (C#)
+[01:02:15] [INFO] [ImpactEffects] Blood decals scheduled: 30 to spawn at particle landing times
+[01:02:15] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 0.0
+[01:02:15] [INFO] [LastChance] Player health updated (C# Damaged): 0.0
+[01:02:15] [INFO] [GameManager] Player Died signal received — starting safety net timer
+[01:02:15] [INFO] [GameManager] Disabled dead player collision from GameManager signal handler
+[01:02:15] [INFO] [GameManager] Disabled dead player collision (safety net)
+[01:02:15] [INFO] [GameManager] Safety net deadline set (1.5 real seconds, wall-clock based)
+[01:02:15] [INFO] [CinemaEffects] Player died - triggering death effects
+[01:02:15] [INFO] [CinemaEffects] Death effects triggered - starting cigarette burn, expanding spots, and end of reel (top-right)
+[01:02:15] [INFO] [PenultimateHit] Player died - ending penultimate effect
+[01:02:15] [INFO] [PenultimateHit] Ending penultimate hit effect
+[01:02:15] [INFO] [PenultimateHit] Starting visual effects fade-out over 400ms
+[01:02:15] [INFO] [LastChance] Player died
+[01:02:15] [INFO] [GameManager] POLL DETECTED: Player collision_layer is 0 (confirming death already flagged)
+[01:02:15] [INFO] [GameManager] Disabled dead player collision (safety net)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2456.035, 2142.912) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2427.308, 2212.834) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2502.057, 2171.931) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2440.929, 2091.404) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2430.94, 2224.179) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2435.353, 2105.188) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2446.995, 2070.431) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2485.379, 2264.234) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2449.437, 2091.492) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2508.478, 2222.072) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2494.186, 2083.742) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2465.839, 2087.876) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2486.912, 2232.112) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2449.972, 2145.199) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2519.174, 2165.372) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2489.617, 2169.61) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2488.743, 2348.56) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2550.12, 2123.759) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2419.014, 2096.635) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2527.287, 2283.345) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2515.653, 2209.701) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2402.831, 2113.976) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2559.096, 2108.081) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2420.021, 2152.698) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2464.691, 2127.251) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2444.203, 2154.597) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2482.145, 2140.109) (added to group)
+[01:02:15] [INFO] [PenultimateHit] Visual effects fade-out complete
+[01:02:15] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[01:02:15] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2426.98, 2153.977) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2506.433, 2128.049) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2411.349, 2165.262) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2456.952, 2194.092) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2498.061, 2155.722) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2476.658, 2163.874) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2442.549, 2125.183) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2542.142, 2258.745) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2421.692, 2181.436) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2479.051, 2252.354) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2602.275, 2198.391) (added to group)
+[01:02:15] [INFO] [BloodDecal] Blood puddle created at (2503.615, 2154.098) (added to group)
+[01:02:15] [INFO] [GameManager] on_player_death() called (legacy entry point)
+[01:02:15] [INFO] [PersistManager] State saved to user://game_state.cfg
+[01:02:15] [INFO] [UnlockManager] Death condition met — Armored Skin now available to unlock in armory
+[01:02:15] [INFO] [GameManager] total_deaths: 111
+[01:02:15] [INFO] [GameManager] restart_scene() — starting scene reload
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Platform_ShieldRight (remaining: 17)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight3 (remaining: 16)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight2 (remaining: 15)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight1 (remaining: 14)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft3 (remaining: 13)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft2 (remaining: 12)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft1 (remaining: 11)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Spawn_GasMaskEnemy (remaining: 10)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator4 (remaining: 9)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator3 (remaining: 8)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator2 (remaining: 7)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator1 (remaining: 6)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: CentralWalkway_ForceFieldRight (remaining: 5)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: CentralWalkway_ForceFieldLeft (remaining: 4)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerRight (remaining: 3)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerLeft (remaining: 2)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerRight (remaining: 1)
+[01:02:15] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerLeft (remaining: 0)
+[01:02:15] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:02:15] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] BloodyFeetComponent ready on NearTracks_MachineGunnerLeft
+[01:02:15] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[01:02:15] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:02:15] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[01:02:15] [INFO] [LastChance] Resetting all effects (scene change detected)
+[01:02:15] [INFO] [CinemaEffects] Scene changed to: RailwayStationLevel
+[01:02:15] [INFO] [CinemaEffects] Death effects reset
+[01:02:15] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[01:02:15] [INFO] [BlackMetalEffectsManager] Scene changed to: RailwayStationLevel
+[01:02:15] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[01:02:15] [INFO] [PersistManager] State saved to user://game_state.cfg
+[01:02:15] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RailwayStationLevel.tscn
+[01:02:15] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] BloodyFeetComponent ready on NearTracks_MachineGunnerRight
+[01:02:15] [ENEMY] [NearTracks_MachineGunnerRight] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] BloodyFeetComponent ready on FarTracks_MachineGunnerLeft
+[01:02:15] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] BloodyFeetComponent ready on FarTracks_MachineGunnerRight
+[01:02:15] [ENEMY] [FarTracks_MachineGunnerRight] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] BloodyFeetComponent ready on CentralWalkway_ForceFieldLeft
+[01:02:15] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:02:15] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:02:15] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:02:15] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:02:15] [ENEMY] [CentralWalkway_ForceFieldLeft] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] BloodyFeetComponent ready on CentralWalkway_ForceFieldRight
+[01:02:15] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:02:15] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:02:15] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:02:15] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:02:15] [ENEMY] [CentralWalkway_ForceFieldRight] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator1] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator1] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator1] BloodyFeetComponent ready on Exit_DroneOperator1
+[01:02:15] [ENEMY] [Exit_DroneOperator1] Death animation component initialized
+[01:02:15] [INFO] [DroneOperator] VR headset visual created
+[01:02:15] [INFO] [DroneOperator] Tablet visual created
+[01:02:15] [INFO] [DroneOperator] Setup complete
+[01:02:15] [ENEMY] [Exit_DroneOperator1] Found cover at (0, 0) (distance: 1303.8, player at (2000, 3100))
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator2] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator2] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator2] BloodyFeetComponent ready on Exit_DroneOperator2
+[01:02:15] [ENEMY] [Exit_DroneOperator2] Death animation component initialized
+[01:02:15] [INFO] [DroneOperator] VR headset visual created
+[01:02:15] [INFO] [DroneOperator] Tablet visual created
+[01:02:15] [INFO] [DroneOperator] Setup complete
+[01:02:15] [ENEMY] [Exit_DroneOperator2] Found cover at (0, 0) (distance: 1941.6, player at (2000, 3100))
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator3] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator3] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator3] BloodyFeetComponent ready on Exit_DroneOperator3
+[01:02:15] [ENEMY] [Exit_DroneOperator3] Death animation component initialized
+[01:02:15] [INFO] [DroneOperator] VR headset visual created
+[01:02:15] [INFO] [DroneOperator] Tablet visual created
+[01:02:15] [INFO] [DroneOperator] Setup complete
+[01:02:15] [ENEMY] [Exit_DroneOperator3] Found cover at (0, 0) (distance: 2731.3, player at (2000, 3100))
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator4] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator4] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Exit_DroneOperator4] BloodyFeetComponent ready on Exit_DroneOperator4
+[01:02:15] [ENEMY] [Exit_DroneOperator4] Death animation component initialized
+[01:02:15] [INFO] [DroneOperator] VR headset visual created
+[01:02:15] [INFO] [DroneOperator] Tablet visual created
+[01:02:15] [INFO] [DroneOperator] Setup complete
+[01:02:15] [ENEMY] [Exit_DroneOperator4] Found cover at (0, 0) (distance: 3478.5, player at (2000, 3100))
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] BloodyFeetComponent ready on Spawn_GasMaskEnemy
+[01:02:15] [ENEMY] [Spawn_GasMaskEnemy] Death animation component initialized
+[01:02:15] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterLeft1] BloodyFeetComponent ready on Platform_TeleporterLeft1
+[01:02:15] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft1
+[01:02:15] [ENEMY] [Platform_TeleporterLeft1] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterLeft2] BloodyFeetComponent ready on Platform_TeleporterLeft2
+[01:02:15] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft2
+[01:02:15] [ENEMY] [Platform_TeleporterLeft2] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterLeft3] BloodyFeetComponent ready on Platform_TeleporterLeft3
+[01:02:15] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft3
+[01:02:15] [ENEMY] [Platform_TeleporterLeft3] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterRight1] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterRight1] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterRight1] BloodyFeetComponent ready on Platform_TeleporterRight1
+[01:02:15] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight1
+[01:02:15] [ENEMY] [Platform_TeleporterRight1] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterRight2] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterRight2] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterRight2] BloodyFeetComponent ready on Platform_TeleporterRight2
+[01:02:15] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight2
+[01:02:15] [ENEMY] [Platform_TeleporterRight2] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterRight3] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterRight3] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Platform_TeleporterRight3] BloodyFeetComponent ready on Platform_TeleporterRight3
+[01:02:15] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight3
+[01:02:15] [ENEMY] [Platform_TeleporterRight3] Death animation component initialized
+[01:02:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:15] [INFO] [BloodyFeet:Platform_ShieldRight] Footprint scene loaded
+[01:02:15] [INFO] [BloodyFeet:Platform_ShieldRight] Found EnemyModel for facing direction
+[01:02:15] [INFO] [BloodyFeet:Platform_ShieldRight] BloodyFeetComponent ready on Platform_ShieldRight
+[01:02:16] [INFO] [EnemyShield] SWAT riot shield visual created with collision area (top-down view)
+[01:02:16] [INFO] [EnemyShield] Setup complete (shield_hp=20, stun=1.0s)
+[01:02:16] [ENEMY] [Platform_ShieldRight] Death animation component initialized
+[01:02:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:02:16] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[01:02:16] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[01:02:16] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[01:02:16] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[01:02:16] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[01:02:16] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[01:02:16] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[01:02:16] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[01:02:16] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[01:02:16] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[01:02:16] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[01:02:16] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[01:02:16] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[01:02:16] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[01:02:16] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[01:02:16] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[01:02:16] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[01:02:16] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[01:02:16] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[01:02:16] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[01:02:16] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[01:02:16] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[01:02:16] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[01:02:16] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[01:02:16] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[01:02:16] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[01:02:16] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[01:02:16] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[01:02:16] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[01:02:16] [INFO] [Player.ItemVisual] Visual applied for item type: 11
+[01:02:16] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[01:02:16] [INFO] [Player.Loudspeaker] Loudspeaker selected, initializing...
+[01:02:16] [INFO] [Player.Loudspeaker] Loudspeaker equipped, level: 7, charges: 0/unlimited, effect: 90%, used_this_level: False, all_charges_used: False
+[01:02:16] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[01:02:16] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[01:02:16] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[01:02:16] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[01:02:16] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[01:02:16] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[01:02:16] [INFO] [Player.Jammer] JammerHUD initialized
+[01:02:16] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[01:02:16] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[01:02:16] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[01:02:16] [INFO] [RailwayStationLevel] Found Environment/Enemies node with 18 children
+[01:02:16] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldLeft': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldRight': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator1': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator2': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator3': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator4': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Spawn_GasMaskEnemy': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft1': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft2': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft3': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight1': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight2': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight3': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Child 'Platform_ShieldRight': script=true, has_died_signal=true
+[01:02:16] [INFO] [RailwayStationLevel] Enemy tracking complete: 18 enemies registered
+[01:02:16] [INFO] [RailwayStationLevel] Setting up weapon: ak_gl
+[01:02:16] [INFO] [RailwayStationLevel] AKGL already equipped by C# Player - skipping GDScript weapon swap
+[01:02:16] [INFO] [GameManager] set_player() called with: <CharacterBody2D#1425912371392> (class: CharacterBody2D)
+[01:02:16] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[01:02:16] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[01:02:16] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[01:02:16] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[01:02:16] [INFO] [ScoreManager] Level started with 18 enemies
+[01:02:16] [INFO] [RailwayStationLevel] ReplayManager found as C# autoload
+[01:02:16] [INFO] [ReplayManager] Replay data cleared
+[01:02:16] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[01:02:16] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[01:02:16] [INFO] [ReplayManager] Level: RailwayStationLevel
+[01:02:16] [INFO] [ReplayManager] Player: Player (valid: True)
+[01:02:16] [INFO] [ReplayManager] Enemies count: 18
+[01:02:16] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[01:02:16] [INFO] [ReplayManager]   Enemy 0: NearTracks_MachineGunnerLeft
+[01:02:16] [INFO] [ReplayManager]   Enemy 1: NearTracks_MachineGunnerRight
+[01:02:16] [INFO] [ReplayManager]   Enemy 2: FarTracks_MachineGunnerLeft
+[01:02:16] [INFO] [ReplayManager]   Enemy 3: FarTracks_MachineGunnerRight
+[01:02:16] [INFO] [ReplayManager]   Enemy 4: CentralWalkway_ForceFieldLeft
+[01:02:16] [INFO] [ReplayManager]   Enemy 5: CentralWalkway_ForceFieldRight
+[01:02:16] [INFO] [ReplayManager]   Enemy 6: Exit_DroneOperator1
+[01:02:16] [INFO] [ReplayManager]   Enemy 7: Exit_DroneOperator2
+[01:02:16] [INFO] [ReplayManager]   Enemy 8: Exit_DroneOperator3
+[01:02:16] [INFO] [ReplayManager]   Enemy 9: Exit_DroneOperator4
+[01:02:16] [INFO] [ReplayManager]   Enemy 10: Spawn_GasMaskEnemy
+[01:02:16] [INFO] [ReplayManager]   Enemy 11: Platform_TeleporterLeft1
+[01:02:16] [INFO] [ReplayManager]   Enemy 12: Platform_TeleporterLeft2
+[01:02:16] [INFO] [ReplayManager]   Enemy 13: Platform_TeleporterLeft3
+[01:02:16] [INFO] [ReplayManager]   Enemy 14: Platform_TeleporterRight1
+[01:02:16] [INFO] [ReplayManager]   Enemy 15: Platform_TeleporterRight2
+[01:02:16] [INFO] [ReplayManager]   Enemy 16: Platform_TeleporterRight3
+[01:02:16] [INFO] [ReplayManager]   Enemy 17: Platform_ShieldRight
+[01:02:16] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[01:02:16] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2532.904, 2195.617) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2514.933, 2195.577) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2530.24, 2206.552) (added to group)
+[01:02:16] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 18) - skipping fallback
+[01:02:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Blood detector created and attached to NearTracks_MachineGunnerLeft
+[01:02:16] [INFO] [CinemaEffects] Found player node: Player
+[01:02:16] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[01:02:16] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerLeft (total: 1)
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerLeft] Registered as sound listener
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerLeft] Spawned at (300, 2670), hp: 2, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Blood detector created and attached to NearTracks_MachineGunnerRight
+[01:02:16] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerRight (total: 2)
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerRight] Registered as sound listener
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerRight] Spawned at (3700, 2670), hp: 3, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Blood detector created and attached to FarTracks_MachineGunnerLeft
+[01:02:16] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerLeft (total: 3)
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerLeft] Registered as sound listener
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerLeft] Spawned at (300, 1890), hp: 3, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Blood detector created and attached to FarTracks_MachineGunnerRight
+[01:02:16] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerRight (total: 4)
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerRight] Registered as sound listener
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerRight] Spawned at (3700, 1890), hp: 4, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Blood detector created and attached to CentralWalkway_ForceFieldLeft
+[01:02:16] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldLeft (total: 5)
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldLeft] Registered as sound listener
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldLeft] Spawned at (1700, 2300), hp: 4, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Blood detector created and attached to CentralWalkway_ForceFieldRight
+[01:02:16] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldRight (total: 6)
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldRight] Registered as sound listener
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldRight] Spawned at (2300, 2300), hp: 3, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Exit_DroneOperator1] Blood detector created and attached to Exit_DroneOperator1
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator1 (total: 7)
+[01:02:16] [ENEMY] [Exit_DroneOperator1] Registered as sound listener
+[01:02:16] [ENEMY] [Exit_DroneOperator1] Spawned at (700, 1100), hp: 4, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Exit_DroneOperator2] Blood detector created and attached to Exit_DroneOperator2
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator2 (total: 8)
+[01:02:16] [ENEMY] [Exit_DroneOperator2] Registered as sound listener
+[01:02:16] [ENEMY] [Exit_DroneOperator2] Spawned at (1600, 1100), hp: 3, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Exit_DroneOperator3] Blood detector created and attached to Exit_DroneOperator3
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator3 (total: 9)
+[01:02:16] [ENEMY] [Exit_DroneOperator3] Registered as sound listener
+[01:02:16] [ENEMY] [Exit_DroneOperator3] Spawned at (2500, 1100), hp: 4, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Exit_DroneOperator4] Blood detector created and attached to Exit_DroneOperator4
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator4 (total: 10)
+[01:02:16] [ENEMY] [Exit_DroneOperator4] Registered as sound listener
+[01:02:16] [ENEMY] [Exit_DroneOperator4] Spawned at (3300, 1100), hp: 4, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Blood detector created and attached to Spawn_GasMaskEnemy
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Spawn_GasMaskEnemy (total: 11)
+[01:02:16] [ENEMY] [Spawn_GasMaskEnemy] Registered as sound listener
+[01:02:16] [ENEMY] [Spawn_GasMaskEnemy] Spawned at (900, 3075), hp: 2, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Blood detector created and attached to Platform_TeleporterLeft1
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft1 (total: 12)
+[01:02:16] [ENEMY] [Platform_TeleporterLeft1] Registered as sound listener
+[01:02:16] [ENEMY] [Platform_TeleporterLeft1] Spawned at (200, 3500), hp: 2, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Blood detector created and attached to Platform_TeleporterLeft2
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft2 (total: 13)
+[01:02:16] [ENEMY] [Platform_TeleporterLeft2] Registered as sound listener
+[01:02:16] [ENEMY] [Platform_TeleporterLeft2] Spawned at (400, 3500), hp: 4, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Blood detector created and attached to Platform_TeleporterLeft3
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft3 (total: 14)
+[01:02:16] [ENEMY] [Platform_TeleporterLeft3] Registered as sound listener
+[01:02:16] [ENEMY] [Platform_TeleporterLeft3] Spawned at (600, 3500), hp: 2, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Platform_TeleporterRight1] Blood detector created and attached to Platform_TeleporterRight1
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight1 (total: 15)
+[01:02:16] [ENEMY] [Platform_TeleporterRight1] Registered as sound listener
+[01:02:16] [ENEMY] [Platform_TeleporterRight1] Spawned at (3400, 3500), hp: 2, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Platform_TeleporterRight2] Blood detector created and attached to Platform_TeleporterRight2
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight2 (total: 16)
+[01:02:16] [ENEMY] [Platform_TeleporterRight2] Registered as sound listener
+[01:02:16] [ENEMY] [Platform_TeleporterRight2] Spawned at (3600, 3500), hp: 3, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Platform_TeleporterRight3] Blood detector created and attached to Platform_TeleporterRight3
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight3 (total: 17)
+[01:02:16] [ENEMY] [Platform_TeleporterRight3] Registered as sound listener
+[01:02:16] [ENEMY] [Platform_TeleporterRight3] Spawned at (3800, 3500), hp: 2, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Platform_ShieldRight] Blood detector created and attached to Platform_ShieldRight
+[01:02:16] [INFO] [SoundPropagation] Registered listener: Platform_ShieldRight (total: 18)
+[01:02:16] [ENEMY] [Platform_ShieldRight] Registered as sound listener
+[01:02:16] [ENEMY] [Platform_ShieldRight] Spawned at (3600, 3650), hp: 3, behavior: GUARD
+[01:02:16] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[01:02:16] [INFO] [Player.Loudspeaker] Level 7 victory state — all enemies start as pacifists!
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldLeft] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldRight] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Exit_DroneOperator1] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Exit_DroneOperator2] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Exit_DroneOperator3] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Exit_DroneOperator4] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Spawn_GasMaskEnemy] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Platform_TeleporterLeft1] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Platform_TeleporterLeft2] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Platform_TeleporterLeft3] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Platform_TeleporterRight1] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Platform_TeleporterRight2] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Platform_TeleporterRight3] Transitioned to PACIFIST
+[01:02:16] [ENEMY] [Platform_ShieldRight] Transitioned to PACIFIST
+[01:02:16] [INFO] [Player.Loudspeaker] Victory message shown (Level 7)
+[01:02:16] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=18
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerLeft] Found cover at (0, 0) (distance: 2686.8, player at (2000, 3100))
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerRight] Found cover at (0, 0) (distance: 4562.8, player at (2000, 3100))
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerLeft] Found cover at (0, 0) (distance: 1913.7, player at (2000, 3100))
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerRight] Found cover at (0, 0) (distance: 4154.8, player at (2000, 3100))
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldLeft] Found cover at (0, 0) (distance: 2860.1, player at (2000, 3100))
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldRight] Found cover at (0, 0) (distance: 3252.7, player at (2000, 3100))
+[01:02:16] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (0, 0) (distance: 3204.0, player at (2000, 3100))
+[01:02:16] [ENEMY] [Platform_TeleporterLeft1] Found cover at (0, 0) (distance: 3505.7, player at (2000, 3100))
+[01:02:16] [ENEMY] [Platform_TeleporterLeft2] Found cover at (0, 0) (distance: 3522.8, player at (2000, 3100))
+[01:02:16] [ENEMY] [Platform_TeleporterLeft3] Found cover at (0, 0) (distance: 3551.1, player at (2000, 3100))
+[01:02:16] [ENEMY] [Platform_TeleporterRight1] Found cover at (0, 0) (distance: 4879.5, player at (2000, 3100))
+[01:02:16] [ENEMY] [Platform_TeleporterRight2] Found cover at (0, 0) (distance: 5021.0, player at (2000, 3100))
+[01:02:16] [ENEMY] [Platform_TeleporterRight3] Found cover at (0, 0) (distance: 5166.2, player at (2000, 3100))
+[01:02:16] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[01:02:16] [ENEMY] [Platform_ShieldRight] Found cover at (0, 0) (distance: 5126.6, player at (2000, 3100))
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-73.2°, current=90.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-113.6°, current=90.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-75.8°, current=90.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-119.2°, current=90.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-126.5°, current=90.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-135.0°, current=90.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: none -> P1:visible, state=PACIFIST, target=2.0°, current=0.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-93.3°, current=0.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-96.5°, current=0.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-99.7°, current=0.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-134.2°, current=0.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-135.8°, current=0.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-137.4°, current=0.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: none -> P4:shield_delayed, state=PACIFIST, target=-161.0°, current=-90.0°, player=(2000,3099), corner_timer=0.00
+[01:02:16] [INFO] [Player] Detecting weapon pose (frame 3)...
+[01:02:16] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[01:02:16] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[01:02:16] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-12.1°, current=-11.5°, player=(2000,3095), corner_timer=0.00
+[01:02:16] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[01:02:16] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[01:02:16] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[01:02:16] [INFO] [LastChance] Found player: Player
+[01:02:16] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[01:02:16] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[01:02:16] [INFO] [LastChance] Connected to player Died signal (C#)
+[01:02:16] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2488.773, 2180.521) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2534.966, 2253.824) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2527.455, 2169.219) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2497.252, 2276.371) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2567.437, 2233.438) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2520.954, 2300.437) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2482.145, 2216.075) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2432.294, 2247.311) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2460.927, 2325.863) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2458.436, 2164.093) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2544.642, 2200.204) (added to group)
+[01:02:16] [INFO] [BloodDecal] Blood puddle created at (2471.443, 2167.231) (added to group)
+[01:02:16] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-13.5°, current=-43.0°, player=(2000,3054), corner_timer=0.00
+[01:02:16] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-106.4°, current=1.6°, player=(2000,3005), corner_timer=0.00
+[01:02:16] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:02:16] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:02:16] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:02:16] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:02:16] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-96.5°, current=-14.2°, player=(2000,2988), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-93.3°, current=-12.8°, player=(2000,2983), corner_timer=0.00
+[01:02:16] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=0.9°, current=-15.6°, player=(2000,2972), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-13.1°, current=-29.9°, player=(2000,2950), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-161.7°, current=-126.1°, player=(2000,2895), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-158.8°, current=-134.2°, player=(2000,2878), corner_timer=0.00
+[01:02:16] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-135.8°, current=-143.2°, player=(2000,2862), corner_timer=0.00
+[01:02:17] [INFO] [Drone] _ready started
+[01:02:17] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:02:17] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:02:17] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:02:17] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:02:17] [INFO] [Drone] Initialized by operator: Exit_DroneOperator1
+[01:02:17] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:02:17] [INFO] [DroneOperator] Connected to drone.died signal
+[01:02:17] [INFO] [DroneOperator] Drone deployed at (700, 1084)
+[01:02:17] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:02:17] [INFO] [Drone] _ready started
+[01:02:17] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:02:17] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:02:17] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:02:17] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:02:17] [INFO] [Drone] Initialized by operator: Exit_DroneOperator2
+[01:02:17] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:02:17] [INFO] [DroneOperator] Connected to drone.died signal
+[01:02:17] [INFO] [DroneOperator] Drone deployed at (1600, 1060)
+[01:02:17] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:02:17] [INFO] [Drone] _ready started
+[01:02:17] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:02:17] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:02:17] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:02:17] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:02:17] [INFO] [Drone] Initialized by operator: Exit_DroneOperator3
+[01:02:17] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:02:17] [INFO] [DroneOperator] Connected to drone.died signal
+[01:02:17] [INFO] [DroneOperator] Drone deployed at (2500, 1084)
+[01:02:17] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:02:17] [INFO] [Drone] _ready started
+[01:02:17] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:02:17] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:02:17] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:02:17] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:02:17] [INFO] [Drone] Initialized by operator: Exit_DroneOperator4
+[01:02:17] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:02:17] [INFO] [DroneOperator] Connected to drone.died signal
+[01:02:17] [INFO] [DroneOperator] Drone deployed at (3300, 1084)
+[01:02:17] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:02:17] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-162.4°, current=-137.4°, player=(2000,2836), corner_timer=0.00
+[01:02:17] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:02:17] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:02:17] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:02:17] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:02:17] [INFO] [Teleporter] Component initialized on Exit_DroneOperator1
+[01:02:17] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:02:17] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:02:17] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:02:17] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:02:17] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:02:17] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:02:17] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:02:17] [INFO] [Teleporter] Component initialized on Exit_DroneOperator2
+[01:02:17] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:02:17] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:02:17] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:02:17] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:02:17] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:02:17] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:02:17] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:02:17] [INFO] [Teleporter] Component initialized on Exit_DroneOperator3
+[01:02:17] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:02:17] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:02:17] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:02:17] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:02:17] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:02:17] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:02:17] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:02:17] [INFO] [Teleporter] Component initialized on Exit_DroneOperator4
+[01:02:17] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:02:17] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:02:17] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:02:17] [ENEMY] [Exit_DroneOperator1] State: IN_COVER -> PURSUING
+[01:02:17] [ENEMY] [Exit_DroneOperator2] State: IN_COVER -> PURSUING
+[01:02:17] [ENEMY] [Exit_DroneOperator3] State: IN_COVER -> PURSUING
+[01:02:17] [ENEMY] [Exit_DroneOperator4] State: IN_COVER -> PURSUING
+[01:02:17] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-93.3°, current=-14.1°, player=(2000,2830), corner_timer=0.00
+[01:02:17] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=18
+[01:02:17] [ENEMY] [Exit_DroneOperator1] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=52.7°, current=0.0°, player=(2000,2827), corner_timer=0.00
+[01:02:17] [ENEMY] [Exit_DroneOperator2] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=77.0°, current=0.0°, player=(2000,2827), corner_timer=0.00
+[01:02:17] [ENEMY] [Exit_DroneOperator3] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=106.4°, current=0.0°, player=(2000,2827), corner_timer=0.00
+[01:02:17] [ENEMY] [Exit_DroneOperator4] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=127.3°, current=0.0°, player=(2000,2827), corner_timer=0.00
+[01:02:17] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-111.0°, current=-157.8°, player=(2000,2827), corner_timer=0.00
+[01:02:17] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-160.3°, current=-135.8°, player=(2000,2826), corner_timer=0.00
+[01:02:17] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-12.8°, current=-48.4°, player=(2009,2826), corner_timer=0.00
+[01:02:17] [WARN] [FPS] Drop detected: 22 fps (threshold: 30)
+[01:02:17] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-93.3°, current=-10.4°, player=(2094,2826), corner_timer=0.00
+[01:02:17] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-158.2°, current=-134.3°, player=(2100,2826), corner_timer=0.00
+[01:02:17] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -152.9° (interval=1.5s)
+[01:02:18] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=18
+[01:02:18] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P4:shield_delayed -> P1:shield_delayed, state=PACIFIST, target=-152.9°, current=-146.3°, player=(2288,2826), corner_timer=0.00
+[01:02:18] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-137.4°, current=-163.3°, player=(2305,2826), corner_timer=0.00
+[01:02:18] [ENEMY] [Exit_DroneOperator1] FLANKING started: target=(2194.276, 2876.99), side=left, pos=(700, 1124.58)
+[01:02:18] [ENEMY] [Exit_DroneOperator1] State: PURSUING -> FLANKING
+[01:02:18] [ENEMY] [Exit_DroneOperator2] FLANKING started: target=(2188.576, 2834), side=left, pos=(1600, 1100.512)
+[01:02:18] [ENEMY] [Exit_DroneOperator2] State: PURSUING -> FLANKING
+[01:02:18] [ENEMY] [Exit_DroneOperator3] Warning: No LOS-positive flank position, falling back to nav-reachable side
+[01:02:18] [ENEMY] [Exit_DroneOperator3] FLANKING started: target=(2567.084, 2686), side=right, pos=(2500, 1124.58)
+[01:02:18] [ENEMY] [Exit_DroneOperator3] State: PURSUING -> FLANKING
+[01:02:18] [ENEMY] [Exit_DroneOperator4] FLANKING started: target=(2587.569, 2834), side=right, pos=(3300, 1124.58)
+[01:02:18] [ENEMY] [Exit_DroneOperator4] State: PURSUING -> FLANKING
+[01:02:18] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 156.1°
+[01:02:18] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:18] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -22.4°
+[01:02:18] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 158.1°
+[01:02:18] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 132.6°
+[01:02:18] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:18] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:18] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 134.6°
+[01:02:19] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-165.1°, current=-126.0°, player=(2536,2826), corner_timer=0.00
+[01:02:19] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=18
+[01:02:19] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -143.8° (interval=1.5s)
+[01:02:19] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-135.7°, current=-158.4°, player=(2569,2826), corner_timer=0.00
+[01:02:19] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:19] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:19] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:19] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 49.7°
+[01:02:19] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-0.2°, current=-44.6°, player=(2613,2825), corner_timer=0.00
+[01:02:19] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-0.6°, current=-33.8°, player=(2640,2813), corner_timer=0.00
+[01:02:19] [WARN] [FPS] Drop detected: 29 fps (threshold: 30)
+[01:02:19] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=173.6°, current=-1.1°, player=(2634,2794), corner_timer=0.00
+[01:02:19] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-16.6°, player=(2634,2794), corner_timer=0.00
+[01:02:19] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-156.5°, current=-118.5°, player=(2630,2788), corner_timer=0.00
+[01:02:19] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-137.7°, current=-164.3°, player=(2630,2788), corner_timer=0.00
+[01:02:19] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-1.2°, player=(2624,2780), corner_timer=0.00
+[01:02:19] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:19] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:19] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:19] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 55.0°
+[01:02:19] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-112.7°, current=-135.7°, player=(2618,2764), corner_timer=0.00
+[01:02:19] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-134.2°, current=-142.8°, player=(2618,2749), corner_timer=0.00
+[01:02:19] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P1:shield_delayed -> P4:shield_delayed, state=PACIFIST, target=-143.8°, current=-143.8°, player=(2618,2749), corner_timer=0.00
+[01:02:19] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=176.3°, current=-180.0°, player=(2618,2716), corner_timer=0.00
+[01:02:19] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=1.4°, current=0.0°, player=(2618,2705), corner_timer=0.00
+[01:02:19] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:19] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:19] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:19] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 59.8°
+[01:02:20] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=18
+[01:02:20] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:20] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:02:20] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:20] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 64.4°
+[01:02:20] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:20] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 4.3°
+[01:02:20] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:02:20] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 68.7°
+[01:02:20] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -142.8° (interval=1.5s)
+[01:02:20] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:02:20] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.9°
+[01:02:20] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -68.0°
+[01:02:20] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -119.1°
+[01:02:21] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=18
+[01:02:21] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 13.3°
+[01:02:21] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:02:21] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -71.4°
+[01:02:21] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 40.8°
+[01:02:21] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -32.1°
+[01:02:21] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:02:21] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -74.7°
+[01:02:21] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-177.4°, current=-137.6°, player=(2048,2646), corner_timer=0.00
+[01:02:21] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.1°
+[01:02:21] [INFO] [Player] Invincibility mode: ON
+[01:02:21] [INFO] [GameManager] Invincibility mode toggled: ON
+[01:02:21] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 8.0°
+[01:02:21] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:02:21] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -99.5°
+[01:02:22] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=18
+[01:02:22] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:02:22] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -156.8° (interval=1.5s)
+[01:02:22] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.3°
+[01:02:22] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:02:22] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -97.6°
+[01:02:22] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=-178.7°, player=(1833,2612), corner_timer=0.00
+[01:02:22] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=-176.3°, player=(1833,2612), corner_timer=0.00
+[01:02:22] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-2.2°, player=(1833,2602), corner_timer=0.00
+[01:02:22] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:22] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:02:22] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:02:22] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -81.6°
+[01:02:22] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:22] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -87.8°
+[01:02:22] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:02:22] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -95.0°
+[01:02:23] [INFO] [ForceFieldEffect] Activated! Charge: 5.0s/8.0s
+[01:02:23] [INFO] [EnemyForceField] Activated
+[01:02:23] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=48.5°, current=0.0°, player=(1896,2460), corner_timer=0.00
+[01:02:23] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=18
+[01:02:23] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:23] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -83.6°
+[01:02:23] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:02:23] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -94.0°
+[01:02:23] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:23] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:02:23] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -85.3°
+[01:02:23] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -142.8° (interval=1.5s)
+[01:02:23] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:23] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:02:23] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -85.2°
+[01:02:24] [INFO] [WeaponHintsComponent] Auto-dismiss timer: clearing all remaining hints for ak_gl
+[01:02:24] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=18
+[01:02:24] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:24] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:02:24] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -108.6°
+[01:02:24] [INFO] [ForceFieldEffect] Activated! Charge: 5.0s/8.0s
+[01:02:24] [INFO] [EnemyForceField] Activated
+[01:02:24] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=35.3°, current=-7.1°, player=(2204,2152), corner_timer=0.00
+[01:02:24] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:24] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:02:24] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.5°
+[01:02:24] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:24] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:02:24] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -108.6°
+[01:02:25] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=18
+[01:02:25] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=-3.9°, player=(2345,1993), corner_timer=0.00
+[01:02:25] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=173.5°, current=-12.2°, player=(2345,1987), corner_timer=0.00
+[01:02:25] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -119.8° (interval=1.5s)
+[01:02:25] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:25] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:02:25] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.5°
+[01:02:25] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=175.7°, current=-180.0°, player=(2345,1938), corner_timer=0.00
+[01:02:25] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=1.9°, current=0.0°, player=(2345,1932), corner_timer=0.00
+[01:02:25] [ENEMY] [Exit_DroneOperator2] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=4.6°, current=1.9°, player=(2346,1916), corner_timer=-0.02
+[01:02:25] [ENEMY] [Exit_DroneOperator2] State: FLANKING -> COMBAT
+[01:02:25] [ENEMY] [Exit_DroneOperator2] Found cover at (1918.317, 1726) (distance: 155.5, player at (2347.781, 1911.434))
+[01:02:25] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:25] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:02:25] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.6°
+[01:02:25] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:25] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:02:25] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -108.6°
+[01:02:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.433, 1891.742), source=ENEMY (Exit_DroneOperator2), range=800, listeners=18
+[01:02:26] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[01:02:26] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=18
+[01:02:26] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2113.8, 1905.9), source=NEUTRAL (null), range=900, listeners=18
+[01:02:26] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2113.8, 1905.9), intensity=0.01, dist=595
+[01:02:26] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2113.8, 1905.9), intensity=0.10, dist=156
+[01:02:26] [ENEMY] [Exit_DroneOperator1] Heard CASING_KICK at (2113.8, 1905.9), intensity=0.00, dist=823
+[01:02:26] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2113.8, 1905.9), intensity=1.00, dist=34
+[01:02:26] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2113.8, 1905.9), intensity=0.00, dist=744
+[01:02:26] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (2113.8, 1905.9), intensity=0.01, dist=626
+[01:02:26] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2113.8, 1905.9), intensity=0.00, dist=756
+[01:02:26] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2113.8, 1905.9), intensity=0.00, dist=756
+[01:02:26] [INFO] [SoundPropagation] Sound result: notified=8, out_of_range=10, self=0
+[01:02:26] [INFO] [ScoreManager] Damage taken: 1 (total: 1)
+[01:02:26] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:26] [INFO] [Player] Spawning blood effect at (2560.059, 1866.0669), dir=(0.9982059, -0.059873458), lethal=False (C#)
+[01:02:26] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:26] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:26] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:02:26] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -85.2°
+[01:02:26] [INFO] [ScoreManager] Damage taken: 1 (total: 2)
+[01:02:26] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:26] [INFO] [Player] Spawning blood effect at (2637.059, 1866.0669), dir=(0.99804366, -0.06252138), lethal=False (C#)
+[01:02:26] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2643.551, 1911.405) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2605.23, 1887.391) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2608.768, 1892.083) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2605.372, 1870.908) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2633.636, 1904.167) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2623.401, 1881.465) (added to group)
+[01:02:26] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2245.421, 1904.787), source=NEUTRAL (null), range=900, listeners=18
+[01:02:26] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (2245.421, 1904.787), intensity=0.00, dist=886
+[01:02:26] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2245.421, 1904.787), intensity=0.00, dist=723
+[01:02:26] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2245.421, 1904.787), intensity=0.05, dist=234
+[01:02:26] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2245.421, 1904.787), intensity=1.00, dist=30
+[01:02:26] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2245.421, 1904.787), intensity=0.01, dist=615
+[01:02:26] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (2245.421, 1904.787), intensity=0.01, dist=691
+[01:02:26] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2245.421, 1904.787), intensity=0.00, dist=736
+[01:02:26] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2245.421, 1904.787), intensity=0.00, dist=822
+[01:02:26] [INFO] [SoundPropagation] Sound result: notified=8, out_of_range=10, self=0
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2687.626, 1854.264) (added to group)
+[01:02:26] [INFO] [ScoreManager] Damage taken: 1 (total: 3)
+[01:02:26] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:26] [INFO] [Player] Spawning blood effect at (2708.559, 1866.0669), dir=(0.9985449, -0.05392802), lethal=False (C#)
+[01:02:26] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:26] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:26] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:02:26] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.6°
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2639.672, 1907.962) (added to group)
+[01:02:26] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2292.965, 1893.936), source=ENEMY (Exit_DroneOperator2), range=800, listeners=18
+[01:02:26] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2673.527, 1894.271) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2722.595, 1909.413) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2700.058, 1883.281) (added to group)
+[01:02:26] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -91.9° (interval=1.5s)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2711.309, 1894.383) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2693.937, 1903.186) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2719.925, 1863.403) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2748.88, 1855.805) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2738.103, 1882.448) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2756.366, 1862.294) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2727.76, 1927.878) (added to group)
+[01:02:26] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2654.828, 1917.646) (added to group)
+[01:02:26] [INFO] [ScoreManager] Damage taken: 1 (total: 4)
+[01:02:26] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:26] [INFO] [Player] Spawning blood effect at (2780.059, 1866.0669), dir=(0.99830484, -0.058202762), lethal=False (C#)
+[01:02:26] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2754.683, 1922.302) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2710.128, 1871.157) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2765.42, 1876.472) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2749.505, 1861.374) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2744.246, 1880.075) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2761.052, 1885.028) (added to group)
+[01:02:26] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:02:26] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:02:26] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -85.0°
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2783.41, 1852.176) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2782.596, 1857.778) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2825.26, 1924.535) (added to group)
+[01:02:26] [INFO] [BloodDecal] Blood puddle created at (2790.153, 1871.429) (added to group)
+[01:02:27] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2377.213, 1904.107), source=NEUTRAL (null), range=900, listeners=18
+[01:02:27] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (2377.213, 1904.107), intensity=0.00, dist=732
+[01:02:27] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2377.213, 1904.107), intensity=0.00, dist=853
+[01:02:27] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2377.213, 1904.107), intensity=0.02, dist=347
+[01:02:27] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2377.213, 1904.107), intensity=1.00, dist=26
+[01:02:27] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2377.213, 1904.107), intensity=0.01, dist=489
+[01:02:27] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (2377.213, 1904.107), intensity=0.00, dist=804
+[01:02:27] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2377.213, 1904.107), intensity=0.00, dist=799
+[01:02:27] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2377.213, 1904.107), intensity=0.00, dist=889
+[01:02:27] [INFO] [SoundPropagation] Sound result: notified=8, out_of_range=10, self=0
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2758.656, 1922.259) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2781.256, 1878.821) (added to group)
+[01:02:27] [INFO] [ScoreManager] Damage taken: 1 (total: 5)
+[01:02:27] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:27] [INFO] [Player] Spawning blood effect at (2851.559, 1866.0669), dir=(0.9970782, -0.07638767), lethal=False (C#)
+[01:02:27] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2813.951, 1911.346) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2814.495, 1925.746) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2804.043, 1908.367) (added to group)
+[01:02:27] [INFO] [ForceFieldEffect] Released 0 trapped projectiles
+[01:02:27] [INFO] [ForceFieldEffect] Deactivated. Charge remaining: 1.0s
+[01:02:27] [INFO] [EnemyForceField] Deactivated — recharging for 5.0s
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2847.62, 1928.483) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2812.814, 1860.747) (added to group)
+[01:02:27] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=18
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2847.693, 1879.059) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2839.12, 1917.685) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2860.761, 1902.38) (added to group)
+[01:02:27] [ENEMY] [Exit_DroneOperator3] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=68.6°, current=74.2°, player=(2886,1854), corner_timer=0.07
+[01:02:27] [ENEMY] [Exit_DroneOperator3] State: FLANKING -> COMBAT
+[01:02:27] [ENEMY] [Exit_DroneOperator3] Found cover at (2804.356, 1715.358) (distance: 32.4, player at (2886.03, 1851.854))
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2852.305, 1929.634) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2900.185, 1929.925) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2920.802, 1916.109) (added to group)
+[01:02:27] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:02:27] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -85.2°
+[01:02:27] [ENEMY] [Exit_DroneOperator3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=56.8°, current=56.3°, player=(2884,1834), corner_timer=0.07
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2862.001, 1918.922) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2913.394, 1901.98) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2932.862, 1909.671) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2899.12, 1863.537) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2923.958, 1874.184) (added to group)
+[01:02:27] [ENEMY] [FarTracks_MachineGunnerRight] [#1033] Machine gunner front-arc hit ignored
+[01:02:27] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=-168.0°, player=(2884,1824), corner_timer=0.00
+[01:02:27] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=0.0°, current=-1.3°, player=(2884,1819), corner_timer=0.00
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2886.938, 1923.118) (added to group)
+[01:02:27] [ENEMY] [Exit_DroneOperator2] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=-14.8°, current=-14.8°, player=(2884,1802), corner_timer=-0.02
+[01:02:27] [ENEMY] [Exit_DroneOperator2] State: COMBAT -> PURSUING
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2927.598, 1888.88) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2938.661, 1854.294) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2936.734, 1890.687) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2906.721, 1907.464) (added to group)
+[01:02:27] [ENEMY] [Exit_DroneOperator2] PURSUING: close/visible unhittable target, attempting FLANKING before pursuit cover
+[01:02:27] [ENEMY] [Exit_DroneOperator2] FLANKING started: target=(2835.984, 2054), side=left, pos=(2520.97, 1901.52)
+[01:02:27] [ENEMY] [Exit_DroneOperator2] State: PURSUING -> FLANKING
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2919.615, 1895.685) (added to group)
+[01:02:27] [ENEMY] [Exit_DroneOperator3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=22.5°, current=22.5°, player=(2884,1769), corner_timer=0.07
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2943.607, 1912.829) (added to group)
+[01:02:27] [ENEMY] [Exit_DroneOperator4] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=174.3°, current=170.6°, player=(2884,1747), corner_timer=0.03
+[01:02:27] [ENEMY] [Exit_DroneOperator4] State: FLANKING -> COMBAT
+[01:02:27] [WARN] [FPS] Drop detected: 29 fps (threshold: 30)
+[01:02:27] [ENEMY] [Exit_DroneOperator1] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=0.6°, current=-1.2°, player=(2884,1742), corner_timer=0.02
+[01:02:27] [ENEMY] [Exit_DroneOperator1] State: FLANKING -> COMBAT
+[01:02:27] [ENEMY] [Exit_DroneOperator4] Found cover at (3424.134, 1874) (distance: 189.2, player at (2884.44, 1742.442))
+[01:02:27] [ENEMY] [Exit_DroneOperator1] Found cover at (1751.313, 1031.278) (distance: 823.6, player at (2884.44, 1736.942))
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (3027.571, 1910.045) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (3042.388, 1864.985) (added to group)
+[01:02:27] [INFO] [BloodDecal] Blood puddle created at (2941.068, 1923.279) (added to group)
+[01:02:27] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2768.902, 1725.933), source=ENEMY (Exit_DroneOperator3), range=800, listeners=18
+[01:02:27] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[01:02:28] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -162.7°
+[01:02:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[01:02:28] [INFO] [BloodyFeet:Player] Blood ran out - no more footprints
+[01:02:28] [INFO] [ReplayManager] Recording frame 720 (12,0s): player_valid=True, enemies=18
+[01:02:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3284.292, 1673.501), source=ENEMY (Exit_DroneOperator4), range=800, listeners=18
+[01:02:28] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[01:02:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1468.221, 1688.477), source=ENEMY (Exit_DroneOperator1), range=800, listeners=18
+[01:02:28] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[01:02:28] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -79.2° (interval=1.5s)
+[01:02:28] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1488.549, 1702.656), source=NEUTRAL (null), range=900, listeners=18
+[01:02:28] [ENEMY] [FarTracks_MachineGunnerLeft] Heard CASING_KICK at (1488.549, 1702.656), intensity=0.00, dist=847
+[01:02:28] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1488.549, 1702.656), intensity=0.02, dist=355
+[01:02:28] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (1488.549, 1702.656), intensity=0.01, dist=675
+[01:02:28] [ENEMY] [Exit_DroneOperator1] Heard CASING_KICK at (1488.549, 1702.656), intensity=1.00, dist=34
+[01:02:28] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (1488.549, 1702.656), intensity=0.02, dist=375
+[01:02:28] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (1488.549, 1702.656), intensity=0.01, dist=519
+[01:02:28] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (1488.549, 1702.656), intensity=0.01, dist=703
+[01:02:28] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=11, self=0
+[01:02:28] [INFO] [ForceFieldEffect] Released 0 trapped projectiles
+[01:02:28] [INFO] [ForceFieldEffect] Deactivated. Charge remaining: 1.0s
+[01:02:28] [INFO] [EnemyForceField] Deactivated — recharging for 5.0s
+[01:02:28] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -9.2°
+[01:02:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2768.902, 1725.933), source=ENEMY (Exit_DroneOperator3), range=800, listeners=18
+[01:02:28] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[01:02:28] [WARN] [FPS] Drop detected: 28 fps (threshold: 30)
+[01:02:28] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -0.1°
+[01:02:28] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2330.09, 1955.397), source=NEUTRAL (null), range=900, listeners=18
+[01:02:28] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (2330.09, 1955.397), intensity=0.01, dist=703
+[01:02:28] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2330.09, 1955.397), intensity=0.00, dist=799
+[01:02:28] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2330.09, 1955.397), intensity=0.03, dist=283
+[01:02:28] [ENEMY] [Exit_DroneOperator1] Heard CASING_KICK at (2330.09, 1955.397), intensity=0.00, dist=745
+[01:02:28] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2330.09, 1955.397), intensity=1.00, dist=20
+[01:02:28] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2330.09, 1955.397), intensity=0.01, dist=495
+[01:02:28] [ENEMY] [Exit_DroneOperator4] Heard CASING_KICK at (2330.09, 1955.397), intensity=0.00, dist=880
+[01:02:28] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2330.09, 1955.397), intensity=0.00, dist=791
+[01:02:28] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2330.09, 1955.397), intensity=0.00, dist=736
+[01:02:28] [INFO] [SoundPropagation] Sound result: notified=9, out_of_range=9, self=0
+[01:02:28] [INFO] [ScoreManager] Damage taken: 1 (total: 6)
+[01:02:28] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:28] [INFO] [Player] Spawning blood effect at (2924.0178, 1351.8359), dir=(0.3520399, -0.935985), lethal=False (C#)
+[01:02:28] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3109.33, 1565.689), source=ENEMY (Exit_DroneOperator4), range=800, listeners=18
+[01:02:28] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[01:02:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1672.899, 1652.476), source=ENEMY (Exit_DroneOperator1), range=800, listeners=18
+[01:02:28] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[01:02:29] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.1°
+[01:02:29] [INFO] [ReplayManager] Recording frame 780 (13,0s): player_valid=True, enemies=18
+[01:02:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2768.902, 1725.933), source=ENEMY (Exit_DroneOperator3), range=800, listeners=18
+[01:02:29] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2984.741, 1297.035) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2954.008, 1274.104) (added to group)
+[01:02:29] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2925.95, 1300.781) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2920.433, 1322.055) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2981.028, 1280.194) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2951.722, 1272.384) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2912.781, 1297.885) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2962.243, 1325.224) (added to group)
+[01:02:29] [INFO] [ScoreManager] Damage taken: 1 (total: 7)
+[01:02:29] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:29] [INFO] [Player] Spawning blood effect at (3020.0269, 1229.2988), dir=(0.45934835, -0.8882562), lethal=False (C#)
+[01:02:29] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2915.212, 1250.895) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2945.675, 1264.068) (added to group)
+[01:02:29] [INFO] [ScoreManager] Damage taken: 1 (total: 8)
+[01:02:29] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:29] [INFO] [Player] Spawning blood effect at (3019.2085, 1216.2314), dir=(-0.20224302, -0.97933537), lethal=False (C#)
+[01:02:29] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2981.398, 1282.976) (added to group)
+[01:02:29] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 131.7°
+[01:02:29] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1827.311, 1626.744), source=NEUTRAL (null), range=900, listeners=18
+[01:02:29] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1827.311, 1626.744), intensity=0.01, dist=516
+[01:02:29] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (1827.311, 1626.744), intensity=0.01, dist=489
+[01:02:29] [ENEMY] [Exit_DroneOperator1] Heard CASING_KICK at (1827.311, 1626.744), intensity=1.00, dist=36
+[01:02:29] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (1827.311, 1626.744), intensity=0.01, dist=643
+[01:02:29] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (1827.311, 1626.744), intensity=0.00, dist=715
+[01:02:29] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (1827.311, 1626.744), intensity=0.01, dist=577
+[01:02:29] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (1827.311, 1626.744), intensity=0.01, dist=594
+[01:02:29] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=11, self=0
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2998.297, 1268.111) (added to group)
+[01:02:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3080.905, 1527.085), source=ENEMY (Exit_DroneOperator4), range=800, listeners=18
+[01:02:29] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2977.459, 1284.372) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2924.017, 1319.38) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2973.136, 1250.053) (added to group)
+[01:02:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1872.509, 1594.324), source=ENEMY (Exit_DroneOperator1), range=800, listeners=18
+[01:02:29] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3047.503, 1188.334) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3023.962, 1155.94) (added to group)
+[01:02:29] [INFO] [ScoreManager] Damage taken: 1 (total: 9)
+[01:02:29] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:29] [INFO] [Player] Spawning blood effect at (2984.1057, 1166.0568), dir=(-0.21548806, -0.9765065), lethal=False (C#)
+[01:02:29] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2969.529, 1101) (added to group)
+[01:02:29] [WARN] [FPS] Drop detected: 26 fps (threshold: 30)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3076.734, 1204.559) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2986.116, 1144.434) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3057.781, 1206.741) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3061.741, 1191.37) (added to group)
+[01:02:29] [ENEMY] [Exit_DroneOperator3] Found cover at (2821.364, 1885.387) (distance: 167.9, player at (2973.976, 1156.762))
+[01:02:29] [ENEMY] [Exit_DroneOperator3] State: COMBAT -> SEEKING_COVER
+[01:02:29] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 40.3°
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3023.747, 1200.421) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3093.94, 1188.13) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3058.272, 1175.489) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3004.507, 1133.397) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3017.826, 1190.658) (added to group)
+[01:02:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2775.214, 1718.101), source=ENEMY (Exit_DroneOperator3), range=800, listeners=18
+[01:02:29] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[01:02:29] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -78.1° (interval=1.5s)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3034.845, 1178.33) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3062.239, 1168.873) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3054.778, 1149.509) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3003.953, 1178.236) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3030.426, 1151.312) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3030.011, 1166.676) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2959.277, 1177.997) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3036.289, 1155.881) (added to group)
+[01:02:29] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2805.34, 1714.831), source=NEUTRAL (null), range=900, listeners=18
+[01:02:29] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (2805.34, 1714.831), intensity=0.04, dist=237
+[01:02:29] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2805.34, 1714.831), intensity=0.00, dist=815
+[01:02:29] [ENEMY] [Exit_DroneOperator1] Heard CASING_KICK at (2805.34, 1714.831), intensity=0.00, dist=898
+[01:02:29] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2805.34, 1714.831), intensity=0.01, dist=560
+[01:02:29] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2805.34, 1714.831), intensity=1.00, dist=10
+[01:02:29] [ENEMY] [Exit_DroneOperator4] Heard CASING_KICK at (2805.34, 1714.831), intensity=0.02, dist=333
+[01:02:29] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=12, self=0
+[01:02:29] [INFO] [ScoreManager] Damage taken: 1 (total: 10)
+[01:02:29] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:29] [INFO] [Player] Spawning blood effect at (2968.3918, 1151.6383), dir=(-0.31409267, -0.9493923), lethal=False (C#)
+[01:02:29] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2951.308, 1101) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3075.498, 1221.197) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3015.775, 1113.011) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3008.106, 1173.604) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2951.146, 1131.601) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3179.604, 1205.625) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3064.344, 1132.716) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3053.203, 1199.594) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2993.317, 1202.047) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2996.185, 1161.222) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (3002.422, 1111.537) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2953.151, 1148.149) (added to group)
+[01:02:29] [INFO] [BloodDecal] Blood puddle created at (2962.518, 1103.729) (added to group)
+[01:02:30] [INFO] [ScoreManager] Damage taken: 1 (total: 11)
+[01:02:30] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:30] [INFO] [Player] Spawning blood effect at (2968.3918, 1151.6383), dir=(0.3214154, -0.94693834), lethal=False (C#)
+[01:02:30] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2985.919, 1101) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2931.007, 1111.142) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2979.546, 1192.905) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (3047.735, 1182.436) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2978.923, 1111.027) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2951.097, 1112.014) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2921.218, 1107.603) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2946.153, 1155.278) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2925.684, 1102.398) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2951.601, 1123.597) (added to group)
+[01:02:30] [INFO] [ScoreManager] Damage taken: 1 (total: 12)
+[01:02:30] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:30] [INFO] [Player] Spawning blood effect at (2968.3918, 1151.6383), dir=(-0.30929413, -0.9509664), lethal=False (C#)
+[01:02:30] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2951.597, 1101) (added to group)
+[01:02:30] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 120.4°
+[01:02:30] [INFO] [ReplayManager] Recording frame 840 (14,0s): player_valid=True, enemies=18
+[01:02:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3080.905, 1527.085), source=ENEMY (Exit_DroneOperator4), range=800, listeners=18
+[01:02:30] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2917.543, 1105.656) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2946.954, 1124.832) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2899.025, 1104.87) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2906.418, 1109.275) (added to group)
+[01:02:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1917.458, 1577.49), source=ENEMY (Exit_DroneOperator1), range=800, listeners=18
+[01:02:30] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2948.72, 1125.996) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2937.308, 1117.068) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2945.506, 1129.014) (added to group)
+[01:02:30] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2900.3, 1768.861), source=NEUTRAL (null), range=900, listeners=18
+[01:02:30] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (2900.3, 1768.861), intensity=0.17, dist=122
+[01:02:30] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2900.3, 1768.861), intensity=0.00, dist=883
+[01:02:30] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2900.3, 1768.861), intensity=0.01, dist=619
+[01:02:30] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2900.3, 1768.861), intensity=1.00, dist=23
+[01:02:30] [ENEMY] [Exit_DroneOperator4] Heard CASING_KICK at (2900.3, 1768.861), intensity=0.03, dist=302
+[01:02:30] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=13, self=0
+[01:02:30] [INFO] [ScoreManager] Damage taken: 1 (total: 13)
+[01:02:30] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:30] [INFO] [Player] Spawning blood effect at (2968.3918, 1151.6383), dir=(-0.30583894, -0.95208323), lethal=False (C#)
+[01:02:30] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2951.804, 1101) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2888.027, 1101.602) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2887.112, 1121.529) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2969.854, 1126.008) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2980.583, 1112.3) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2971.368, 1130.893) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (3031.458, 1113.722) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2970.158, 1108.503) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2966.077, 1104.325) (added to group)
+[01:02:30] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 70.7°
+[01:02:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2877.934, 1811.565), source=ENEMY (Exit_DroneOperator3), range=800, listeners=18
+[01:02:30] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[01:02:30] [INFO] [ScoreManager] Damage taken: 1 (total: 14)
+[01:02:30] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:30] [INFO] [Player] Spawning blood effect at (2968.3918, 1151.6383), dir=(0.169096, -0.9855996), lethal=False (C#)
+[01:02:30] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2977.251, 1101) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2920.881, 1139.34) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (3060.804, 1102.587) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (3022.843, 1102.307) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2933.01, 1124.832) (added to group)
+[01:02:30] [INFO] [ScoreManager] Damage taken: 1 (total: 15)
+[01:02:30] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:30] [INFO] [Player] Spawning blood effect at (2968.3918, 1151.6383), dir=(-0.2932347, -0.9560405), lethal=False (C#)
+[01:02:30] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2952.553, 1101) (added to group)
+[01:02:30] [INFO] [BloodyFeet:Exit_DroneOperator3] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2966.939, 1135.293) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2932.197, 1151.562) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2995.57, 1140.629) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (3010.157, 1120.903) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2956.439, 1105.971) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2902.313, 1137.187) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2958.875, 1114.057) (added to group)
+[01:02:30] [WARN] [FPS] Drop detected: 14 fps (threshold: 30)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2916.881, 1143.773) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2913.476, 1118.145) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2939.38, 1131.88) (added to group)
+[01:02:30] [INFO] [ScoreManager] Damage taken: 1 (total: 16)
+[01:02:30] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:30] [INFO] [Player] Spawning blood effect at (2968.3918, 1151.6383), dir=(-0.2720121, -0.96229386), lethal=False (C#)
+[01:02:30] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2953.795, 1101) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2912.67, 1147.839) (added to group)
+[01:02:30] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 43.0°
+[01:02:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3080.905, 1527.085), source=ENEMY (Exit_DroneOperator4), range=800, listeners=18
+[01:02:30] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[01:02:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1917.458, 1577.49), source=ENEMY (Exit_DroneOperator1), range=800, listeners=18
+[01:02:30] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2896.191, 1136.771) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2940.983, 1126.971) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (3019.634, 1102.855) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2969.839, 1118.762) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2895.483, 1125.603) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2946.49, 1135.363) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2899.348, 1145.83) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2931.096, 1125.93) (added to group)
+[01:02:30] [INFO] [ScoreManager] Damage taken: 1 (total: 17)
+[01:02:30] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:02:30] [INFO] [Player] Spawning blood effect at (2968.3918, 1151.6383), dir=(-0.24814999, -0.9687216), lethal=False (C#)
+[01:02:30] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2955.164, 1101) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2948.346, 1133.475) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2961.151, 1100.861) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (3026.279, 1121.823) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2926.644, 1129.375) (added to group)
+[01:02:30] [INFO] [BloodDecal] Blood puddle created at (2935.084, 1121.031) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (3030.105, 1100.587) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2903.706, 1111.674) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2910.102, 1139.277) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2980.136, 1109.014) (added to group)
+[01:02:31] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 120.4°
+[01:02:31] [INFO] [ReplayManager] Recording frame 900 (15,0s): player_valid=True, enemies=18
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (3029.605, 1138.4) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2921.649, 1158.711) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2876.901, 1126.803) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2871.817, 1124.897) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2931.25, 1133.248) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2943.841, 1119.715) (added to group)
+[01:02:31] [ENEMY] [Exit_DroneOperator4] Found cover at (3156.057, 1874) (distance: 355.0, player at (2968.392, 1151.638))
+[01:02:31] [ENEMY] [Exit_DroneOperator4] State: COMBAT -> SEEKING_COVER
+[01:02:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(3100.745, 1509.675), source=NEUTRAL (null), range=900, listeners=18
+[01:02:31] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (3100.745, 1509.675), intensity=0.02, dist=407
+[01:02:31] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (3100.745, 1509.675), intensity=0.02, dist=400
+[01:02:31] [ENEMY] [Exit_DroneOperator4] Heard CASING_KICK at (3100.745, 1509.675), intensity=1.00, dist=23
+[01:02:31] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=15, self=0
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2910.289, 1157.244) (added to group)
+[01:02:31] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -78.1° (interval=1.5s)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2904.159, 1147.359) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2975.749, 1115.723) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2953.465, 1139.789) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2944.851, 1122.969) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2839.229, 1096.41) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2896.58, 1171.999) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2949.159, 1120.559) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2929.876, 1127.708) (added to group)
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2984.846, 1109.382) (added to group)
+[01:02:31] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 131.8°
+[01:02:31] [INFO] [BloodDecal] Blood puddle created at (2932.079, 1119.056) (added to group)
+[01:02:31] [INFO] ------------------------------------------------------------
+[01:02:31] [INFO] GAME LOG ENDED: 2026-04-18T01:02:31
+[01:02:31] [INFO] ============================================================

--- a/docs/case-studies/issue-1868/game_log_20260418_010323.txt
+++ b/docs/case-studies/issue-1868/game_log_20260418_010323.txt
@@ -1,0 +1,1718 @@
+[01:03:23] [INFO] ============================================================
+[01:03:23] [INFO] GAME LOG STARTED
+[01:03:23] [INFO] ============================================================
+[01:03:23] [INFO] Timestamp: 2026-04-18T01:03:23
+[01:03:23] [INFO] Log file: I:/Загрузки/godot exe/АКТИВНЫЙ ПРЕДМЕТ/game_log_20260418_010323.txt
+[01:03:23] [INFO] Executable: I:/Загрузки/godot exe/АКТИВНЫЙ ПРЕДМЕТ/Godot-Top-Down-Template.exe
+[01:03:23] [INFO] OS: Windows
+[01:03:23] [INFO] Debug build: false
+[01:03:23] [INFO] Engine version: 4.3-stable (official)
+[01:03:23] [INFO] Project: Godot Top-Down Template
+[01:03:23] [INFO] Build info: not available (build_info.cfg not found)
+[01:03:23] [INFO] ------------------------------------------------------------
+[01:03:23] [INFO] [GameManager] GameManager ready
+[01:03:23] [INFO] [ScoreManager] ScoreManager ready
+[01:03:23] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[01:03:23] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[01:03:23] [INFO] [DifficultyManager] Loaded difficulty: Normal (value: 1)
+[01:03:23] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[01:03:23] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[01:03:23] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[01:03:23] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[01:03:23] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[01:03:23] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[01:03:23] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[01:03:23] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[01:03:23] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[01:03:23] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[01:03:23] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[01:03:23] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[01:03:23] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[01:03:23] [INFO] [LastChance] Resetting all effects (scene change detected)
+[01:03:23] [INFO] [LastChance] Last chance shader loaded successfully
+[01:03:23] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[01:03:23] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[01:03:23] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[01:03:23] [INFO] [LastChance]   Sepia intensity: 0.70
+[01:03:23] [INFO] [LastChance]   Brightness: 0.60
+[01:03:23] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[01:03:23] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[01:03:23] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[01:03:23] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[01:03:23] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DroneGrenade.tscn
+[01:03:23] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: true, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: false, FPS drop logging: true, All weapons unlocked: false, All maps unlocked: true, Global stuck max time: 20.0s, Nav mesh visible: false, Search path visible: false, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false, Enemy path visible: false, Cover raycast visible: false, Tactical group: false, Cover infinite rays: true, Cover sector rays: true, Roguelike unlocked: true
+[01:03:23] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[01:03:23] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.50, music: 1.00
+[01:03:23] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true, revolver_aim_assist: true, combo_font_size: 140
+[01:03:23] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[01:03:23] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[01:03:23] [INFO] [CinemaEffects] Created effects layer at layer 99
+[01:03:23] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[01:03:23] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[01:03:23] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[01:03:23] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[01:03:23] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[01:03:23] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[01:03:23] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[01:03:23] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[01:03:23] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[01:03:23] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[01:03:23] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[01:03:23] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[01:03:23] [INFO] [GrenadeTimerHelper] Autoload ready
+[01:03:23] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[01:03:23] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[01:03:23] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[01:03:23] [INFO] [PowerFantasy]   Kill effect duration: 600ms
+[01:03:23] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[01:03:23] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[01:03:23] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[01:03:23] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[01:03:23] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[01:03:23] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[01:03:23] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[01:03:23] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[01:03:23] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[01:03:23] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[01:03:23] [INFO] [ProgressManager] ProgressManager ready, loaded 14 entries
+[01:03:23] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[01:03:23] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[01:03:23] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[01:03:23] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[01:03:23] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[01:03:23] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[01:03:23] [INFO] [SceneLoader] SceneLoader initialized
+[01:03:23] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[01:03:23] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[01:03:23] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[01:03:23] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[01:03:23] [INFO] [PersistManager] Restored kills_without_laser_sight: 396
+[01:03:23] [INFO] [PersistManager] Restored shots_fired_special_weapons: 735
+[01:03:23] [INFO] [PersistManager] Restored total_deaths: 111
+[01:03:23] [INFO] [PersistManager] Restored no_damage_levels_completed: 8
+[01:03:23] [INFO] [PersistManager] Restored levels_completed_rank_a_or_higher: 5
+[01:03:23] [INFO] [PersistManager] Restored kills_through_wall: 1
+[01:03:23] [INFO] [PersistManager] Restored levels_completed_with_silenced_pistol: 0
+[01:03:23] [INFO] [GameManager] Weapon selected: ak_gl
+[01:03:23] [INFO] [PersistManager] Restored selected weapon: ak_gl
+[01:03:23] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[01:03:23] [INFO] [PersistManager] Restored selected grenade type: 0
+[01:03:23] [INFO] [PersistManager] Restored unlocked active item type: 0
+[01:03:23] [INFO] [PersistManager] Restored unlocked active item type: 11
+[01:03:23] [INFO] [ActiveItemManager] Active item changed from None to Loudspeaker
+[01:03:23] [INFO] [PersistManager] Restored selected active item type: 11
+[01:03:23] [INFO] [PersistManager] Loudspeaker progress restored: level 7, levels_completed=11
+[01:03:23] [INFO] [PersistManager] State loaded successfully
+[01:03:23] [INFO] [PersistManager] PersistManager ready
+[01:03:23] [INFO] [UnlockManager] UnlockManager ready
+[01:03:23] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["makarov_pm", "mini_uzi", "shotgun", "sniper", "revolver", "m16", "silenced_pistol", "ak_gl"]
+[01:03:23] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, warm_lights: true, ai: true
+[01:03:23] [INFO] [LocalizationSettings] Loaded 2 translation(s)
+[01:03:23] [INFO] [LocalizationSettings] LocalizationSettings initialized — locale: en
+[01:03:23] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:23] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[01:03:23] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[01:03:23] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[01:03:23] [ENEMY] [Enemy1] Death animation component initialized
+[01:03:23] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:23] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[01:03:23] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[01:03:23] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[01:03:23] [ENEMY] [Enemy2] Death animation component initialized
+[01:03:23] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:23] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[01:03:23] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[01:03:23] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[01:03:23] [ENEMY] [Enemy3] Death animation component initialized
+[01:03:23] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:23] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[01:03:23] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[01:03:23] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[01:03:23] [ENEMY] [Enemy4] Death animation component initialized
+[01:03:23] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:23] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[01:03:23] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[01:03:23] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[01:03:23] [ENEMY] [Enemy5] Death animation component initialized
+[01:03:23] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:23] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[01:03:23] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[01:03:23] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[01:03:23] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[01:03:23] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[01:03:23] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[01:03:23] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[01:03:24] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[01:03:24] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[01:03:24] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[01:03:24] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[01:03:24] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[01:03:24] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[01:03:24] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[01:03:24] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[01:03:24] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[01:03:24] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[01:03:24] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[01:03:24] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[01:03:24] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[01:03:24] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[01:03:24] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[01:03:24] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[01:03:24] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[01:03:24] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[01:03:24] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[01:03:24] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[01:03:24] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[01:03:24] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[01:03:24] [INFO] [Player.ItemVisual] Visual applied for item type: 11
+[01:03:24] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[01:03:24] [INFO] [Player.Loudspeaker] Loudspeaker selected, initializing...
+[01:03:24] [INFO] [Player.Loudspeaker] Loudspeaker equipped, level: 7, charges: 0/unlimited, effect: 90%, used_this_level: False, all_charges_used: False
+[01:03:24] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[01:03:24] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[01:03:24] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[01:03:24] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[01:03:24] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[01:03:24] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[01:03:24] [INFO] [Player.Jammer] JammerHUD initialized
+[01:03:24] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[01:03:24] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[01:03:24] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[01:03:24] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[01:03:24] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[01:03:24] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[01:03:24] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[01:03:24] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[01:03:24] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[01:03:24] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[01:03:24] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[01:03:24] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[01:03:24] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[01:03:24] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/30
+[01:03:24] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[01:03:24] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/30
+[01:03:24] [INFO] [GameManager] set_player() called with: <CharacterBody2D#86486550283> (class: CharacterBody2D)
+[01:03:24] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[01:03:24] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[01:03:24] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[01:03:24] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[01:03:24] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[01:03:24] [INFO] [ScoreManager] Level started with 5 enemies
+[01:03:24] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[01:03:24] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[01:03:24] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[01:03:24] [INFO] [ReplayManager] Replay data cleared
+[01:03:24] [INFO] [LabyrinthLevel] Previous replay data cleared
+[01:03:24] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[01:03:24] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[01:03:24] [INFO] [ReplayManager] Level: LabyrinthLevel
+[01:03:24] [INFO] [ReplayManager] Player: Player (valid: True)
+[01:03:24] [INFO] [ReplayManager] Enemies count: 5
+[01:03:24] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[01:03:24] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[01:03:24] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[01:03:24] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[01:03:24] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[01:03:24] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[01:03:24] [INFO] [LabyrinthLevel] Replay recording started successfully
+[01:03:24] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[01:03:24] [INFO] [CinemaEffects] Found player node: Player
+[01:03:24] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[01:03:24] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/RailwayStationLevel.tscn
+[01:03:24] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/RailwayStationLevel.tscn
+[01:03:24] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[01:03:24] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[01:03:24] [INFO] [UnlockManager] Restored saved unlock for weapon: ak_gl
+[01:03:24] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[01:03:24] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[01:03:24] [ENEMY] [Enemy1] Registered as sound listener
+[01:03:24] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 2, behavior: GUARD
+[01:03:24] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[01:03:24] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[01:03:24] [ENEMY] [Enemy2] Registered as sound listener
+[01:03:24] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[01:03:24] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[01:03:24] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[01:03:24] [ENEMY] [Enemy3] Registered as sound listener
+[01:03:24] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[01:03:24] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[01:03:24] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[01:03:24] [ENEMY] [Enemy4] Registered as sound listener
+[01:03:24] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 2, behavior: GUARD
+[01:03:24] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[01:03:24] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[01:03:24] [ENEMY] [Enemy5] Registered as sound listener
+[01:03:24] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 2, behavior: GUARD
+[01:03:24] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[01:03:24] [INFO] [Player.Loudspeaker] Level 7 victory state — all enemies start as pacifists!
+[01:03:24] [ENEMY] [Enemy1] Transitioned to PACIFIST
+[01:03:24] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:03:24] [ENEMY] [Enemy2] Transitioned to PACIFIST
+[01:03:24] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:03:24] [ENEMY] [Enemy3] Transitioned to PACIFIST
+[01:03:24] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:03:24] [ENEMY] [Enemy4] Transitioned to PACIFIST
+[01:03:24] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:03:24] [ENEMY] [Enemy5] Transitioned to PACIFIST
+[01:03:24] [INFO] [LabyrinthLevel] [LabyrinthLevel] Enemy became pacifist - counting as eliminated
+[01:03:24] [INFO] [Player.Loudspeaker] Victory message shown (Level 7)
+[01:03:24] [ENEMY] [Enemy1] Found cover at (386.9966, 474.5157) (distance: 175.0, player at (150, 1000))
+[01:03:24] [ENEMY] [Enemy2] Found cover at (699.5566, 1128) (distance: 268.1, player at (150, 1000))
+[01:03:24] [ENEMY] [Enemy3] Found cover at (708.7476, 1128) (distance: 507.7, player at (150, 1000))
+[01:03:24] [ENEMY] [Enemy4] Found cover at (701.3369, 1128) (distance: 1062.3, player at (150, 1000))
+[01:03:25] [ENEMY] [Enemy5] Found cover at (484.2751, 480.5201) (distance: 1031.6, player at (150, 1000))
+[01:03:25] [ENEMY] [Enemy1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=94.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:03:25] [ENEMY] [Enemy2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=138.4°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:03:25] [ENEMY] [Enemy3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=165.4°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:03:25] [ENEMY] [Enemy4] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=153.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:03:25] [ENEMY] [Enemy5] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=169.9°, current=0.0°, player=(150,1000), corner_timer=0.00
+[01:03:25] [INFO] [Player] Detecting weapon pose (frame 3)...
+[01:03:25] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[01:03:25] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[01:03:25] [INFO] [PenultimateHit] Shader warmup complete in 1332 ms
+[01:03:25] [INFO] [LastChance] Shader warmup complete in 1330 ms
+[01:03:25] [INFO] [CinemaEffects] Cinema shader warmup complete in 1191 ms
+[01:03:25] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1183 ms
+[01:03:25] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[01:03:25] [INFO] [FlashbangPlayer] Shader warmup complete in 1179 ms
+[01:03:25] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[01:03:25] [INFO] [SceneLoader] ERROR: Invalid resource (falling back to sync): res://scenes/levels/RailwayStationLevel.tscn
+[01:03:25] [INFO] [SceneLoader] Using synchronous load fallback
+[01:03:25] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[01:03:25] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[01:03:25] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[01:03:25] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[01:03:25] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[01:03:25] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:03:25] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] BloodyFeetComponent ready on NearTracks_MachineGunnerLeft
+[01:03:25] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[01:03:25] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:03:25] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[01:03:25] [INFO] [LastChance] Resetting all effects (scene change detected)
+[01:03:25] [INFO] [CinemaEffects] Scene changed to: RailwayStationLevel
+[01:03:25] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[01:03:25] [INFO] [BlackMetalEffectsManager] Scene changed to: RailwayStationLevel
+[01:03:25] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[01:03:25] [INFO] [PersistManager] Startup navigation complete — arrived at: res://scenes/levels/RailwayStationLevel.tscn
+[01:03:25] [INFO] [PersistManager] State saved to user://game_state.cfg
+[01:03:25] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RailwayStationLevel.tscn
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] BloodyFeetComponent ready on NearTracks_MachineGunnerRight
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerRight] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] BloodyFeetComponent ready on FarTracks_MachineGunnerLeft
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] BloodyFeetComponent ready on FarTracks_MachineGunnerRight
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerRight] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] BloodyFeetComponent ready on CentralWalkway_ForceFieldLeft
+[01:03:25] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:03:25] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:03:25] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:03:25] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldLeft] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] BloodyFeetComponent ready on CentralWalkway_ForceFieldRight
+[01:03:25] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:03:25] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:03:25] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:03:25] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldRight] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator1] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator1] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator1] BloodyFeetComponent ready on Exit_DroneOperator1
+[01:03:25] [ENEMY] [Exit_DroneOperator1] Death animation component initialized
+[01:03:25] [INFO] [DroneOperator] VR headset visual created
+[01:03:25] [INFO] [DroneOperator] Tablet visual created
+[01:03:25] [INFO] [DroneOperator] Setup complete
+[01:03:25] [ENEMY] [Exit_DroneOperator1] Found cover at (721.5328, 1104) (distance: 21.9, player at (2000, 3100))
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator2] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator2] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator2] BloodyFeetComponent ready on Exit_DroneOperator2
+[01:03:25] [ENEMY] [Exit_DroneOperator2] Death animation component initialized
+[01:03:25] [INFO] [DroneOperator] VR headset visual created
+[01:03:25] [INFO] [DroneOperator] Tablet visual created
+[01:03:25] [INFO] [DroneOperator] Setup complete
+[01:03:25] [ENEMY] [Exit_DroneOperator2] Found cover at (1602.407, 1104) (distance: 4.7, player at (2000, 3100))
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator3] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator3] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator3] BloodyFeetComponent ready on Exit_DroneOperator3
+[01:03:25] [ENEMY] [Exit_DroneOperator3] Death animation component initialized
+[01:03:25] [INFO] [DroneOperator] VR headset visual created
+[01:03:25] [INFO] [DroneOperator] Tablet visual created
+[01:03:25] [INFO] [DroneOperator] Setup complete
+[01:03:25] [ENEMY] [Exit_DroneOperator3] Found cover at (1944, 1104) (distance: 556.0, player at (2000, 3100))
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator4] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator4] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator4] BloodyFeetComponent ready on Exit_DroneOperator4
+[01:03:25] [ENEMY] [Exit_DroneOperator4] Death animation component initialized
+[01:03:25] [INFO] [DroneOperator] VR headset visual created
+[01:03:25] [INFO] [DroneOperator] Tablet visual created
+[01:03:25] [INFO] [DroneOperator] Setup complete
+[01:03:25] [ENEMY] [Exit_DroneOperator4] Found cover at (1944, 1104) (distance: 1356.0, player at (2000, 3100))
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] BloodyFeetComponent ready on Spawn_GasMaskEnemy
+[01:03:25] [ENEMY] [Spawn_GasMaskEnemy] Death animation component initialized
+[01:03:25] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft1] BloodyFeetComponent ready on Platform_TeleporterLeft1
+[01:03:25] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft1
+[01:03:25] [ENEMY] [Platform_TeleporterLeft1] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft2] BloodyFeetComponent ready on Platform_TeleporterLeft2
+[01:03:25] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft2
+[01:03:25] [ENEMY] [Platform_TeleporterLeft2] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft3] BloodyFeetComponent ready on Platform_TeleporterLeft3
+[01:03:25] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft3
+[01:03:25] [ENEMY] [Platform_TeleporterLeft3] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight1] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight1] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight1] BloodyFeetComponent ready on Platform_TeleporterRight1
+[01:03:25] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight1
+[01:03:25] [ENEMY] [Platform_TeleporterRight1] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight2] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight2] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight2] BloodyFeetComponent ready on Platform_TeleporterRight2
+[01:03:25] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight2
+[01:03:25] [ENEMY] [Platform_TeleporterRight2] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight3] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight3] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight3] BloodyFeetComponent ready on Platform_TeleporterRight3
+[01:03:25] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight3
+[01:03:25] [ENEMY] [Platform_TeleporterRight3] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Platform_ShieldRight] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Platform_ShieldRight] Found EnemyModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Platform_ShieldRight] BloodyFeetComponent ready on Platform_ShieldRight
+[01:03:25] [INFO] [EnemyShield] SWAT riot shield visual created with collision area (top-down view)
+[01:03:25] [INFO] [EnemyShield] Setup complete (shield_hp=20, stun=1.0s)
+[01:03:25] [ENEMY] [Platform_ShieldRight] Death animation component initialized
+[01:03:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:25] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[01:03:25] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[01:03:25] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[01:03:25] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[01:03:25] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[01:03:25] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[01:03:25] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[01:03:25] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[01:03:25] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[01:03:25] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[01:03:25] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[01:03:25] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[01:03:25] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[01:03:25] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[01:03:25] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[01:03:25] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[01:03:25] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[01:03:25] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[01:03:25] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[01:03:25] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[01:03:25] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[01:03:25] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[01:03:25] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[01:03:25] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[01:03:25] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[01:03:25] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[01:03:25] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[01:03:25] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[01:03:25] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[01:03:25] [INFO] [Player.ItemVisual] Visual applied for item type: 11
+[01:03:25] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[01:03:25] [INFO] [Player.Loudspeaker] Loudspeaker selected, initializing...
+[01:03:25] [INFO] [Player.Loudspeaker] Loudspeaker equipped, level: 7, charges: 0/unlimited, effect: 90%, used_this_level: False, all_charges_used: False
+[01:03:25] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[01:03:25] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[01:03:25] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[01:03:25] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[01:03:25] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[01:03:25] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[01:03:25] [INFO] [Player.Jammer] JammerHUD initialized
+[01:03:25] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[01:03:25] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[01:03:25] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[01:03:25] [INFO] [RailwayStationLevel] Found Environment/Enemies node with 18 children
+[01:03:25] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldLeft': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldRight': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator1': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator2': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator3': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator4': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Spawn_GasMaskEnemy': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft1': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft2': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft3': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight1': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight2': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight3': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Child 'Platform_ShieldRight': script=true, has_died_signal=true
+[01:03:25] [INFO] [RailwayStationLevel] Enemy tracking complete: 18 enemies registered
+[01:03:25] [INFO] [RailwayStationLevel] Setting up weapon: ak_gl
+[01:03:25] [INFO] [RailwayStationLevel] AKGL already equipped by C# Player - skipping GDScript weapon swap
+[01:03:25] [INFO] [GameManager] set_player() called with: <CharacterBody2D#221861908714> (class: CharacterBody2D)
+[01:03:25] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[01:03:25] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[01:03:25] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[01:03:25] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[01:03:25] [INFO] [ScoreManager] Level started with 18 enemies
+[01:03:25] [INFO] [RailwayStationLevel] ReplayManager found as C# autoload
+[01:03:25] [INFO] [ReplayManager] Replay data cleared
+[01:03:25] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[01:03:25] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[01:03:25] [INFO] [ReplayManager] Level: RailwayStationLevel
+[01:03:25] [INFO] [ReplayManager] Player: Player (valid: True)
+[01:03:25] [INFO] [ReplayManager] Enemies count: 18
+[01:03:25] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[01:03:25] [INFO] [ReplayManager]   Enemy 0: NearTracks_MachineGunnerLeft
+[01:03:25] [INFO] [ReplayManager]   Enemy 1: NearTracks_MachineGunnerRight
+[01:03:25] [INFO] [ReplayManager]   Enemy 2: FarTracks_MachineGunnerLeft
+[01:03:25] [INFO] [ReplayManager]   Enemy 3: FarTracks_MachineGunnerRight
+[01:03:25] [INFO] [ReplayManager]   Enemy 4: CentralWalkway_ForceFieldLeft
+[01:03:25] [INFO] [ReplayManager]   Enemy 5: CentralWalkway_ForceFieldRight
+[01:03:25] [INFO] [ReplayManager]   Enemy 6: Exit_DroneOperator1
+[01:03:25] [INFO] [ReplayManager]   Enemy 7: Exit_DroneOperator2
+[01:03:25] [INFO] [ReplayManager]   Enemy 8: Exit_DroneOperator3
+[01:03:25] [INFO] [ReplayManager]   Enemy 9: Exit_DroneOperator4
+[01:03:25] [INFO] [ReplayManager]   Enemy 10: Spawn_GasMaskEnemy
+[01:03:25] [INFO] [ReplayManager]   Enemy 11: Platform_TeleporterLeft1
+[01:03:25] [INFO] [ReplayManager]   Enemy 12: Platform_TeleporterLeft2
+[01:03:25] [INFO] [ReplayManager]   Enemy 13: Platform_TeleporterLeft3
+[01:03:25] [INFO] [ReplayManager]   Enemy 14: Platform_TeleporterRight1
+[01:03:25] [INFO] [ReplayManager]   Enemy 15: Platform_TeleporterRight2
+[01:03:25] [INFO] [ReplayManager]   Enemy 16: Platform_TeleporterRight3
+[01:03:25] [INFO] [ReplayManager]   Enemy 17: Platform_ShieldRight
+[01:03:25] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[01:03:25] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[01:03:25] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 18) - skipping fallback
+[01:03:25] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Blood detector created and attached to NearTracks_MachineGunnerLeft
+[01:03:25] [INFO] [CinemaEffects] Found player node: Player
+[01:03:25] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[01:03:25] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerLeft (total: 1)
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerLeft] Registered as sound listener
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerLeft] Spawned at (300, 2670), hp: 2, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Blood detector created and attached to NearTracks_MachineGunnerRight
+[01:03:25] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerRight (total: 2)
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerRight] Registered as sound listener
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerRight] Spawned at (3700, 2670), hp: 3, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Blood detector created and attached to FarTracks_MachineGunnerLeft
+[01:03:25] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerLeft (total: 3)
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerLeft] Registered as sound listener
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerLeft] Spawned at (300, 1890), hp: 2, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Blood detector created and attached to FarTracks_MachineGunnerRight
+[01:03:25] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerRight (total: 4)
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerRight] Registered as sound listener
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerRight] Spawned at (3700, 1890), hp: 4, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Blood detector created and attached to CentralWalkway_ForceFieldLeft
+[01:03:25] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldLeft (total: 5)
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldLeft] Registered as sound listener
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldLeft] Spawned at (1700, 2300), hp: 3, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Blood detector created and attached to CentralWalkway_ForceFieldRight
+[01:03:25] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldRight (total: 6)
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldRight] Registered as sound listener
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldRight] Spawned at (2300, 2300), hp: 4, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator1] Blood detector created and attached to Exit_DroneOperator1
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator1 (total: 7)
+[01:03:25] [ENEMY] [Exit_DroneOperator1] Registered as sound listener
+[01:03:25] [ENEMY] [Exit_DroneOperator1] Spawned at (700, 1100), hp: 4, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator2] Blood detector created and attached to Exit_DroneOperator2
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator2 (total: 8)
+[01:03:25] [ENEMY] [Exit_DroneOperator2] Registered as sound listener
+[01:03:25] [ENEMY] [Exit_DroneOperator2] Spawned at (1600, 1100), hp: 3, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator3] Blood detector created and attached to Exit_DroneOperator3
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator3 (total: 9)
+[01:03:25] [ENEMY] [Exit_DroneOperator3] Registered as sound listener
+[01:03:25] [ENEMY] [Exit_DroneOperator3] Spawned at (2500, 1100), hp: 4, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Exit_DroneOperator4] Blood detector created and attached to Exit_DroneOperator4
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator4 (total: 10)
+[01:03:25] [ENEMY] [Exit_DroneOperator4] Registered as sound listener
+[01:03:25] [ENEMY] [Exit_DroneOperator4] Spawned at (3300, 1100), hp: 3, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Blood detector created and attached to Spawn_GasMaskEnemy
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Spawn_GasMaskEnemy (total: 11)
+[01:03:25] [ENEMY] [Spawn_GasMaskEnemy] Registered as sound listener
+[01:03:25] [ENEMY] [Spawn_GasMaskEnemy] Spawned at (900, 3075), hp: 2, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Blood detector created and attached to Platform_TeleporterLeft1
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft1 (total: 12)
+[01:03:25] [ENEMY] [Platform_TeleporterLeft1] Registered as sound listener
+[01:03:25] [ENEMY] [Platform_TeleporterLeft1] Spawned at (200, 3500), hp: 2, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Blood detector created and attached to Platform_TeleporterLeft2
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft2 (total: 13)
+[01:03:25] [ENEMY] [Platform_TeleporterLeft2] Registered as sound listener
+[01:03:25] [ENEMY] [Platform_TeleporterLeft2] Spawned at (400, 3500), hp: 4, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Blood detector created and attached to Platform_TeleporterLeft3
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft3 (total: 14)
+[01:03:25] [ENEMY] [Platform_TeleporterLeft3] Registered as sound listener
+[01:03:25] [ENEMY] [Platform_TeleporterLeft3] Spawned at (600, 3500), hp: 4, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight1] Blood detector created and attached to Platform_TeleporterRight1
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight1 (total: 15)
+[01:03:25] [ENEMY] [Platform_TeleporterRight1] Registered as sound listener
+[01:03:25] [ENEMY] [Platform_TeleporterRight1] Spawned at (3400, 3500), hp: 3, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight2] Blood detector created and attached to Platform_TeleporterRight2
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight2 (total: 16)
+[01:03:25] [ENEMY] [Platform_TeleporterRight2] Registered as sound listener
+[01:03:25] [ENEMY] [Platform_TeleporterRight2] Spawned at (3600, 3500), hp: 3, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Platform_TeleporterRight3] Blood detector created and attached to Platform_TeleporterRight3
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight3 (total: 17)
+[01:03:25] [ENEMY] [Platform_TeleporterRight3] Registered as sound listener
+[01:03:25] [ENEMY] [Platform_TeleporterRight3] Spawned at (3800, 3500), hp: 3, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Platform_ShieldRight] Blood detector created and attached to Platform_ShieldRight
+[01:03:25] [INFO] [SoundPropagation] Registered listener: Platform_ShieldRight (total: 18)
+[01:03:25] [ENEMY] [Platform_ShieldRight] Registered as sound listener
+[01:03:25] [ENEMY] [Platform_ShieldRight] Spawned at (3600, 3650), hp: 4, behavior: GUARD
+[01:03:25] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[01:03:25] [INFO] [Player.Loudspeaker] Level 7 victory state — all enemies start as pacifists!
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldLeft] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldRight] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Exit_DroneOperator1] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Exit_DroneOperator2] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Exit_DroneOperator3] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Exit_DroneOperator4] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Spawn_GasMaskEnemy] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Platform_TeleporterLeft1] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Platform_TeleporterLeft2] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Platform_TeleporterLeft3] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Platform_TeleporterRight1] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Platform_TeleporterRight2] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Platform_TeleporterRight3] Transitioned to PACIFIST
+[01:03:25] [ENEMY] [Platform_ShieldRight] Transitioned to PACIFIST
+[01:03:25] [INFO] [Player.Loudspeaker] Victory message shown (Level 7)
+[01:03:25] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=18
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerLeft] Found cover at (259.6943, 1104) (distance: 1566.5, player at (2000, 3100))
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerRight] Found cover at (1944, 1104) (distance: 2352.8, player at (2000, 3100))
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerLeft] Found cover at (283.8475, 1104) (distance: 786.2, player at (2000, 3100))
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerRight] Found cover at (1944, 1104) (distance: 1923.9, player at (2000, 3100))
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldLeft] Found cover at (1702.349, 1104) (distance: 1196.0, player at (2000, 3100))
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldRight] Found cover at (1944, 1104) (distance: 1247.9, player at (2000, 3100))
+[01:03:25] [ENEMY] [Exit_DroneOperator1] Found cover at (721.5328, 1104) (distance: 21.9, player at (2000, 3100))
+[01:03:25] [ENEMY] [Exit_DroneOperator2] Found cover at (1602.407, 1104) (distance: 4.7, player at (2000, 3100))
+[01:03:25] [ENEMY] [Exit_DroneOperator3] Found cover at (1944, 1104) (distance: 556.0, player at (2000, 3100))
+[01:03:25] [ENEMY] [Exit_DroneOperator4] Found cover at (1944, 1104) (distance: 1356.0, player at (2000, 3100))
+[01:03:25] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (915.174, 1104) (distance: 1971.1, player at (2000, 3100))
+[01:03:25] [ENEMY] [Platform_TeleporterLeft1] Found cover at (142.7924, 1104) (distance: 2396.7, player at (2000, 3100))
+[01:03:25] [ENEMY] [Platform_TeleporterLeft2] Found cover at (371.5358, 1104) (distance: 2396.2, player at (2000, 3100))
+[01:03:25] [ENEMY] [Platform_TeleporterLeft3] Found cover at (553.3558, 1104) (distance: 2396.5, player at (2000, 3100))
+[01:03:25] [ENEMY] [Platform_TeleporterRight1] Found cover at (1944, 1104) (distance: 2803.7, player at (2000, 3100))
+[01:03:25] [ENEMY] [Platform_TeleporterRight2] Found cover at (1944, 1104) (distance: 2912.6, player at (2000, 3100))
+[01:03:25] [ENEMY] [Platform_TeleporterRight3] Found cover at (1944, 1104) (distance: 3030.8, player at (2000, 3100))
+[01:03:25] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[01:03:25] [ENEMY] [Platform_ShieldRight] Found cover at (1944, 1104) (distance: 3037.2, player at (2000, 3100))
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-68.3°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-110.7°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-68.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-121.3°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-89.9°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-106.6°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-89.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-91.4°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-90.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-91.1°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-121.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-124.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-127.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: none -> P4:shield_delayed, state=PACIFIST, target=-161.0°, current=-90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=2.2°, current=-2.9°, player=(2000,3100), corner_timer=0.00
+[01:03:25] [INFO] [Player] Detecting weapon pose (frame 3)...
+[01:03:25] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[01:03:25] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[01:03:25] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[01:03:25] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[01:03:25] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[01:03:25] [INFO] [LastChance] Found player: Player
+[01:03:25] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[01:03:25] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[01:03:25] [INFO] [LastChance] Connected to player Died signal (C#)
+[01:03:25] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[01:03:26] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-11.4°, current=-25.8°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 2340 ms
+[01:03:26] [INFO] [SceneLoader] Background load started successfully
+[01:03:26] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-11.8°, current=-48.7°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:03:26] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:03:26] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:03:26] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:03:26] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-89.6°, current=7.7°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=10.2°, current=-26.7°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-170.9°, current=-123.2°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-169.0°, current=-121.3°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-170.3°, current=-124.7°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [INFO] [Drone] _ready started
+[01:03:26] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:03:26] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:03:26] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:03:26] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:03:26] [INFO] [Drone] Initialized by operator: Exit_DroneOperator1
+[01:03:26] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:03:26] [INFO] [DroneOperator] Connected to drone.died signal
+[01:03:26] [INFO] [DroneOperator] Drone deployed at (700, 1084)
+[01:03:26] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:03:26] [INFO] [Drone] _ready started
+[01:03:26] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:03:26] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:03:26] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:03:26] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:03:26] [INFO] [Drone] Initialized by operator: Exit_DroneOperator2
+[01:03:26] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:03:26] [INFO] [DroneOperator] Connected to drone.died signal
+[01:03:26] [INFO] [DroneOperator] Drone deployed at (1600, 1060)
+[01:03:26] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:03:26] [INFO] [Drone] _ready started
+[01:03:26] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:03:26] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:03:26] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:03:26] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:03:26] [INFO] [Drone] Initialized by operator: Exit_DroneOperator3
+[01:03:26] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:03:26] [INFO] [DroneOperator] Connected to drone.died signal
+[01:03:26] [INFO] [DroneOperator] Drone deployed at (2500, 1084)
+[01:03:26] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:03:26] [WARN] [FPS] Drop detected: 5 fps (threshold: 30)
+[01:03:26] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:03:26] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:03:26] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:03:26] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:03:26] [INFO] [Teleporter] Component initialized on Exit_DroneOperator1
+[01:03:26] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:03:26] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:03:26] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:03:26] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:03:26] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:03:26] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:03:26] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:03:26] [INFO] [Teleporter] Component initialized on Exit_DroneOperator2
+[01:03:26] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:03:26] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:03:26] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:03:26] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:03:26] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:03:26] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:03:26] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:03:26] [INFO] [Teleporter] Component initialized on Exit_DroneOperator3
+[01:03:26] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:03:26] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:03:26] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:03:26] [ENEMY] [Exit_DroneOperator1] State: IN_COVER -> PURSUING
+[01:03:26] [ENEMY] [Exit_DroneOperator2] State: IN_COVER -> PURSUING
+[01:03:26] [ENEMY] [Exit_DroneOperator3] State: IN_COVER -> PURSUING
+[01:03:26] [INFO] [Drone] _ready started
+[01:03:26] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:03:26] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:03:26] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:03:26] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:03:26] [INFO] [Drone] Initialized by operator: Exit_DroneOperator4
+[01:03:26] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:03:26] [INFO] [DroneOperator] Connected to drone.died signal
+[01:03:26] [INFO] [DroneOperator] Drone deployed at (3300, 1084)
+[01:03:26] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:03:26] [ENEMY] [Exit_DroneOperator1] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=56.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [ENEMY] [Exit_DroneOperator2] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=78.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [ENEMY] [Exit_DroneOperator3] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=104.2°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:03:26] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:03:26] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:03:26] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:03:26] [INFO] [Teleporter] Component initialized on Exit_DroneOperator4
+[01:03:26] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:03:26] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:03:26] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:03:26] [ENEMY] [Exit_DroneOperator4] State: IN_COVER -> PURSUING
+[01:03:26] [ENEMY] [Exit_DroneOperator4] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=123.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:26] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=18
+[01:03:27] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -164.8° (interval=1.5s)
+[01:03:27] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-124.7°, current=-175.4°, player=(2000,3100), corner_timer=0.00
+[01:03:27] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-127.8°, current=-175.7°, player=(2000,3100), corner_timer=0.00
+[01:03:27] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-121.3°, current=-175.8°, player=(2000,3100), corner_timer=0.00
+[01:03:27] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-90.7°, current=-1.1°, player=(2000,3100), corner_timer=0.00
+[01:03:27] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-91.4°, current=-0.5°, player=(2000,3100), corner_timer=0.00
+[01:03:27] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=1.0°, current=-34.9°, player=(2000,3100), corner_timer=0.00
+[01:03:27] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=18
+[01:03:28] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=3.6°, current=-42.4°, player=(2000,3100), corner_timer=0.00
+[01:03:28] [ENEMY] [Exit_DroneOperator1] FLANKING started: target=(2089.705, 2921.25), side=right, pos=(700, 1124.555)
+[01:03:28] [ENEMY] [Exit_DroneOperator1] State: PURSUING -> FLANKING
+[01:03:28] [ENEMY] [Exit_DroneOperator2] FLANKING started: target=(2150.221, 2967.966), side=right, pos=(1600, 1100.487)
+[01:03:28] [ENEMY] [Exit_DroneOperator2] State: PURSUING -> FLANKING
+[01:03:28] [ENEMY] [Exit_DroneOperator3] FLANKING started: target=(2192.47, 3044.124), side=right, pos=(2500, 1124.555)
+[01:03:28] [ENEMY] [Exit_DroneOperator3] State: PURSUING -> FLANKING
+[01:03:28] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 156.1°
+[01:03:28] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:28] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -22.4°
+[01:03:28] [ENEMY] [Exit_DroneOperator4] FLANKING started: target=(1910.284, 2921.25), side=left, pos=(3300, 1124.555)
+[01:03:28] [ENEMY] [Exit_DroneOperator4] State: PURSUING -> FLANKING
+[01:03:28] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 24.7°
+[01:03:28] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-91.4°, current=4.4°, player=(2000,3100), corner_timer=0.00
+[01:03:28] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=5.9°, current=-30.0°, player=(2000,3100), corner_timer=0.00
+[01:03:28] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 132.6°
+[01:03:28] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:28] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:28] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P4:shield_delayed -> P1:shield_delayed, state=PACIFIST, target=-164.8°, current=-160.9°, player=(2000,3100), corner_timer=0.00
+[01:03:28] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:03:28] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-92.9°, current=7.8°, player=(2000,3100), corner_timer=0.00
+[01:03:28] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-56.6°, current=7.8°, player=(2000,3100), corner_timer=0.00
+[01:03:28] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=18
+[01:03:28] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=9.8°, current=-26.6°, player=(2000,3100), corner_timer=0.00
+[01:03:28] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -169.2° (interval=1.5s)
+[01:03:28] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:28] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:28] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:28] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:03:28] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=9.7°, current=-36.2°, player=(2000,3100), corner_timer=0.00
+[01:03:29] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:29] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:29] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:29] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:03:29] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=168.0°, current=-154.2°, player=(2000,3100), corner_timer=0.00
+[01:03:29] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=169.4°, current=-142.1°, player=(2000,3100), corner_timer=0.00
+[01:03:29] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:29] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:29] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:29] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:03:29] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=18
+[01:03:29] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=166.4°, player=(2000,3100), corner_timer=0.00
+[01:03:29] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:29] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:29] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:29] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 35.2°
+[01:03:29] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=165.8°, current=-180.0°, player=(2000,3100), corner_timer=0.00
+[01:03:30] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=165.6°, player=(2000,3100), corner_timer=0.00
+[01:03:30] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:30] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 4.3°
+[01:03:30] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:30] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 37.7°
+[01:03:30] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=161.4°, current=-180.0°, player=(2000,3100), corner_timer=0.00
+[01:03:30] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -174.4° (interval=1.5s)
+[01:03:30] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=166.4°, player=(2000,3100), corner_timer=0.00
+[01:03:30] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:30] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -29.4°
+[01:03:30] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -119.1°
+[01:03:30] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -154.4°
+[01:03:30] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=165.9°, current=-180.0°, player=(2000,3100), corner_timer=0.00
+[01:03:30] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P1:shield_delayed -> P4:shield_delayed, state=PACIFIST, target=-174.4°, current=-174.4°, player=(2000,3100), corner_timer=0.00
+[01:03:30] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=180.0°, current=165.6°, player=(2000,3100), corner_timer=0.00
+[01:03:30] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=18
+[01:03:30] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 13.2°
+[01:03:30] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -36.8°
+[01:03:30] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 40.8°
+[01:03:31] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=161.6°, current=-180.0°, player=(2000,3100), corner_timer=0.00
+[01:03:31] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -32.1°
+[01:03:31] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -18.9°
+[01:03:31] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 8.2°
+[01:03:31] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-90.0°, current=153.0°, player=(2000,3100), corner_timer=0.00
+[01:03:31] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.1°
+[01:03:31] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 8.0°
+[01:03:31] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 8.7°
+[01:03:31] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:03:31] [WARN] [FPS] Drop detected: 29 fps (threshold: 30)
+[01:03:31] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=18
+[01:03:31] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -179.2° (interval=1.5s)
+[01:03:31] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.3°
+[01:03:31] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -169.1°
+[01:03:31] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=161.1°, current=-180.0°, player=(2000,3100), corner_timer=0.00
+[01:03:32] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-90.0°, current=153.7°, player=(2000,3100), corner_timer=0.00
+[01:03:32] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:32] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:03:32] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.1°
+[01:03:32] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:32] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -87.8°
+[01:03:32] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -18.8°
+[01:03:32] [ENEMY] [Exit_DroneOperator3] FLANKING stuck (2.0s), pos=(2837.852, 1717.916), fail=1
+[01:03:32] [ENEMY] [Exit_DroneOperator3] State: FLANKING -> PURSUING
+[01:03:32] [ENEMY] [Exit_DroneOperator3] State: PURSUING -> COMBAT
+[01:03:32] [ENEMY] [Exit_DroneOperator3] Found cover at (2854.543, 2686) (distance: 976.1, player at (2000, 3100))
+[01:03:32] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=18
+[01:03:32] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=-90.0°, current=153.8°, player=(2000,3100), corner_timer=0.00
+[01:03:32] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:32] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -86.9°
+[01:03:33] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -21.4°
+[01:03:33] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P4:shield_delayed -> P1:shield_delayed, state=PACIFIST, target=-179.2°, current=-179.2°, player=(2000,3100), corner_timer=0.00
+[01:03:33] [ENEMY] [Exit_DroneOperator3] State: COMBAT -> PURSUING
+[01:03:33] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:33] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -112.7°
+[01:03:33] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P1:shield_delayed -> P4:shield_delayed, state=PACIFIST, target=-179.2°, current=-179.2°, player=(2000,3100), corner_timer=0.00
+[01:03:33] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to 173.9° (interval=1.5s)
+[01:03:33] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 76.2°
+[01:03:33] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:33] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P4:shield_delayed -> P1:shield_delayed, state=PACIFIST, target=173.9°, current=173.9°, player=(2000,3100), corner_timer=0.00
+[01:03:33] [INFO] [WeaponHintsComponent] Auto-dismiss timer: clearing all remaining hints for ak_gl
+[01:03:33] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=18
+[01:03:33] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 60.6°
+[01:03:33] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:34] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 88.5°
+[01:03:34] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:34] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 128.7°
+[01:03:34] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:34] [ENEMY] [Exit_DroneOperator3] State: PURSUING -> COMBAT
+[01:03:34] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=18
+[01:03:34] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 130.5°
+[01:03:34] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P1:shield_delayed -> P4:shield_delayed, state=PACIFIST, target=173.9°, current=173.9°, player=(2000,3100), corner_timer=0.00
+[01:03:34] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:34] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to 166.1° (interval=1.5s)
+[01:03:35] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -108.0°
+[01:03:35] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:35] [ENEMY] [Exit_DroneOperator3] State: COMBAT -> PURSUING
+[01:03:35] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 89.9°
+[01:03:35] [INFO] [Player.Loudspeaker] End screen shown (Level 7)
+[01:03:35] [INFO] [WeaponHintsComponent] Shot fired with ak_gl (1 total)
+[01:03:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2000, 3100), source=PLAYER (AKGL), range=871, listeners=18
+[01:03:35] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=15, self=0
+[01:03:35] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:35] [WARN] [FPS] Drop detected: 29 fps (threshold: 30)
+[01:03:35] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=18
+[01:03:35] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 59.1°
+[01:03:35] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:36] [ENEMY] [Exit_DroneOperator4] FLANKING stuck (2.0s), pos=(2336.817, 2005.304), fail=1
+[01:03:36] [ENEMY] [Exit_DroneOperator4] State: FLANKING -> PURSUING
+[01:03:36] [ENEMY] [Exit_DroneOperator4] State: PURSUING -> COMBAT
+[01:03:36] [ENEMY] [Exit_DroneOperator4] Found cover at (2231.447, 2654.718) (distance: 660.4, player at (2000, 3100))
+[01:03:36] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:36] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to 163.8° (interval=1.5s)
+[01:03:36] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -23.7°
+[01:03:36] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:36] [ENEMY] [Exit_DroneOperator4] State: COMBAT -> PURSUING
+[01:03:36] [ENEMY] [Exit_DroneOperator3] State: PURSUING -> COMBAT
+[01:03:36] [WARN] [FPS] Drop detected: 22 fps (threshold: 30)
+[01:03:36] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=18
+[01:03:36] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 104.9°
+[01:03:36] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:37] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:37] [ENEMY] [Exit_DroneOperator3] State: COMBAT -> PURSUING
+[01:03:37] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:37] [INFO] [GameManager] restart_scene() — starting scene reload
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Platform_ShieldRight (remaining: 17)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight3 (remaining: 16)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight2 (remaining: 15)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight1 (remaining: 14)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft3 (remaining: 13)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft2 (remaining: 12)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft1 (remaining: 11)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Spawn_GasMaskEnemy (remaining: 10)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator4 (remaining: 9)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator3 (remaining: 8)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator2 (remaining: 7)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator1 (remaining: 6)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: CentralWalkway_ForceFieldRight (remaining: 5)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: CentralWalkway_ForceFieldLeft (remaining: 4)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerRight (remaining: 3)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerLeft (remaining: 2)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerRight (remaining: 1)
+[01:03:37] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerLeft (remaining: 0)
+[01:03:37] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:03:37] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] BloodyFeetComponent ready on NearTracks_MachineGunnerLeft
+[01:03:37] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[01:03:37] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[01:03:37] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[01:03:37] [INFO] [LastChance] Resetting all effects (scene change detected)
+[01:03:37] [INFO] [CinemaEffects] Scene changed to: RailwayStationLevel
+[01:03:37] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[01:03:37] [INFO] [BlackMetalEffectsManager] Scene changed to: RailwayStationLevel
+[01:03:37] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[01:03:37] [INFO] [PersistManager] State saved to user://game_state.cfg
+[01:03:37] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RailwayStationLevel.tscn
+[01:03:37] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] BloodyFeetComponent ready on NearTracks_MachineGunnerRight
+[01:03:37] [ENEMY] [NearTracks_MachineGunnerRight] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] BloodyFeetComponent ready on FarTracks_MachineGunnerLeft
+[01:03:37] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] BloodyFeetComponent ready on FarTracks_MachineGunnerRight
+[01:03:37] [ENEMY] [FarTracks_MachineGunnerRight] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] BloodyFeetComponent ready on CentralWalkway_ForceFieldLeft
+[01:03:37] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:03:37] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:03:37] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:03:37] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:03:37] [ENEMY] [CentralWalkway_ForceFieldLeft] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] BloodyFeetComponent ready on CentralWalkway_ForceFieldRight
+[01:03:37] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[01:03:37] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[01:03:37] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[01:03:37] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[01:03:37] [ENEMY] [CentralWalkway_ForceFieldRight] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator1] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator1] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator1] BloodyFeetComponent ready on Exit_DroneOperator1
+[01:03:37] [ENEMY] [Exit_DroneOperator1] Death animation component initialized
+[01:03:37] [INFO] [DroneOperator] VR headset visual created
+[01:03:37] [INFO] [DroneOperator] Tablet visual created
+[01:03:37] [INFO] [DroneOperator] Setup complete
+[01:03:37] [ENEMY] [Exit_DroneOperator1] Found cover at (721.5328, 2686) (distance: 1586.1, player at (2000, 3100))
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator2] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator2] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator2] BloodyFeetComponent ready on Exit_DroneOperator2
+[01:03:37] [ENEMY] [Exit_DroneOperator2] Death animation component initialized
+[01:03:37] [INFO] [DroneOperator] VR headset visual created
+[01:03:37] [INFO] [DroneOperator] Tablet visual created
+[01:03:37] [INFO] [DroneOperator] Setup complete
+[01:03:37] [ENEMY] [Exit_DroneOperator2] Found cover at (1560.777, 2654) (distance: 1554.5, player at (2000, 3100))
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator3] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator3] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator3] BloodyFeetComponent ready on Exit_DroneOperator3
+[01:03:37] [ENEMY] [Exit_DroneOperator3] Death animation component initialized
+[01:03:37] [INFO] [DroneOperator] VR headset visual created
+[01:03:37] [INFO] [DroneOperator] Tablet visual created
+[01:03:37] [INFO] [DroneOperator] Setup complete
+[01:03:37] [ENEMY] [Exit_DroneOperator3] Found cover at (2441.834, 2654) (distance: 1555.1, player at (2000, 3100))
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator4] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator4] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Exit_DroneOperator4] BloodyFeetComponent ready on Exit_DroneOperator4
+[01:03:37] [ENEMY] [Exit_DroneOperator4] Death animation component initialized
+[01:03:37] [INFO] [DroneOperator] VR headset visual created
+[01:03:37] [INFO] [DroneOperator] Tablet visual created
+[01:03:37] [INFO] [DroneOperator] Setup complete
+[01:03:37] [ENEMY] [Exit_DroneOperator4] Found cover at (3149.732, 2686) (distance: 1593.1, player at (2000, 3100))
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] BloodyFeetComponent ready on Spawn_GasMaskEnemy
+[01:03:37] [ENEMY] [Spawn_GasMaskEnemy] Death animation component initialized
+[01:03:37] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterLeft1] BloodyFeetComponent ready on Platform_TeleporterLeft1
+[01:03:37] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft1
+[01:03:37] [ENEMY] [Platform_TeleporterLeft1] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterLeft2] BloodyFeetComponent ready on Platform_TeleporterLeft2
+[01:03:37] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft2
+[01:03:37] [ENEMY] [Platform_TeleporterLeft2] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterLeft3] BloodyFeetComponent ready on Platform_TeleporterLeft3
+[01:03:37] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft3
+[01:03:37] [ENEMY] [Platform_TeleporterLeft3] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterRight1] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterRight1] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterRight1] BloodyFeetComponent ready on Platform_TeleporterRight1
+[01:03:37] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight1
+[01:03:37] [ENEMY] [Platform_TeleporterRight1] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterRight2] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterRight2] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterRight2] BloodyFeetComponent ready on Platform_TeleporterRight2
+[01:03:37] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight2
+[01:03:37] [ENEMY] [Platform_TeleporterRight2] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterRight3] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterRight3] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Platform_TeleporterRight3] BloodyFeetComponent ready on Platform_TeleporterRight3
+[01:03:37] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight3
+[01:03:37] [ENEMY] [Platform_TeleporterRight3] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Platform_ShieldRight] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Platform_ShieldRight] Found EnemyModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Platform_ShieldRight] BloodyFeetComponent ready on Platform_ShieldRight
+[01:03:37] [INFO] [EnemyShield] SWAT riot shield visual created with collision area (top-down view)
+[01:03:37] [INFO] [EnemyShield] Setup complete (shield_hp=20, stun=1.0s)
+[01:03:37] [ENEMY] [Platform_ShieldRight] Death animation component initialized
+[01:03:37] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[01:03:37] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[01:03:37] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[01:03:37] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[01:03:37] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[01:03:37] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[01:03:37] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[01:03:37] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[01:03:37] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[01:03:37] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[01:03:37] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[01:03:37] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[01:03:37] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[01:03:37] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[01:03:37] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[01:03:37] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[01:03:37] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[01:03:37] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[01:03:37] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[01:03:37] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[01:03:37] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[01:03:37] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[01:03:37] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[01:03:37] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[01:03:37] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[01:03:37] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[01:03:37] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[01:03:37] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[01:03:37] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[01:03:37] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[01:03:37] [INFO] [Player.ItemVisual] Visual applied for item type: 11
+[01:03:37] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[01:03:37] [INFO] [Player.Loudspeaker] Loudspeaker selected, initializing...
+[01:03:37] [INFO] [Player.Loudspeaker] Loudspeaker equipped, level: 7, charges: 0/unlimited, effect: 90%, used_this_level: False, all_charges_used: False
+[01:03:37] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[01:03:37] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[01:03:37] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[01:03:37] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[01:03:37] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[01:03:37] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[01:03:37] [INFO] [Player.Jammer] JammerHUD initialized
+[01:03:37] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[01:03:37] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[01:03:37] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[01:03:37] [INFO] [RailwayStationLevel] Found Environment/Enemies node with 18 children
+[01:03:37] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerRight': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldLeft': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldRight': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator1': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator2': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator3': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator4': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Spawn_GasMaskEnemy': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft1': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft2': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft3': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight1': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight2': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight3': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Child 'Platform_ShieldRight': script=true, has_died_signal=true
+[01:03:37] [INFO] [RailwayStationLevel] Enemy tracking complete: 18 enemies registered
+[01:03:37] [INFO] [RailwayStationLevel] Setting up weapon: ak_gl
+[01:03:37] [INFO] [RailwayStationLevel] AKGL already equipped by C# Player - skipping GDScript weapon swap
+[01:03:37] [INFO] [GameManager] set_player() called with: <CharacterBody2D#715028175936> (class: CharacterBody2D)
+[01:03:37] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[01:03:37] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[01:03:37] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[01:03:37] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[01:03:37] [INFO] [ScoreManager] Level started with 18 enemies
+[01:03:37] [INFO] [RailwayStationLevel] ReplayManager found as C# autoload
+[01:03:37] [INFO] [ReplayManager] Replay data cleared
+[01:03:37] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[01:03:37] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[01:03:37] [INFO] [ReplayManager] Level: RailwayStationLevel
+[01:03:37] [INFO] [ReplayManager] Player: Player (valid: True)
+[01:03:37] [INFO] [ReplayManager] Enemies count: 18
+[01:03:37] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[01:03:37] [INFO] [ReplayManager]   Enemy 0: NearTracks_MachineGunnerLeft
+[01:03:37] [INFO] [ReplayManager]   Enemy 1: NearTracks_MachineGunnerRight
+[01:03:37] [INFO] [ReplayManager]   Enemy 2: FarTracks_MachineGunnerLeft
+[01:03:37] [INFO] [ReplayManager]   Enemy 3: FarTracks_MachineGunnerRight
+[01:03:37] [INFO] [ReplayManager]   Enemy 4: CentralWalkway_ForceFieldLeft
+[01:03:37] [INFO] [ReplayManager]   Enemy 5: CentralWalkway_ForceFieldRight
+[01:03:37] [INFO] [ReplayManager]   Enemy 6: Exit_DroneOperator1
+[01:03:37] [INFO] [ReplayManager]   Enemy 7: Exit_DroneOperator2
+[01:03:37] [INFO] [ReplayManager]   Enemy 8: Exit_DroneOperator3
+[01:03:37] [INFO] [ReplayManager]   Enemy 9: Exit_DroneOperator4
+[01:03:37] [INFO] [ReplayManager]   Enemy 10: Spawn_GasMaskEnemy
+[01:03:37] [INFO] [ReplayManager]   Enemy 11: Platform_TeleporterLeft1
+[01:03:37] [INFO] [ReplayManager]   Enemy 12: Platform_TeleporterLeft2
+[01:03:37] [INFO] [ReplayManager]   Enemy 13: Platform_TeleporterLeft3
+[01:03:37] [INFO] [ReplayManager]   Enemy 14: Platform_TeleporterRight1
+[01:03:37] [INFO] [ReplayManager]   Enemy 15: Platform_TeleporterRight2
+[01:03:37] [INFO] [ReplayManager]   Enemy 16: Platform_TeleporterRight3
+[01:03:37] [INFO] [ReplayManager]   Enemy 17: Platform_ShieldRight
+[01:03:37] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[01:03:37] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[01:03:38] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 18) - skipping fallback
+[01:03:38] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Blood detector created and attached to NearTracks_MachineGunnerLeft
+[01:03:38] [INFO] [CinemaEffects] Found player node: Player
+[01:03:38] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[01:03:38] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerLeft (total: 1)
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerLeft] Registered as sound listener
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerLeft] Spawned at (300, 2670), hp: 3, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Blood detector created and attached to NearTracks_MachineGunnerRight
+[01:03:38] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerRight (total: 2)
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerRight] Registered as sound listener
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerRight] Spawned at (3700, 2670), hp: 4, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Blood detector created and attached to FarTracks_MachineGunnerLeft
+[01:03:38] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerLeft (total: 3)
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerLeft] Registered as sound listener
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerLeft] Spawned at (300, 1890), hp: 2, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Blood detector created and attached to FarTracks_MachineGunnerRight
+[01:03:38] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerRight (total: 4)
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerRight] Registered as sound listener
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerRight] Spawned at (3700, 1890), hp: 3, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Blood detector created and attached to CentralWalkway_ForceFieldLeft
+[01:03:38] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldLeft (total: 5)
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldLeft] Registered as sound listener
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldLeft] Spawned at (1700, 2300), hp: 2, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Blood detector created and attached to CentralWalkway_ForceFieldRight
+[01:03:38] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldRight (total: 6)
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldRight] Registered as sound listener
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldRight] Spawned at (2300, 2300), hp: 3, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Exit_DroneOperator1] Blood detector created and attached to Exit_DroneOperator1
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator1 (total: 7)
+[01:03:38] [ENEMY] [Exit_DroneOperator1] Registered as sound listener
+[01:03:38] [ENEMY] [Exit_DroneOperator1] Spawned at (700, 1100), hp: 4, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Exit_DroneOperator2] Blood detector created and attached to Exit_DroneOperator2
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator2 (total: 8)
+[01:03:38] [ENEMY] [Exit_DroneOperator2] Registered as sound listener
+[01:03:38] [ENEMY] [Exit_DroneOperator2] Spawned at (1600, 1100), hp: 4, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Exit_DroneOperator3] Blood detector created and attached to Exit_DroneOperator3
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator3 (total: 9)
+[01:03:38] [ENEMY] [Exit_DroneOperator3] Registered as sound listener
+[01:03:38] [ENEMY] [Exit_DroneOperator3] Spawned at (2500, 1100), hp: 2, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Exit_DroneOperator4] Blood detector created and attached to Exit_DroneOperator4
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator4 (total: 10)
+[01:03:38] [ENEMY] [Exit_DroneOperator4] Registered as sound listener
+[01:03:38] [ENEMY] [Exit_DroneOperator4] Spawned at (3300, 1100), hp: 3, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Blood detector created and attached to Spawn_GasMaskEnemy
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Spawn_GasMaskEnemy (total: 11)
+[01:03:38] [ENEMY] [Spawn_GasMaskEnemy] Registered as sound listener
+[01:03:38] [ENEMY] [Spawn_GasMaskEnemy] Spawned at (900, 3075), hp: 2, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Blood detector created and attached to Platform_TeleporterLeft1
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft1 (total: 12)
+[01:03:38] [ENEMY] [Platform_TeleporterLeft1] Registered as sound listener
+[01:03:38] [ENEMY] [Platform_TeleporterLeft1] Spawned at (200, 3500), hp: 3, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Blood detector created and attached to Platform_TeleporterLeft2
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft2 (total: 13)
+[01:03:38] [ENEMY] [Platform_TeleporterLeft2] Registered as sound listener
+[01:03:38] [ENEMY] [Platform_TeleporterLeft2] Spawned at (400, 3500), hp: 3, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Blood detector created and attached to Platform_TeleporterLeft3
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft3 (total: 14)
+[01:03:38] [ENEMY] [Platform_TeleporterLeft3] Registered as sound listener
+[01:03:38] [ENEMY] [Platform_TeleporterLeft3] Spawned at (600, 3500), hp: 4, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Platform_TeleporterRight1] Blood detector created and attached to Platform_TeleporterRight1
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight1 (total: 15)
+[01:03:38] [ENEMY] [Platform_TeleporterRight1] Registered as sound listener
+[01:03:38] [ENEMY] [Platform_TeleporterRight1] Spawned at (3400, 3500), hp: 3, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Platform_TeleporterRight2] Blood detector created and attached to Platform_TeleporterRight2
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight2 (total: 16)
+[01:03:38] [ENEMY] [Platform_TeleporterRight2] Registered as sound listener
+[01:03:38] [ENEMY] [Platform_TeleporterRight2] Spawned at (3600, 3500), hp: 3, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Platform_TeleporterRight3] Blood detector created and attached to Platform_TeleporterRight3
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight3 (total: 17)
+[01:03:38] [ENEMY] [Platform_TeleporterRight3] Registered as sound listener
+[01:03:38] [ENEMY] [Platform_TeleporterRight3] Spawned at (3800, 3500), hp: 4, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Platform_ShieldRight] Blood detector created and attached to Platform_ShieldRight
+[01:03:38] [INFO] [SoundPropagation] Registered listener: Platform_ShieldRight (total: 18)
+[01:03:38] [ENEMY] [Platform_ShieldRight] Registered as sound listener
+[01:03:38] [ENEMY] [Platform_ShieldRight] Spawned at (3600, 3650), hp: 3, behavior: GUARD
+[01:03:38] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[01:03:38] [INFO] [Player.Loudspeaker] Level 7 victory state — all enemies start as pacifists!
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerLeft] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerRight] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldLeft] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldRight] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Exit_DroneOperator1] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Exit_DroneOperator2] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Exit_DroneOperator3] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Exit_DroneOperator4] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Spawn_GasMaskEnemy] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Platform_TeleporterLeft1] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Platform_TeleporterLeft2] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Platform_TeleporterLeft3] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Platform_TeleporterRight1] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Platform_TeleporterRight2] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Platform_TeleporterRight3] Transitioned to PACIFIST
+[01:03:38] [ENEMY] [Platform_ShieldRight] Transitioned to PACIFIST
+[01:03:38] [INFO] [Player.Loudspeaker] Victory message shown (Level 7)
+[01:03:38] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=18
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerLeft] Found cover at (259.6943, 2686) (distance: 43.4, player at (2000, 3100))
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerRight] Found cover at (3108.278, 2685.692) (distance: 591.9, player at (2000, 3100))
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerLeft] Found cover at (283.8475, 2686) (distance: 796.2, player at (2000, 3100))
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerRight] Found cover at (3135.116, 2686) (distance: 976.1, player at (2000, 3100))
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldLeft] Found cover at (1758.679, 2656.264) (distance: 361.1, player at (2000, 3100))
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldRight] Found cover at (2241.223, 2656.267) (distance: 361.1, player at (2000, 3100))
+[01:03:38] [ENEMY] [Exit_DroneOperator1] Found cover at (721.5328, 2686) (distance: 1586.1, player at (2000, 3100))
+[01:03:38] [ENEMY] [Exit_DroneOperator2] Found cover at (1560.777, 2654) (distance: 1554.5, player at (2000, 3100))
+[01:03:38] [ENEMY] [Exit_DroneOperator3] Found cover at (2441.834, 2654) (distance: 1555.1, player at (2000, 3100))
+[01:03:38] [ENEMY] [Exit_DroneOperator4] Found cover at (3149.732, 2686) (distance: 1593.1, player at (2000, 3100))
+[01:03:38] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (736.9224, 3400.999) (distance: 364.5, player at (2000, 3100))
+[01:03:38] [ENEMY] [Platform_TeleporterLeft1] Found cover at (723.9988, 3413.163) (distance: 531.1, player at (2000, 3100))
+[01:03:38] [ENEMY] [Platform_TeleporterLeft2] Found cover at (730.0936, 3427.389) (distance: 338.0, player at (2000, 3100))
+[01:03:38] [ENEMY] [Platform_TeleporterLeft3] Found cover at (724.6032, 3494.945) (distance: 124.7, player at (2000, 3100))
+[01:03:38] [ENEMY] [Platform_TeleporterRight1] Found cover at (3275.396, 3494.945) (distance: 124.7, player at (2000, 3100))
+[01:03:38] [ENEMY] [Platform_TeleporterRight2] Found cover at (3269.906, 3427.39) (distance: 338.0, player at (2000, 3100))
+[01:03:38] [ENEMY] [Platform_TeleporterRight3] Found cover at (3263.501, 3593.948) (distance: 544.7, player at (2000, 3100))
+[01:03:38] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[01:03:38] [ENEMY] [Platform_ShieldRight] Found cover at (3274.059, 3590.884) (distance: 331.3, player at (2000, 3100))
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=123.2°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-144.1°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=68.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=102.2°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=80.6°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=99.4°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=180.0°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-9.4°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-12.4°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-2.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-177.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=-167.6°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: none -> P4:velocity, state=PACIFIST, target=170.1°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: none -> P4:shield_delayed, state=PACIFIST, target=-161.0°, current=-90.0°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [INFO] [Player] Detecting weapon pose (frame 3)...
+[01:03:38] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[01:03:38] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[01:03:38] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=2.0°, current=-5.7°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[01:03:38] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[01:03:38] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[01:03:38] [INFO] [LastChance] Found player: Player
+[01:03:38] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[01:03:38] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[01:03:38] [INFO] [LastChance] Connected to player Died signal (C#)
+[01:03:38] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[01:03:38] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:03:38] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:03:38] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:03:38] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[01:03:38] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=PACIFIST, target=129.0°, current=0.5°, player=(2000,3100), corner_timer=0.00
+[01:03:38] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-1.7°, current=34.9°, player=(2000,3100), corner_timer=0.00
+[01:03:39] [INFO] [Drone] _ready started
+[01:03:39] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:03:39] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:03:39] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:03:39] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:03:39] [INFO] [Drone] Initialized by operator: Exit_DroneOperator1
+[01:03:39] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:03:39] [INFO] [DroneOperator] Connected to drone.died signal
+[01:03:39] [INFO] [DroneOperator] Drone deployed at (700, 1084)
+[01:03:39] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:03:39] [INFO] [Drone] _ready started
+[01:03:39] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:03:39] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:03:39] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:03:39] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:03:39] [INFO] [Drone] Initialized by operator: Exit_DroneOperator2
+[01:03:39] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:03:39] [INFO] [DroneOperator] Connected to drone.died signal
+[01:03:39] [INFO] [DroneOperator] Drone deployed at (1600, 1060)
+[01:03:39] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:03:39] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:03:39] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:03:39] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:03:39] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:03:39] [INFO] [Teleporter] Component initialized on Exit_DroneOperator1
+[01:03:39] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:03:39] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:03:39] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:03:39] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:03:39] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:03:39] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:03:39] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:03:39] [INFO] [Teleporter] Component initialized on Exit_DroneOperator2
+[01:03:39] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:03:39] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:03:39] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:03:39] [ENEMY] [Exit_DroneOperator1] State: IN_COVER -> PURSUING
+[01:03:39] [ENEMY] [Exit_DroneOperator2] State: IN_COVER -> PURSUING
+[01:03:39] [INFO] [Drone] _ready started
+[01:03:39] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:03:39] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:03:39] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:03:39] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:03:39] [INFO] [Drone] Initialized by operator: Exit_DroneOperator3
+[01:03:39] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:03:39] [INFO] [DroneOperator] Connected to drone.died signal
+[01:03:39] [INFO] [DroneOperator] Drone deployed at (2500, 1084)
+[01:03:39] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:03:39] [ENEMY] [Exit_DroneOperator1] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=56.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:39] [ENEMY] [Exit_DroneOperator2] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=78.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:39] [INFO] [Drone] _ready started
+[01:03:39] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[01:03:39] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[01:03:39] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[01:03:39] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[01:03:39] [INFO] [Drone] Initialized by operator: Exit_DroneOperator4
+[01:03:39] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[01:03:39] [INFO] [DroneOperator] Connected to drone.died signal
+[01:03:39] [INFO] [DroneOperator] Drone deployed at (3300, 1084)
+[01:03:39] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[01:03:39] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:03:39] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:03:39] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:03:39] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:03:39] [INFO] [Teleporter] Component initialized on Exit_DroneOperator3
+[01:03:39] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:03:39] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:03:39] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:03:39] [ENEMY] [Exit_DroneOperator3] State: IN_COVER -> PURSUING
+[01:03:39] [INFO] [Drone] Operator became pacifist — neutralizing drone (Issue #1868)
+[01:03:39] [INFO] [DroneOperator] Drone destroyed! Transitioning to ACTIVE
+[01:03:39] [INFO] [DroneOperator] Laser sight visual added to weapon mount (z_index=-2, under arm)
+[01:03:39] [INFO] [DroneOperator] Drone destroyed but operator is pacifist — staying pacifist (Issue #1744)
+[01:03:39] [INFO] [Teleporter] Component initialized on Exit_DroneOperator4
+[01:03:39] [INFO] [DroneOperator] Teleport component set up (teleport evasion, Issue #1664)
+[01:03:39] [INFO] [DroneOperator] Phase: ACTIVE (silenced pistol + laser, teleport evasion)
+[01:03:39] [INFO] [Drone] Destroyed (ricochet=false, penetration=false, player=false)
+[01:03:39] [ENEMY] [Exit_DroneOperator3] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=104.2°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:39] [ENEMY] [Exit_DroneOperator4] State: IN_COVER -> PURSUING
+[01:03:39] [ENEMY] [Exit_DroneOperator4] ROT_CHANGE: none -> P2:combat_state, state=PURSUING, target=123.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[01:03:39] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=18
+[01:03:39] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -155.7° (interval=1.5s)
+[01:03:39] [INFO] [Player] Invincibility mode: ON
+[01:03:39] [INFO] [GameManager] Invincibility mode toggled: ON
+[01:03:40] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=18
+[01:03:40] [INFO] [Player.Debug] Debug mode toggled: ON
+[01:03:40] [INFO] [GameManager] Debug mode toggled: ON
+[01:03:40] [ENEMY] [Exit_DroneOperator1] FLANKING started: target=(2101.941, 2984.609), side=left, pos=(700, 1124.555)
+[01:03:40] [ENEMY] [Exit_DroneOperator1] State: PURSUING -> FLANKING
+[01:03:40] [ENEMY] [Exit_DroneOperator2] FLANKING started: target=(2100.694, 2913.341), side=left, pos=(1600, 1100.487)
+[01:03:40] [ENEMY] [Exit_DroneOperator2] State: PURSUING -> FLANKING
+[01:03:40] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 156.1°
+[01:03:40] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:40] [ENEMY] [Exit_DroneOperator3] FLANKING started: target=(2491.771, 2864.126), side=right, pos=(2500, 1124.555)
+[01:03:40] [ENEMY] [Exit_DroneOperator3] State: PURSUING -> FLANKING
+[01:03:40] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -22.4°
+[01:03:40] [ENEMY] [Exit_DroneOperator4] FLANKING started: target=(2514.51, 2940.009), side=right, pos=(3300, 1124.58)
+[01:03:40] [ENEMY] [Exit_DroneOperator4] State: PURSUING -> FLANKING
+[01:03:40] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 158.1°
+[01:03:40] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 132.6°
+[01:03:40] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:41] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:41] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 134.6°
+[01:03:41] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=18
+[01:03:41] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -141.1° (interval=1.5s)
+[01:03:41] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:41] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:41] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:41] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -45.4°
+[01:03:41] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:41] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:41] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:41] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -47.5°
+[01:03:41] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=-137.7°, current=-167.6°, player=(2621,2824), corner_timer=0.00
+[01:03:41] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:41] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:42] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:42] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -52.3°
+[01:03:42] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=179.2°, current=-180.0°, player=(2639,2689), corner_timer=0.00
+[01:03:42] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=18
+[01:03:42] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:42] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 21.5°
+[01:03:42] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:42] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -56.6°
+[01:03:42] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:42] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 4.3°
+[01:03:42] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -31.9°
+[01:03:42] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -61.4°
+[01:03:42] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -131.7° (interval=1.5s)
+[01:03:42] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -47.4°
+[01:03:43] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -119.1°
+[01:03:43] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.9°
+[01:03:43] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle 74.9°
+[01:03:43] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=18
+[01:03:43] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 13.2°
+[01:03:43] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:03:43] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -69.7°
+[01:03:43] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle 40.8°
+[01:03:43] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -32.1°
+[01:03:43] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:03:43] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -73.1°
+[01:03:43] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.1°
+[01:03:43] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 8.0°
+[01:03:44] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:03:44] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -97.8°
+[01:03:44] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:03:44] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=18
+[01:03:44] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.3°
+[01:03:44] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -144.8° (interval=1.5s)
+[01:03:44] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:03:44] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -96.3°
+[01:03:44] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:44] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -102.0°
+[01:03:44] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:03:44] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -81.2°
+[01:03:44] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:44] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -87.8°
+[01:03:45] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:03:45] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -94.0°
+[01:03:45] [INFO] [ForceFieldEffect] Activated! Charge: 5.0s/8.0s
+[01:03:45] [INFO] [EnemyForceField] Activated
+[01:03:45] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=174.6°, current=-180.0°, player=(1833,2538), corner_timer=0.00
+[01:03:45] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=18
+[01:03:45] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:45] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -86.9°
+[01:03:45] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:03:45] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.2°
+[01:03:45] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:45] [ENEMY] [Exit_DroneOperator2] FLANKING corner check: angle -112.7°
+[01:03:45] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:03:45] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -84.7°
+[01:03:45] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -138.7° (interval=1.5s)
+[01:03:45] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:46] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:03:46] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.3°
+[01:03:46] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=18
+[01:03:46] [INFO] [WeaponHintsComponent] Auto-dismiss timer: clearing all remaining hints for ak_gl
+[01:03:46] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:46] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:03:46] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.1°
+[01:03:46] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:46] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:03:46] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -108.0°
+[01:03:46] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:47] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:03:47] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.2°
+[01:03:47] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=18
+[01:03:47] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:47] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:03:47] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -124.3° (interval=1.5s)
+[01:03:47] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -84.2°
+[01:03:47] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:47] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:03:47] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -84.5°
+[01:03:47] [ENEMY] [Exit_DroneOperator2] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=9.7°, current=18.5°, player=(2343,1942), corner_timer=-0.02
+[01:03:47] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:47] [ENEMY] [Exit_DroneOperator2] State: FLANKING -> COMBAT
+[01:03:48] [ENEMY] [Exit_DroneOperator2] Found cover at (2082.737, 1726) (distance: 163.1, player at (2343.796, 1927.241))
+[01:03:48] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:03:48] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.3°
+[01:03:48] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: P4:velocity -> P1:visible, state=PACIFIST, target=179.1°, current=-180.0°, player=(2343,1914), corner_timer=0.00
+[01:03:48] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=18
+[01:03:48] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:48] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:03:48] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -107.9°
+[01:03:48] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.086, 1881.576), source=ENEMY (Exit_DroneOperator2), range=800, listeners=18
+[01:03:48] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[01:03:48] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:48] [INFO] [ScoreManager] Damage taken: 1 (total: 1)
+[01:03:48] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:48] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.99993086, 0.011762513), lethal=False (C#)
+[01:03:48] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:48] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:03:48] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -107.9°
+[01:03:48] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -119.8° (interval=1.5s)
+[01:03:48] [INFO] [ScoreManager] Damage taken: 1 (total: 2)
+[01:03:48] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:48] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.9999003, 0.014124095), lethal=False (C#)
+[01:03:48] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:48] [INFO] [BloodDecal] Blood puddle created at (2415.861, 1909.993) (added to group)
+[01:03:48] [INFO] [BloodDecal] Blood puddle created at (2414.231, 1893.875) (added to group)
+[01:03:48] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:48] [INFO] [BloodDecal] Blood puddle created at (2416.984, 1912.583) (added to group)
+[01:03:49] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:03:49] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -107.8°
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2439.226, 1890.487) (added to group)
+[01:03:49] [INFO] [ScoreManager] Damage taken: 1 (total: 3)
+[01:03:49] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:49] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.9996836, 0.025154904), lethal=False (C#)
+[01:03:49] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:49] [INFO] [ForceFieldEffect] Released 0 trapped projectiles
+[01:03:49] [INFO] [ForceFieldEffect] Deactivated. Charge remaining: 1.0s
+[01:03:49] [INFO] [EnemyForceField] Deactivated — recharging for 5.0s
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2454.128, 1919.372) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2481.478, 1896.703) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2419.224, 1907.282) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2399.027, 1926.323) (added to group)
+[01:03:49] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=18
+[01:03:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.086, 1881.576), source=ENEMY (Exit_DroneOperator2), range=800, listeners=18
+[01:03:49] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2522.571, 1879.252) (added to group)
+[01:03:49] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2423.534, 1925.009) (added to group)
+[01:03:49] [INFO] [ScoreManager] Damage taken: 1 (total: 4)
+[01:03:49] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:49] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.99995595, 0.009392407), lethal=False (C#)
+[01:03:49] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:49] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2421.006, 1888.002) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2397.247, 1887.659) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2397.078, 1903.722) (added to group)
+[01:03:49] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.1°
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2456.815, 1869.001) (added to group)
+[01:03:49] [INFO] [ScoreManager] Damage taken: 1 (total: 5)
+[01:03:49] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:49] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.999956, 0.009379208), lethal=False (C#)
+[01:03:49] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2552.233, 1910.677) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2424.312, 1905.305) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2476.871, 1908.021) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2431.555, 1912.562) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2398.754, 1897.717) (added to group)
+[01:03:49] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2498.182, 1899.729) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2456.005, 1910.353) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2412.228, 1887.781) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2432.72, 1899.184) (added to group)
+[01:03:49] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:03:49] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.2°
+[01:03:49] [INFO] [ScoreManager] Damage taken: 1 (total: 6)
+[01:03:49] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:49] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.9999651, 0.008362955), lethal=False (C#)
+[01:03:49] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2389.34, 1877.181) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2468.901, 1875.139) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2421.727, 1907.054) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2487.891, 1871.128) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2398.813, 1884.88) (added to group)
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2442.075, 1897.906) (added to group)
+[01:03:49] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.086, 1881.576), source=ENEMY (Exit_DroneOperator2), range=800, listeners=18
+[01:03:49] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[01:03:49] [INFO] [BloodDecal] Blood puddle created at (2448.122, 1877.288) (added to group)
+[01:03:49] [INFO] [ScoreManager] Damage taken: 1 (total: 7)
+[01:03:49] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:49] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.99984306, -0.017715797), lethal=False (C#)
+[01:03:49] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:50] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2444.809, 1905.695) (added to group)
+[01:03:50] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:03:50] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -84.5°
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2420.962, 1900.681) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2513.494, 1897.128) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2441.9, 1927.889) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2485.088, 1921.201) (added to group)
+[01:03:50] [INFO] [ScoreManager] Damage taken: 1 (total: 8)
+[01:03:50] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:50] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.99999976, 0.0007425677), lethal=False (C#)
+[01:03:50] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2463.359, 1889.805) (added to group)
+[01:03:50] [INFO] [ReplayManager] Recording frame 720 (12,0s): player_valid=True, enemies=18
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2401.204, 1917.887) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2418, 1889.023) (added to group)
+[01:03:50] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2421.649, 1894.988) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2437.013, 1878.047) (added to group)
+[01:03:50] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:03:50] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.1°
+[01:03:50] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -119.8° (interval=1.5s)
+[01:03:50] [INFO] [ScoreManager] Damage taken: 1 (total: 9)
+[01:03:50] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:50] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.99999195, 0.0040200306), lethal=False (C#)
+[01:03:50] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2501.325, 1891.327) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2493.84, 1874.647) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2388.285, 1888.335) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2461.272, 1911.285) (added to group)
+[01:03:50] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.086, 1881.576), source=ENEMY (Exit_DroneOperator2), range=800, listeners=18
+[01:03:50] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2427.139, 1929.329) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2419.533, 1879.806) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2511.991, 1908.918) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2471.948, 1919.636) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2437.124, 1925.965) (added to group)
+[01:03:50] [WARN] [FPS] Drop detected: 27 fps (threshold: 30)
+[01:03:50] [INFO] [ScoreManager] Damage taken: 1 (total: 10)
+[01:03:50] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:50] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.99907225, 0.04306564), lethal=False (C#)
+[01:03:50] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:50] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:50] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2479.341, 1906.463) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2390.795, 1892.527) (added to group)
+[01:03:50] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -84.2°
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2414.542, 1911.936) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2405.616, 1901.874) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2481.749, 1915.898) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2406.081, 1922.828) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2478.167, 1922.683) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2462.77, 1879.895) (added to group)
+[01:03:50] [INFO] [ScoreManager] Damage taken: 1 (total: 11)
+[01:03:50] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:50] [INFO] [Player] Spawning blood effect at (2343.796, 1885.6852), dir=(0.9999544, 0.009554067), lethal=False (C#)
+[01:03:50] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2478.334, 1887.275) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2421.295, 1890.281) (added to group)
+[01:03:50] [ENEMY] [Exit_DroneOperator2] Found cover at (2106.016, 1726) (distance: 155.7, player at (2344.129, 1885.685))
+[01:03:50] [ENEMY] [Exit_DroneOperator2] State: COMBAT -> SEEKING_COVER
+[01:03:50] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2114.161, 1910.274), source=NEUTRAL (null), range=900, listeners=18
+[01:03:50] [ENEMY] [FarTracks_MachineGunnerRight] Heard CASING_KICK at (2114.161, 1910.274), intensity=0.00, dist=737
+[01:03:50] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2114.161, 1910.274), intensity=0.00, dist=728
+[01:03:50] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2114.161, 1910.274), intensity=0.01, dist=599
+[01:03:50] [ENEMY] [Exit_DroneOperator1] Heard CASING_KICK at (2114.161, 1910.274), intensity=0.00, dist=828
+[01:03:50] [ENEMY] [Exit_DroneOperator2] Heard CASING_KICK at (2114.161, 1910.274), intensity=1.00, dist=32
+[01:03:50] [ENEMY] [Exit_DroneOperator3] Heard CASING_KICK at (2114.161, 1910.274), intensity=0.00, dist=747
+[01:03:50] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=12, self=0
+[01:03:50] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2523.489, 1869.023) (added to group)
+[01:03:50] [INFO] [BloodDecal] Blood puddle created at (2515.332, 1920.563) (added to group)
+[01:03:51] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2423.802, 1885.192) (added to group)
+[01:03:51] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -84.5°
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2479.793, 1900.045) (added to group)
+[01:03:51] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (1, 1, 1, 1)
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2429.761, 1890.172) (added to group)
+[01:03:51] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2041.765, 1905.594), source=ENEMY (Exit_DroneOperator2), range=800, listeners=18
+[01:03:51] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2412.415, 1920.13) (added to group)
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2431.302, 1918.378) (added to group)
+[01:03:51] [INFO] [ReplayManager] Recording frame 780 (13,0s): player_valid=True, enemies=18
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2480.657, 1918.599) (added to group)
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2437.021, 1889.548) (added to group)
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2521.165, 1903.12) (added to group)
+[01:03:51] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:51] [INFO] [ScoreManager] Damage taken: 1 (total: 12)
+[01:03:51] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[01:03:51] [INFO] [Player] Spawning blood effect at (2438.6292, 1885.6852), dir=(0.99507457, -0.0991289), lethal=False (C#)
+[01:03:51] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[01:03:51] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -138.7°
+[01:03:51] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.3°
+[01:03:51] [WARN] [FPS] Drop detected: 28 fps (threshold: 30)
+[01:03:51] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:51] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -17.9°
+[01:03:51] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -107.9°
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2535.676, 1868.391) (added to group)
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2514.24, 1925.375) (added to group)
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2509.222, 1920.196) (added to group)
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2543.754, 1910.774) (added to group)
+[01:03:51] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -113.8° (interval=1.5s)
+[01:03:51] [INFO] [BloodDecal] Blood puddle created at (2618.296, 1918.292) (added to group)
+[01:03:51] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle 7.8°
+[01:03:52] [INFO] [BloodDecal] Blood puddle created at (2589.092, 1923.573) (added to group)
+[01:03:52] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle -38.7°
+[01:03:52] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.2°
+[01:03:52] [INFO] [ReplayManager] Recording frame 840 (14,0s): player_valid=True, enemies=18
+[01:03:52] [ENEMY] [Exit_DroneOperator1] FLANKING corner check: angle -12.1°
+[01:03:52] [ENEMY] [Exit_DroneOperator3] FLANKING corner check: angle 9.6°
+[01:03:52] [ENEMY] [Exit_DroneOperator4] FLANKING corner check: angle -93.1°
+[01:03:52] [INFO] ------------------------------------------------------------
+[01:03:52] [INFO] GAME LOG ENDED: 2026-04-18T01:03:52
+[01:03:52] [INFO] ============================================================

--- a/scripts/components/drone_operator_component.gd
+++ b/scripts/components/drone_operator_component.gd
@@ -186,6 +186,11 @@ func _show_weapon_hide_tablet() -> void:
 
 ## Update called each physics frame from enemy._physics_process().
 func update(delta: float) -> void:
+	if _parent_is_pacifist():
+		if _drone != null and is_instance_valid(_drone) and _drone.has_method("_explode"):
+			FileLogger.info("[DroneOperator] Operator is pacifist - neutralizing controlled drone (Issue #1868)")
+			_drone._explode()
+		return
 	match _phase:
 		Phase.DEPLOYING:
 			_update_deploying(delta)
@@ -203,6 +208,10 @@ func get_phase() -> Phase:
 ## Returns true if the operator is in the defenseless controlling phase.
 func is_controlling_drone() -> bool:
 	return _phase == Phase.CONTROLLING
+
+
+func _parent_is_pacifist() -> bool:
+	return _parent != null and _parent.has_method("is_pacifist") and _parent.is_pacifist()
 
 
 ## Returns true if the teleport is ready (off cooldown). ACTIVE phase only.
@@ -380,8 +389,7 @@ func _transition_to_active() -> void:
 	# Force transition to COMBAT state — unless the operator is already pacifist (Issue #1744).
 	# A pacifist drone operator should stay pacifist even after their drone is destroyed;
 	# forcing COMBAT here would override the loudspeaker effect and make them attack again.
-	var is_pacifist: bool = _parent and _parent.has_method("is_pacifist") and _parent.is_pacifist()
-	if not is_pacifist:
+	if not _parent_is_pacifist():
 		if _parent and _parent.has_method("_transition_to_combat"):
 			_parent._transition_to_combat()
 		elif _parent and _parent.get("_current_state") != null:

--- a/scripts/objects/drone.gd
+++ b/scripts/objects/drone.gd
@@ -116,6 +116,10 @@ func initialize_drone(operator: Node2D) -> void:
 func _physics_process(delta: float) -> void:
 	if not _is_alive:
 		return
+	if _operator_is_pacifist():
+		FileLogger.info("[Drone] Operator became pacifist — neutralizing drone (Issue #1868)")
+		_die(false, false, false)
+		return
 
 	_rotor_angle += 20.0 * delta
 	_animate_rotors()
@@ -448,6 +452,10 @@ func is_alive() -> bool:
 
 func is_in_combat() -> bool:
 	return _state == DroneState.COMBAT
+
+
+func _operator_is_pacifist() -> bool:
+	return _operator != null and is_instance_valid(_operator) and _operator.has_method("is_pacifist") and _operator.is_pacifist()
 
 
 ## Called by NavigationAgent2D.velocity_computed when ORCA avoidance is enabled.

--- a/scripts/objects/enemy.gd
+++ b/scripts/objects/enemy.gd
@@ -816,6 +816,8 @@ func _physics_process(delta: float) -> void:
 	# Issue #1186: performance toggles - skip AI if disabled; per-state filter applied below
 	var _perf_settings: Node = get_node_or_null("/root/PerformanceSettings")
 	if _perf_settings and not _perf_settings.is_ai_enabled(): return
+	if _pacifist and _pacifist.is_pacifist and _drone_operator and _drone_operator.get_phase() != DroneOperatorComponent.Phase.ACTIVE:
+		_drone_operator.update(delta); velocity = Vector2.ZERO; move_and_slide(); return  # Issue #1868: pacifist operators must not deploy/control drones or seek combat cover
 	if _drone_operator and _drone_operator.get_phase() != DroneOperatorComponent.Phase.ACTIVE:  # Issue #1397: drone operator phase control
 		_drone_operator.update(delta)
 		if _drone_operator.is_controlling_drone(): velocity = Vector2.ZERO; move_and_slide(); return  # CONTROLLING: fully frozen
@@ -2854,6 +2856,7 @@ func _transition_to_pacifist(emit_signal: bool = true) -> void:
 	var was := _pacifist.is_pacifist if _pacifist else false
 	_current_state = AIState.PACIFIST; _has_left_idle = true; velocity = Vector2.ZERO
 	if _nav_agent: _nav_agent.path_desired_distance = _nav_default_path_desired_distance  # #1289
+	if _aggression: _aggression.set_aggressive(false)
 	if _pacifist: _pacifist.start_pacifism()
 	_log_to_file("Transitioned to PACIFIST"); if emit_signal and not was: became_pacifist.emit()
 ## Make this enemy a pacifist via loudspeaker. Returns true if successful.

--- a/tests/unit/test_drone.gd
+++ b/tests/unit/test_drone.gd
@@ -545,10 +545,43 @@ class MockDroneWithOperatorLink:
 		return _has_exploded
 
 
+class MockDroneWithPacifistOperatorLink:
+	## Mirrors Issue #1868: a live drone must be neutralized when its operator
+	## becomes pacifist, before the drone can enter or continue combat.
+	var _is_alive: bool = true
+	var _is_combat: bool = false
+	var _operator: MockOperatorNode = null
+
+	func initialize_drone(operator: MockOperatorNode) -> void:
+		_operator = operator
+
+	func physics_tick() -> void:
+		if not _is_alive:
+			return
+		if _operator_is_pacifist():
+			_die()
+			return
+		_is_combat = true
+
+	func _operator_is_pacifist() -> bool:
+		return _operator != null and _operator.is_pacifist()
+
+	func _die() -> void:
+		_is_alive = false
+		_is_combat = false
+
+	func is_alive() -> bool:
+		return _is_alive
+
+	func is_in_combat() -> bool:
+		return _is_combat
+
+
 class MockOperatorNode:
 	## Minimal operator node that can emit a died signal (simulated via callbacks).
 	var on_died_callbacks: Array = []
 	var _is_alive: bool = true
+	var _is_pacifist: bool = false
 
 	func die() -> void:
 		_is_alive = false
@@ -557,6 +590,12 @@ class MockOperatorNode:
 
 	func is_alive() -> bool:
 		return _is_alive
+
+	func become_pacifist() -> void:
+		_is_pacifist = true
+
+	func is_pacifist() -> bool:
+		return _is_pacifist
 
 
 func test_drone_explodes_when_operator_killed() -> void:
@@ -597,3 +636,31 @@ func test_drone_without_operator_does_not_crash() -> void:
 	# No initialize_drone() call — operator is null
 	assert_true(drone.is_alive(), "Drone without operator should still be alive initially")
 	assert_false(drone.has_exploded(), "Drone without operator should not have exploded")
+
+
+# ============================================================================
+# Pacifist operator tests (Issue #1868)
+# ============================================================================
+
+
+func test_drone_dies_when_operator_becomes_pacifist() -> void:
+	var operator := MockOperatorNode.new()
+	var drone := MockDroneWithPacifistOperatorLink.new()
+	drone.initialize_drone(operator)
+
+	operator.become_pacifist()
+	drone.physics_tick()
+
+	assert_false(drone.is_alive(), "Drone must be neutralized when its operator becomes pacifist")
+	assert_false(drone.is_in_combat(), "Drone must not stay aggressive after operator pacifism")
+
+
+func test_drone_with_non_pacifist_operator_can_enter_combat() -> void:
+	var operator := MockOperatorNode.new()
+	var drone := MockDroneWithPacifistOperatorLink.new()
+	drone.initialize_drone(operator)
+
+	drone.physics_tick()
+
+	assert_true(drone.is_alive(), "Drone should remain alive while operator is not pacifist")
+	assert_true(drone.is_in_combat(), "Non-pacifist operator should not block normal drone aggression")

--- a/tests/unit/test_drone_operator.gd
+++ b/tests/unit/test_drone_operator.gd
@@ -636,6 +636,47 @@ func test_drone_operator_pacifist_guard_in_source() -> void:
 		"drone_operator_component.gd must reference Issue #1744 in the pacifist guard comment")
 
 
+func test_drone_operator_update_returns_early_when_parent_is_pacifist() -> void:
+	## Issue #1868: level-7 pacifist operators must not deploy drones or keep controlling them.
+	var file := FileAccess.open("res://scripts/components/drone_operator_component.gd", FileAccess.READ)
+	if file == null:
+		gut.p("Cannot open drone_operator_component.gd — skipping (export build)")
+		pass_test("Skipped in export build")
+		return
+	var source := file.get_as_text()
+	file.close()
+	var update_start: int = source.find("func update(delta: float) -> void:")
+	assert_gt(update_start, 0, "drone_operator_component.gd must define update()")
+	var next_func: int = source.find("func get_phase()", update_start)
+	assert_gt(next_func, update_start, "get_phase() should follow update()")
+	var update_body: String = source.substr(update_start, next_func - update_start)
+	assert_true(update_body.contains("_parent_is_pacifist()"),
+		"DroneOperatorComponent.update() must check parent pacifism before phase updates")
+	assert_true(update_body.contains("return"),
+		"DroneOperatorComponent.update() must return early for pacifist operators")
+	assert_true(source.contains("Issue #1868"),
+		"DroneOperatorComponent must document the Issue #1868 pacifist operator guard")
+
+
+func test_enemy_physics_blocks_pacifist_operator_phase_control_before_deploying() -> void:
+	## Issue #1868: enemy.gd must not run the normal DEPLOYING/CONTROLLING branch for pacifist operators.
+	var file := FileAccess.open("res://scripts/objects/enemy.gd", FileAccess.READ)
+	if file == null:
+		gut.p("Cannot open enemy.gd — skipping (export build)")
+		pass_test("Skipped in export build")
+		return
+	var source := file.get_as_text()
+	file.close()
+	var pacifist_guard: int = source.find("Issue #1868: pacifist operators")
+	var phase_control: int = source.find("Issue #1397: drone operator phase control")
+	assert_gt(pacifist_guard, 0,
+		"enemy.gd must contain a pacifist drone-operator guard for Issue #1868")
+	assert_gt(phase_control, pacifist_guard,
+		"The Issue #1868 pacifist guard must run before normal drone-operator phase control")
+	assert_true(source.contains("_aggression.set_aggressive(false)"),
+		"Pacifist transition must clear aggression so pacifists cannot keep aggressive behavior")
+
+
 func test_enemy_pacifist_retaliation_uses_attacker_node() -> void:
 	## Issue #1744 follow-up: when another enemy hits a pacifist, retaliation targets that enemy, not the player.
 	var file := FileAccess.open("res://scripts/objects/enemy.gd", FileAccess.READ)


### PR DESCRIPTION
Fixes Jhon-Crow/godot-topdown-MVP#1868

## Summary
- Neutralize a spawned drone when its drone operator becomes pacifist, before the drone can enter or continue aggressive combat behavior.
- Block pacifist drone operators from running the normal DEPLOYING/CONTROLLING phase loop, so level-7 loudspeaker pacifism prevents them from seeking cover, deploying drones, or later re-entering combat.
- Clear aggression state when an enemy transitions to pacifism so stale aggressive behavior cannot survive the pacifist transition.
- Add regression coverage for the drone and drone-operator pacifist paths.
- Download and commit the owner-provided logs plus a case-study timeline/root-cause writeup under `docs/case-studies/issue-1868/`.

## Root Cause
The first fix handled drones after their linked operator was already pacifist, but the logs showed a second path: newly loaded railway-station drone operators were transitioned to `PACIFIST` by the level-7 loudspeaker victory state, then their `DroneOperatorComponent` still ran before normal pacifist AI processing. That component reached cover, deployed drones, entered `CONTROLLING`, and later operators appeared in `FLANKING`/`COMBAT` and emitted enemy gunshots.

## Reproduction From Logs
1. Use Loudspeaker level 7 so the victory state makes all enemies pacifists.
2. Enter the railway-station section with `Exit_DroneOperator*` enemies.
3. In `game_log_20260418_010323.txt`, the operators transition to `PACIFIST` at 01:03:25, then still log `Reached cover, deploying drone in 0.5s` and deploy drones at 01:03:26.
4. In `game_log_20260418_010143.txt`, operators later log `FLANKING -> COMBAT` and enemy `GUNSHOT` events around 01:02:25-01:02:30.

## Case Study Artifacts
- `docs/case-studies/issue-1868/README.md`
- `docs/case-studies/issue-1868/game_log_20260418_010143.txt`
- `docs/case-studies/issue-1868/game_log_20260418_010323.txt`

## Verification
- `git diff --check` passes.
- Static architecture checks for script size, component/state `class_name` declarations, and required folder structure pass locally.
- Added/updated regression coverage:
  - `tests/unit/test_drone.gd::test_drone_dies_when_operator_becomes_pacifist`
  - `tests/unit/test_drone.gd::test_drone_with_non_pacifist_operator_can_enter_combat`
  - `tests/unit/test_drone_operator.gd::test_drone_operator_update_returns_early_when_parent_is_pacifist`
  - `tests/unit/test_drone_operator.gd::test_enemy_physics_blocks_pacifist_operator_phase_control_before_deploying`

## Notes
The local environment does not have the Godot executable installed, so I could not run the full GUT command locally. GitHub Actions downloads Godot 4.3 and should run the full suite on this branch.
