### PR TITLE
fix: add unlock toast test control

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T00:04:22.726Z for PR creation at branch issue-1875-7fb6c8848021 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1875

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-18T00:04:22.726Z for PR creation at branch issue-1875-7fb6c8848021 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1875

--- a/scenes/ui/ExperimentalMenu.tscn
+++ b/scenes/ui/ExperimentalMenu.tscn
@@ -713,6 +713,33 @@ autowrap_mode = 2
 [node name="HSeparatorEnemiesTable" type="HSeparator" parent="MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer"]
 layout_mode = 2
 
+[node name="UnlockToastContainer" type="HBoxContainer" parent="MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="UnlockToastLabel" type="Label" parent="MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/UnlockToastContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Show Unlock Toast"
+autowrap_mode = 2
+
+[node name="UnlockToastItemOption" type="OptionButton" parent="MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/UnlockToastContainer"]
+custom_minimum_size = Vector2(220, 0)
+layout_mode = 2
+
+[node name="ShowUnlockToastButton" type="Button" parent="MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/UnlockToastContainer"]
+layout_mode = 2
+text = "Show"
+
+[node name="UnlockToastDescription" type="Label" parent="MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer"]
+layout_mode = 2
+text = "Shows the unlock toast for the selected item text:
+Drilling Bullets, Armored Skin, Fine Motor Skills, or Laser Sight."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="HSeparatorUnlockToast" type="HSeparator" parent="MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
 [node name="EnemySpawnerLabel" type="Label" parent="MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer"]
 layout_mode = 2
 text = "Enemy Spawner"

--- a/scripts/autoload/unlock_notification_manager.gd
+++ b/scripts/autoload/unlock_notification_manager.gd
@@ -17,6 +17,7 @@ const TOAST_CONTENT_LEFT_MARGIN: float = 16.0
 const TOAST_CONTENT_TOP_MARGIN: float = 10.0
 const TOAST_CONTENT_RIGHT_MARGIN: float = 18.0
 const TOAST_CONTENT_BOTTOM_MARGIN: float = 10.0
+const ARMORY_ICON_TEXT_GAP: float = 24.0
 const ARMORY_ICON_PATH: String = "res://assets/sprites/ui/menu_icons/icon_armory.svg"
 const GOLD_SHINE_SHADER_PATH: String = "res://scripts/shaders/gold_shine.gdshader"
 const NOTIFICATION_TEMPLATE_KEY: String = "UNLOCK_NOTIFICATION_OPENED"
@@ -272,7 +273,7 @@ func _build_ui() -> void:
 	var row := HBoxContainer.new()
 	row.name = "ContentRow"
 	row.alignment = BoxContainer.ALIGNMENT_CENTER
-	row.add_theme_constant_override("separation", 14)
+	row.add_theme_constant_override("separation", int(ARMORY_ICON_TEXT_GAP))
 	margin.add_child(row)
 
 	_icon_rect = TextureRect.new()
@@ -550,7 +551,7 @@ func _position_toast(visible_position: bool) -> void:
 				maxf(0.0, toast_width - TOAST_CONTENT_LEFT_MARGIN - TOAST_CONTENT_RIGHT_MARGIN),
 				maxf(0.0, TOAST_HEIGHT - TOAST_CONTENT_TOP_MARGIN - TOAST_CONTENT_BOTTOM_MARGIN))
 	if _message_shadow_label:
-		var icon_column_width: float = 42.0 + 14.0
+		var icon_column_width: float = 42.0 + ARMORY_ICON_TEXT_GAP
 		_message_shadow_label.position = Vector2(
 			TOAST_CONTENT_LEFT_MARGIN + icon_column_width,
 			TOAST_CONTENT_TOP_MARGIN)

--- a/scripts/ui/experimental_menu.gd
+++ b/scripts/ui/experimental_menu.gd
@@ -37,6 +37,8 @@ signal back_pressed
 @onready var delete_saves_button: Button = $MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/DeleteSavesContainer/DeleteSavesButton
 @onready var unlock_table_button: Button = $MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/UnlockTableContainer/UnlockTableButton
 @onready var enemies_table_button: Button = $MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/EnemiesTableContainer/EnemiesTableButton
+@onready var unlock_toast_item_option: OptionButton = $MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/UnlockToastContainer/UnlockToastItemOption
+@onready var show_unlock_toast_button: Button = $MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/UnlockToastContainer/ShowUnlockToastButton
 @onready var enemy_type_option: OptionButton = $MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/EnemySpawnerContainer/EnemyTypeOption
 @onready var spawn_enemy_button: Button = $MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/SpawnEnemyButton
 @onready var spawn_status_label: Label = $MenuContainer/PanelContainer/MarginContainer/ScrollContainer/VBoxContainer/SpawnStatusLabel
@@ -63,6 +65,13 @@ var enemies_table_menu_scene: PackedScene = preload("res://scenes/ui/EnemiesTabl
 
 ## The instantiated enemies table menu.
 var enemies_table_menu: CanvasLayer = null
+
+const UNLOCK_TOAST_SAMPLE_ITEMS: Array[Dictionary] = [
+	{"name": "Бурящие пули", "kind": "active_item"},
+	{"name": "Бронированная кожа", "kind": "active_item"},
+	{"name": "Хорошая мелкая моторика", "kind": "active_item"},
+	{"name": "Лазерный прицел", "kind": "active_item"}
+]
 
 
 func _ready() -> void:
@@ -147,6 +156,9 @@ func _ready() -> void:
 	_setup_row_hover(_vbox.get_node("EnemiesTableContainer"),
 			"View Enemies Table",
 			_vbox.get_node("EnemiesTableDescription"))
+	_setup_row_hover(_vbox.get_node("UnlockToastContainer"),
+			"Show Unlock Toast",
+			_vbox.get_node("UnlockToastDescription"))
 	_setup_row_hover(_vbox.get_node("EnemySpawnerContainer"),
 			"Enemy Spawner")
 
@@ -178,6 +190,8 @@ func _ready() -> void:
 	delete_saves_button.pressed.connect(_on_delete_saves_pressed)
 	unlock_table_button.pressed.connect(_on_unlock_table_pressed)
 	enemies_table_button.pressed.connect(_on_enemies_table_pressed)
+	_setup_unlock_toast_items()
+	show_unlock_toast_button.pressed.connect(_on_show_unlock_toast_pressed)
 	_setup_enemy_spawner()
 	enemy_type_option.item_selected.connect(_on_enemy_type_selected)
 	spawn_enemy_button.pressed.connect(_on_spawn_enemy_pressed)
@@ -540,6 +554,27 @@ func _on_enemies_table_back_pressed() -> void:
 	_log("Enemies table back button pressed")
 	if enemies_table_menu:
 		enemies_table_menu.hide()
+
+
+func _setup_unlock_toast_items() -> void:
+	unlock_toast_item_option.clear()
+	for item in UNLOCK_TOAST_SAMPLE_ITEMS:
+		unlock_toast_item_option.add_item(item["name"])
+		unlock_toast_item_option.set_item_metadata(unlock_toast_item_option.item_count - 1, item)
+
+
+func _on_show_unlock_toast_pressed() -> void:
+	var notification_manager: Node = get_node_or_null("/root/UnlockNotificationManager")
+	if notification_manager == null or not notification_manager.has_method("show_unlock_notification"):
+		status_label.text = "Error: UnlockNotificationManager not found"
+		return
+
+	var idx: int = unlock_toast_item_option.selected
+	var item: Dictionary = unlock_toast_item_option.get_item_metadata(idx) if idx >= 0 else UNLOCK_TOAST_SAMPLE_ITEMS[0]
+	var item_name: String = item.get("name", "")
+	var kind: String = item.get("kind", "active_item")
+	notification_manager.show_unlock_notification(item_name, kind)
+	status_label.text = "Unlock toast shown: %s" % item_name
 
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/tests/unit/test_experimental_menu.gd
+++ b/tests/unit/test_experimental_menu.gd
@@ -447,3 +447,23 @@ func test_experimental_menu_should_use_process_always() -> void:
 	# Experimental menu must use PROCESS_MODE_ALWAYS to receive input while paused
 	var expected_mode := Node.PROCESS_MODE_ALWAYS
 	assert_eq(expected_mode, 3, "PROCESS_MODE_ALWAYS should be 3")
+
+
+func test_unlock_toast_sample_items_match_issue_request() -> void:
+	var script: GDScript = load("res://scripts/ui/experimental_menu.gd")
+	assert_not_null(script, "ExperimentalMenu script should load")
+
+	var expected_names: Array[String] = [
+		"Бурящие пули",
+		"Бронированная кожа",
+		"Хорошая мелкая моторика",
+		"Лазерный прицел"
+	]
+	var actual_names: Array[String] = []
+	for item in script.UNLOCK_TOAST_SAMPLE_ITEMS:
+		actual_names.append(item["name"])
+		assert_eq(item.get("kind", ""), "active_item",
+			"Unlock toast samples should be active item notifications")
+
+	assert_eq(actual_names, expected_names,
+		"Experimental menu should offer exactly the requested unlock toast item texts")

--- a/tests/unit/test_unlock_notification_manager.gd
+++ b/tests/unit/test_unlock_notification_manager.gd
@@ -142,6 +142,7 @@ func test_gold_text_remains_above_shine_overlay() -> void:
 	var label: Label = content_margin.get_node("ContentRow/MessageLabel")
 	var shadow_label: Label = toast.get_node("MessageShadowLabel")
 	var font_color: Color = label.get_theme_color("font_color")
+	var row_gap: int = content_row.get_theme_constant("separation")
 
 	assert_eq(toast.modulate.a, 1.0,
 		"Toast container alpha should stay opaque so child label text is never faded by parent modulation")
@@ -153,6 +154,10 @@ func test_gold_text_remains_above_shine_overlay() -> void:
 		"Content should render above the toast background")
 	assert_gt(shadow_label.z_index, shine_overlay.z_index,
 		"Fallback text label should render above the shine overlay in exported builds")
+	assert_eq(row_gap, int(manager.ARMORY_ICON_TEXT_GAP),
+		"Content row should use the configured Armory icon/text gap")
+	assert_ge(row_gap, 24,
+		"Armory icon and text should have a larger readable gap")
 	assert_gt(content_margin.size.x, 0.0,
 		"Content margin should have explicit width so exported builds lay out the label")
 	assert_gt(content_row.size.x, 0.0,


### PR DESCRIPTION
Fixes Jhon-Crow/godot-topdown-MVP#1875

## Summary
- Increased the unlock toast gap between the Armory icon and message text via `ARMORY_ICON_TEXT_GAP`.
- Added an Experimental menu utility row with an item selector and Show button for manual unlock toast previews.
- Added the requested sample item texts: `Бурящие пули`, `Бронированная кожа`, `Хорошая мелкая моторика`, and `Лазерный прицел`.
- Added regression coverage for the toast icon/text spacing and the Experimental menu sample item list.

## Testing
- `git diff --check` - passed
- GUT tests not run locally: this workspace does not have a Godot binary (`godot`, `godot4`, or `Godot_v4.3-stable_mono_linux.x86_64`) available.
