### PR TITLE
Localize roguelike exit label

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-17T23:01:30.027Z for PR creation at branch issue-1872-b740cb6df397 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1872

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-17T23:01:30.027Z for PR creation at branch issue-1872-b740cb6df397 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1872

--- a/resources/translations/translations.csv
+++ b/resources/translations/translations.csv
@@ -221,6 +221,9 @@ HINT_RELOAD_2STEP_0,[R] [R] Reload,[R] [R] Перезарядись
 HUD_ENEMIES,Enemies: %d,Враги: %d
 HUD_AMMO,Ammo: %d / %d,Патроны: %d / %d
 HUD_DIFFICULTY,Difficulty: %s,Сложность: %s
+ROGUELIKE_ROOM_START,START,СТАРТ
+ROGUELIKE_ROOM_TREASURE,TREASURE,СОКРОВИЩНИЦА
+ROGUELIKE_ROOM_EXIT,EXIT,ВЫХОД
 HINT_RELOAD_2STEP_1,[R] [R] Reload,[R] [R] Перезарядись
 HINT_RELOAD_3STEP_0,[R] [F] [R] Reload,[R] [F] [R] Перезарядись
 HINT_RELOAD_3STEP_1,[R] [F] [R] Reload,[R] [F] [R] Перезарядись

--- a/scripts/levels/roguelike_level.gd
+++ b/scripts/levels/roguelike_level.gd
@@ -2146,9 +2146,9 @@ func _get_room_progress_text() -> String:
 		var total_count: int = rooms.size()
 		var map_type_label: String = ""
 		match map_type:
-			"start": map_type_label = "СТАРТ"
-			"treasure": map_type_label = "СОКРОВИЩНИЦА"
-			"exit": map_type_label = "ВЫХОД"
+			"start": map_type_label = tr("ROGUELIKE_ROOM_START")
+			"treasure": map_type_label = tr("ROGUELIKE_ROOM_TREASURE")
+			"exit": map_type_label = tr("ROGUELIKE_ROOM_EXIT")
 			_: map_type_label = type_name
 		return "РОГАЛИК — Ур.%d — %s — Комнат: %d/%d" % [
 			GameManager.roguelike_current_level,

--- a/tests/unit/test_level_localization.gd
+++ b/tests/unit/test_level_localization.gd
@@ -27,6 +27,15 @@ func test_localized_hud_labels_use_translation_keys() -> void:
 	assert_eq(_helper.get_difficulty_text("Hard"), tr("HUD_DIFFICULTY") % tr("HARD"))
 
 
+func test_roguelike_exit_room_label_has_english_translation() -> void:
+	var file := FileAccess.open("res://resources/translations/translations.csv", FileAccess.READ)
+	assert_not_null(file)
+	var source := file.get_as_text()
+
+	assert_string_contains(source, "ROGUELIKE_ROOM_EXIT,EXIT,ВЫХОД")
+	assert_false(source.contains("ROGUELIKE_ROOM_EXIT,ВЫХОД,ВЫХОД"))
+
+
 func test_known_level_name_translations_resolve_for_bidirectional_locales() -> void:
 	assert_eq(_helper.get_level_display_name("res://scenes/levels/TestTier.tscn"), tr("LEVEL_POLYGON_NAME"))
 	assert_eq(_helper.get_level_display_name("res://scenes/levels/CastleLevel.tscn"), tr("LEVEL_CASTLE_NAME"))
@@ -303,3 +312,14 @@ func test_level_init_fallback_localizes_building_hud_source() -> void:
 	assert_false(source.contains("\"AMMO: "))
 	assert_false(source.contains("\"MAGS: "))
 	assert_false(source.contains("\"Difficulty: "))
+
+
+func test_roguelike_room_progress_uses_localized_exit_label_source() -> void:
+	var file := FileAccess.open("res://scripts/levels/roguelike_level.gd", FileAccess.READ)
+	assert_not_null(file)
+	var source := file.get_as_text()
+
+	assert_string_contains(source, "ROGUELIKE_ROOM_EXIT")
+	assert_string_contains(source, "ROGUELIKE_ROOM_START")
+	assert_string_contains(source, "ROGUELIKE_ROOM_TREASURE")
+	assert_false(source.contains("\"exit\": map_type_label = \"ВЫХОД\""))


### PR DESCRIPTION
Fixes Jhon-Crow/godot-topdown-MVP#1872

## Summary
- Added localized roguelike room labels for start, treasure, and exit map rooms.
- Replaced the hardcoded Russian exit map label with `tr("ROGUELIKE_ROOM_EXIT")` so English locale displays `EXIT`.
- Added regression tests that guard the CSV translation entry and roguelike progress source against reverting to a Russian-only exit label.

## Testing
- `git diff --check`
- `dotnet build` (passed; existing warnings remain)

## Notes
- GUT tests were not run locally because no Godot executable is installed in this workspace.
