### PR TITLE
Localize exit zone indicator

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-17T23:19:10.427Z for PR creation at branch issue-1872-14232dcc754b for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1872

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-17T23:19:10.427Z for PR creation at branch issue-1872-14232dcc754b for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1872

--- a/resources/translations/translations.csv
+++ b/resources/translations/translations.csv
@@ -8,6 +8,7 @@ ROGUELIKE,Roguelike,Рогалик
 ARENA,Arena,Арена
 SETTINGS,Settings,Настройки
 QUIT,Quit,Выход
+EXIT_ZONE_LABEL,EXIT,ВЫХОД
 SETTINGS_TITLE,Settings,Настройки
 CONTROLS,Controls,Управление
 DIFFICULTY,Difficulty,Сложность

--- a/scripts/components/exit_zone.gd
+++ b/scripts/components/exit_zone.gd
@@ -63,6 +63,10 @@ func _ready() -> void:
 	# Set monitoring to false initially
 	monitoring = false
 
+	var localization_settings: Node = get_node_or_null("/root/LocalizationSettings")
+	if localization_settings and localization_settings.has_signal("locale_changed") and not localization_settings.locale_changed.is_connected(_on_locale_changed):
+		localization_settings.locale_changed.connect(_on_locale_changed)
+
 
 func _process(_delta: float) -> void:
 	if _is_active and _player != null and is_instance_valid(_player):
@@ -103,7 +107,7 @@ func _create_visuals() -> void:
 	# Create exit label
 	_exit_label = Label.new()
 	_exit_label.name = "ExitLabel"
-	_exit_label.text = "ВЫХОД"
+	_exit_label.text = tr("EXIT_ZONE_LABEL")
 	_exit_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	_exit_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	_exit_label.add_theme_font_size_override("font_size", 24)
@@ -118,7 +122,7 @@ func _create_visuals() -> void:
 	# Create arrow indicator (shows when player is far from exit)
 	_arrow_indicator = Label.new()
 	_arrow_indicator.name = "ArrowIndicator"
-	_arrow_indicator.text = "← ВЫХОД"
+	_arrow_indicator.text = _get_arrow_text(Vector2.LEFT)
 	_arrow_indicator.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	_arrow_indicator.add_theme_font_size_override("font_size", 32)
 	_arrow_indicator.add_theme_color_override("font_color", Color(0.3, 1.0, 0.4, 1.0))
@@ -162,18 +166,29 @@ func _update_arrow_indicator() -> void:
 		_arrow_indicator.position = arrow_world_pos - global_position - Vector2(80, 20)
 
 		# Update arrow text based on direction
-		if abs(direction.x) > abs(direction.y):
-			if direction.x < 0:
-				_arrow_indicator.text = "← ВЫХОД"
-			else:
-				_arrow_indicator.text = "ВЫХОД →"
-		else:
-			if direction.y < 0:
-				_arrow_indicator.text = "↑ ВЫХОД"
-			else:
-				_arrow_indicator.text = "ВЫХОД ↓"
+		_arrow_indicator.text = _get_arrow_text(direction)
 	else:
 		_arrow_indicator.visible = false
+
+
+## Returns localized arrow text for the direction from player to exit.
+func _get_arrow_text(direction: Vector2) -> String:
+	var exit_text: String = tr("EXIT_ZONE_LABEL")
+	if abs(direction.x) > abs(direction.y):
+		if direction.x < 0:
+			return "← %s" % exit_text
+		return "%s →" % exit_text
+	if direction.y < 0:
+		return "↑ %s" % exit_text
+	return "%s ↓" % exit_text
+
+
+## Refresh localized text when the display language changes.
+func _on_locale_changed(_locale: String) -> void:
+	if _exit_label:
+		_exit_label.text = tr("EXIT_ZONE_LABEL")
+	if _arrow_indicator:
+		_arrow_indicator.text = _get_arrow_text(Vector2.LEFT)
 
 
 ## Set the visibility of the exit zone.

--- a/tests/unit/test_exit_zone.gd
+++ b/tests/unit/test_exit_zone.gd
@@ -344,3 +344,40 @@ func test_custom_offset() -> void:
 
 	assert_eq(exit_zone.zone_offset, Vector2(50, 100),
 		"Custom offset should be applied")
+
+
+# ============================================================================
+# Localization Regression Tests
+# ============================================================================
+
+
+func test_exit_zone_uses_translation_key_for_label() -> void:
+	var source := FileAccess.get_file_as_string("res://scripts/components/exit_zone.gd")
+
+	assert_true(source.contains("tr(\"EXIT_ZONE_LABEL\")"),
+		"Exit zone label should use the localized EXIT_ZONE_LABEL key")
+
+
+func test_exit_zone_does_not_hardcode_russian_exit_text() -> void:
+	var source := FileAccess.get_file_as_string("res://scripts/components/exit_zone.gd")
+
+	assert_false(source.contains("\"ВЫХОД\""),
+		"Exit zone should not hard-code Russian text")
+
+
+func test_exit_zone_arrow_text_uses_localized_label() -> void:
+	var source := FileAccess.get_file_as_string("res://scripts/components/exit_zone.gd")
+
+	assert_true(source.contains("func _get_arrow_text(direction: Vector2) -> String:"),
+		"Exit zone should centralize localized arrow text")
+	assert_true(source.contains("var exit_text: String = tr(\"EXIT_ZONE_LABEL\")"),
+		"Arrow indicator should use the localized exit label")
+
+
+func test_exit_zone_refreshes_text_on_locale_change() -> void:
+	var source := FileAccess.get_file_as_string("res://scripts/components/exit_zone.gd")
+
+	assert_true(source.contains("locale_changed.connect(_on_locale_changed)"),
+		"Exit zone should listen for locale changes")
+	assert_true(source.contains("func _on_locale_changed(_locale: String) -> void:"),
+		"Exit zone should refresh visible text when locale changes")


### PR DESCRIPTION
## Summary
- Added `EXIT_ZONE_LABEL` translations (`EXIT` / `ВЫХОД`).
- Updated `ExitZone` so the post-clear exit label and distant arrow indicator use the active locale instead of hard-coded Russian text.
- Refreshes existing exit zone text when `LocalizationSettings.locale_changed` fires.
- Added regression coverage to prevent reintroducing hard-coded Russian exit text.

Fixes Jhon-Crow/godot-topdown-MVP#1872

## Testing
- `git diff --check`
- Targeted GUT command could not run locally because this container does not have a `godot`/`godot4` executable installed.
