### PR TITLE
Add gameplay toggle for unlock toasts

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-18T00:27:02.856Z for PR creation at branch issue-1883-782ff415107d for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1883

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T00:27:02.856Z for PR creation at branch issue-1883-782ff415107d for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1883

--- a/resources/translations/translations.csv
+++ b/resources/translations/translations.csv
@@ -26,6 +26,7 @@ BLOOD_AMOUNT,Blood Amount,Количество крови
 WEAPON_HINTS,Weapon Hints,Подсказки оружия
 REVOLVER_AIM_ASSIST,Revolver Aim Assist,Помощь прицеливания револьвера
 COMBO_FONT_SIZE,Combo Font Size,Размер шрифта комбо
+UNLOCK_NOTIFICATIONS,Unlock Notifications,Оповещения об анлоке
 WEAPON_HINTS_ALWAYS,Always,Всегда
 WEAPON_HINTS_FIRST_TIME,First time only,Только первый раз
 WEAPON_HINTS_NEVER,Never,Никогда

--- a/scenes/ui/GameplayMenu.tscn
+++ b/scenes/ui/GameplayMenu.tscn
@@ -26,9 +26,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -200.0
-offset_top = -200.0
+offset_top = -230.0
 offset_right = 200.0
-offset_bottom = 200.0
+offset_bottom = 230.0
 grow_horizontal = 2
 grow_vertical = 2
 
@@ -107,6 +107,22 @@ button_pressed = true
 [node name="HSeparator4" type="HSeparator" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
+[node name="UnlockNotificationsContainer" type="HBoxContainer" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="UnlockNotificationsLabel" type="Label" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer/UnlockNotificationsContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "UNLOCK_NOTIFICATIONS"
+autowrap_mode = 2
+
+[node name="UnlockNotificationsToggle" type="CheckButton" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer/UnlockNotificationsContainer"]
+layout_mode = 2
+button_pressed = true
+
+[node name="HSeparator5" type="HSeparator" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
 [node name="ComboSizeLabel" type="Label" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "COMBO_FONT_SIZE"
@@ -129,7 +145,7 @@ layout_mode = 2
 text = "112"
 horizontal_alignment = 2
 
-[node name="HSeparator5" type="HSeparator" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+[node name="HSeparator6" type="HSeparator" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
 [node name="BackButton" type="Button" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]

--- a/scripts/autoload/gameplay_settings.gd
+++ b/scripts/autoload/gameplay_settings.gd
@@ -3,6 +3,7 @@ extends Node
 ##
 ## Provides centralized control over gameplay-affecting visual settings:
 ## - Blood amount (количество крови): multiplier for blood decals spawned per hit
+## - Unlock notifications: show or suppress Armory unlock toast messages
 ## - Combo font size (Issue #1790): pixel size of the combo counter label
 ##
 ## Settings are persisted to disk.
@@ -22,6 +23,10 @@ var wall_hit_particles_enabled: bool = true
 ## Whether revolver aim assist (slight bullet homing) is enabled (Issue #1332).
 ## When enabled (default), revolver bullets gently steer toward enemies near the crosshair.
 var revolver_aim_assist_enabled: bool = true
+
+## Whether unlock toast notifications are shown when new Armory items become available.
+## Enabled by default so existing behavior is preserved.
+var unlock_notifications_enabled: bool = true
 
 ## Combo label font size in pixels (Issue #1790). Default is 112 (2× the base 56px).
 ## Range: [28, 224].
@@ -45,7 +50,7 @@ const MAX_COMBO_FONT_SIZE: int = 224
 
 func _ready() -> void:
 	_load_settings()
-	_log_to_file("GameplaySettings initialized - blood_amount: %.2f, wall_hit_particles: %s, revolver_aim_assist: %s, combo_font_size: %d" % [blood_amount, wall_hit_particles_enabled, revolver_aim_assist_enabled, combo_font_size])
+	_log_to_file("GameplaySettings initialized - blood_amount: %.2f, wall_hit_particles: %s, revolver_aim_assist: %s, unlock_notifications: %s, combo_font_size: %d" % [blood_amount, wall_hit_particles_enabled, revolver_aim_assist_enabled, unlock_notifications_enabled, combo_font_size])
 
 
 ## Sets the blood amount multiplier.
@@ -94,6 +99,21 @@ func is_revolver_aim_assist_enabled() -> bool:
 	return revolver_aim_assist_enabled
 
 
+## Sets whether unlock toast notifications are shown.
+## @param enabled: true to show unlock toasts, false to suppress them.
+func set_unlock_notifications_enabled(enabled: bool) -> void:
+	if unlock_notifications_enabled != enabled:
+		unlock_notifications_enabled = enabled
+		settings_changed.emit()
+		_save_settings()
+		_log_to_file("Unlock notifications %s" % ("enabled" if enabled else "disabled"))
+
+
+## Returns whether unlock toast notifications are shown.
+func are_unlock_notifications_enabled() -> bool:
+	return unlock_notifications_enabled
+
+
 ## Sets the combo label font size (Issue #1790).
 ## @param size: Pixel size [28, 224].
 func set_combo_font_size(size: int) -> void:
@@ -116,6 +136,7 @@ func _save_settings() -> void:
 	config.set_value("gameplay", "blood_amount", blood_amount)
 	config.set_value("gameplay", "wall_hit_particles_enabled", wall_hit_particles_enabled)
 	config.set_value("gameplay", "revolver_aim_assist_enabled", revolver_aim_assist_enabled)
+	config.set_value("gameplay", "unlock_notifications_enabled", unlock_notifications_enabled)
 	config.set_value("gameplay", "combo_font_size", combo_font_size)
 	var error := config.save(SETTINGS_PATH)
 	if error != OK:
@@ -131,12 +152,14 @@ func _load_settings() -> void:
 		blood_amount = clamp(blood_amount, MIN_BLOOD_AMOUNT, MAX_BLOOD_AMOUNT)
 		wall_hit_particles_enabled = config.get_value("gameplay", "wall_hit_particles_enabled", true)
 		revolver_aim_assist_enabled = config.get_value("gameplay", "revolver_aim_assist_enabled", true)
+		unlock_notifications_enabled = config.get_value("gameplay", "unlock_notifications_enabled", true)
 		combo_font_size = config.get_value("gameplay", "combo_font_size", 112)
 		combo_font_size = clampi(combo_font_size, MIN_COMBO_FONT_SIZE, MAX_COMBO_FONT_SIZE)
 	else:
 		blood_amount = 1.0
 		wall_hit_particles_enabled = true
 		revolver_aim_assist_enabled = true
+		unlock_notifications_enabled = true
 		combo_font_size = 112
 
 

--- a/scripts/autoload/unlock_notification_manager.gd
+++ b/scripts/autoload/unlock_notification_manager.gd
@@ -178,6 +178,8 @@ func show_unlock_notification(item_name: String, kind: String = "") -> void:
 	var clean_name: String = item_name.strip_edges()
 	if clean_name.is_empty():
 		return
+	if not _are_unlock_notifications_enabled():
+		return
 	_pending_notifications.append({
 		"kind": kind.strip_edges(),
 		"item_name": clean_name
@@ -359,6 +361,15 @@ func _queue_new_available_unlocks() -> void:
 		if _startup_suppressed_available_keys.erase(key):
 			_log("Announcing previously startup-available unlock after live condition signal: %s" % key)
 		show_unlock_notification(entry["name"], entry["kind"])
+
+
+func _are_unlock_notifications_enabled() -> bool:
+	var gameplay_settings: Node = get_node_or_null("/root/GameplaySettings")
+	if gameplay_settings == null:
+		return true
+	if not gameplay_settings.has_method("are_unlock_notifications_enabled"):
+		return true
+	return gameplay_settings.are_unlock_notifications_enabled()
 
 
 func _collect_weapon_entries(unlock_manager: Node, game_manager: Node) -> Array[Dictionary]:

--- a/scripts/ui/gameplay_menu.gd
+++ b/scripts/ui/gameplay_menu.gd
@@ -4,6 +4,7 @@ extends CanvasLayer
 ## Provides settings that affect gameplay mechanics:
 ## - Blood amount (количество крови): slider controlling blood decals per hit (Issue #1090)
 ## - Weapon hints display mode (Issue #809): Always / First time only / Never
+## - Unlock notifications: toggle Armory unlock toast display
 
 ## Signal emitted when the back button is pressed.
 signal back_pressed
@@ -13,6 +14,7 @@ signal back_pressed
 @onready var blood_value_label: Label = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/BloodContainer/BloodValueLabel
 @onready var weapon_hints_option: OptionButton = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/WeaponHintsContainer/WeaponHintsOption
 @onready var aim_assist_toggle: CheckButton = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/AimAssistContainer/AimAssistToggle
+@onready var unlock_notifications_toggle: CheckButton = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/UnlockNotificationsContainer/UnlockNotificationsToggle
 @onready var combo_size_slider: HSlider = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ComboSizeContainer/ComboSizeSlider
 @onready var combo_size_value_label: Label = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ComboSizeContainer/ComboSizeValueLabel
 @onready var back_button: Button = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/BackButton
@@ -26,6 +28,8 @@ func _ready() -> void:
 			tr("WEAPON_HINTS"))
 	_setup_row_hover($MenuContainer/PanelContainer/MarginContainer/VBoxContainer/AimAssistContainer,
 			tr("REVOLVER_AIM_ASSIST"))
+	_setup_row_hover($MenuContainer/PanelContainer/MarginContainer/VBoxContainer/UnlockNotificationsContainer,
+			tr("UNLOCK_NOTIFICATIONS"))
 	_setup_row_hover($MenuContainer/PanelContainer/MarginContainer/VBoxContainer/ComboSizeContainer,
 			tr("COMBO_FONT_SIZE"))
 
@@ -34,6 +38,7 @@ func _ready() -> void:
 	_setup_weapon_hints_option()
 	weapon_hints_option.item_selected.connect(_on_weapon_hints_selected)
 	aim_assist_toggle.toggled.connect(_on_aim_assist_toggled)
+	unlock_notifications_toggle.toggled.connect(_on_unlock_notifications_toggled)
 	combo_size_slider.value_changed.connect(_on_combo_size_changed)
 	back_button.pressed.connect(_on_back_pressed)
 
@@ -64,6 +69,14 @@ func _update_ui() -> void:
 	aim_assist_toggle.set_block_signals(true)
 	aim_assist_toggle.button_pressed = gameplay_settings.is_revolver_aim_assist_enabled()
 	aim_assist_toggle.set_block_signals(false)
+
+	# Unlock toast notification toggle (Issue #1883)
+	unlock_notifications_toggle.set_block_signals(true)
+	if gameplay_settings.has_method("are_unlock_notifications_enabled"):
+		unlock_notifications_toggle.button_pressed = gameplay_settings.are_unlock_notifications_enabled()
+	else:
+		unlock_notifications_toggle.button_pressed = true
+	unlock_notifications_toggle.set_block_signals(false)
 
 	# Combo font size slider (Issue #1790)
 	combo_size_slider.set_block_signals(true)
@@ -101,6 +114,13 @@ func _on_aim_assist_toggled(enabled: bool) -> void:
 	var gameplay_settings: Node = get_node_or_null("/root/GameplaySettings")
 	if gameplay_settings:
 		gameplay_settings.set_revolver_aim_assist_enabled(enabled)
+
+
+## Called when unlock toast notifications are toggled (Issue #1883).
+func _on_unlock_notifications_toggled(enabled: bool) -> void:
+	var gameplay_settings: Node = get_node_or_null("/root/GameplaySettings")
+	if gameplay_settings and gameplay_settings.has_method("set_unlock_notifications_enabled"):
+		gameplay_settings.set_unlock_notifications_enabled(enabled)
 
 
 ## Called when the combo font size slider is changed (Issue #1790).

--- a/tests/unit/test_gameplay_menu.gd
+++ b/tests/unit/test_gameplay_menu.gd
@@ -29,6 +29,9 @@ class MockGameplayMenu:
 	## Current weapon hints mode.
 	var weapon_hints_mode: int = WEAPON_HINTS_ALWAYS
 
+	## Current unlock toast notification visibility.
+	var unlock_notifications_enabled: bool = true
+
 	## Signal tracking.
 	var back_pressed_count: int = 0
 
@@ -48,6 +51,10 @@ class MockGameplayMenu:
 	func set_weapon_hints(mode: int) -> void:
 		if mode >= WEAPON_HINTS_ALWAYS and mode <= WEAPON_HINTS_NEVER:
 			weapon_hints_mode = mode
+
+	## Toggle unlock toast notifications.
+	func set_unlock_notifications(enabled: bool) -> void:
+		unlock_notifications_enabled = enabled
 
 	## Press back.
 	func press_back() -> void:
@@ -177,6 +184,31 @@ func test_weapon_hints_mode_count() -> void:
 	]
 	assert_eq(valid_modes.size(), 3,
 		"Should have 3 weapon hints modes")
+
+
+# ============================================================================
+# Unlock Notifications Tests
+# ============================================================================
+
+
+func test_unlock_notifications_default_enabled() -> void:
+	assert_true(menu.unlock_notifications_enabled,
+		"Unlock notifications should be enabled by default")
+
+
+func test_can_disable_unlock_notifications() -> void:
+	menu.set_unlock_notifications(false)
+
+	assert_false(menu.unlock_notifications_enabled,
+		"Gameplay menu should allow disabling unlock notifications")
+
+
+func test_can_reenable_unlock_notifications() -> void:
+	menu.set_unlock_notifications(false)
+	menu.set_unlock_notifications(true)
+
+	assert_true(menu.unlock_notifications_enabled,
+		"Gameplay menu should allow re-enabling unlock notifications")
 
 
 # ============================================================================

--- a/tests/unit/test_gameplay_settings.gd
+++ b/tests/unit/test_gameplay_settings.gd
@@ -18,6 +18,9 @@ class MockGameplaySettings:
 	## Combo font size in pixels [20, 200]. Default is 112.
 	var combo_font_size: int = 112
 
+	## Unlock toast notifications are enabled by default.
+	var unlock_notifications_enabled: bool = true
+
 	## Track emitted signals
 	var settings_changed_count: int = 0
 
@@ -51,6 +54,14 @@ class MockGameplaySettings:
 	func get_combo_font_size() -> int:
 		return combo_font_size
 
+	func set_unlock_notifications_enabled(enabled: bool) -> void:
+		if unlock_notifications_enabled != enabled:
+			unlock_notifications_enabled = enabled
+			settings_changed_count += 1
+
+	func are_unlock_notifications_enabled() -> bool:
+		return unlock_notifications_enabled
+
 
 var settings: MockGameplaySettings
 
@@ -71,6 +82,11 @@ func after_each() -> void:
 func test_default_blood_amount_is_one() -> void:
 	assert_eq(settings.get_blood_amount(), 1.0,
 		"Default blood amount should be 1.0 (100%)")
+
+
+func test_default_unlock_notifications_enabled() -> void:
+	assert_true(settings.are_unlock_notifications_enabled(),
+		"Unlock notifications should be enabled by default")
 
 
 # ============================================================================
@@ -131,6 +147,22 @@ func test_set_blood_amount_signal_fires_each_change() -> void:
 	settings.set_blood_amount(1.0)
 	assert_eq(settings.settings_changed_count, 3,
 		"settings_changed should fire for each distinct value change")
+
+
+func test_set_unlock_notifications_emits_signal_on_change() -> void:
+	settings.set_unlock_notifications_enabled(false)
+	assert_false(settings.are_unlock_notifications_enabled(),
+		"Unlock notifications should be disabled after setting false")
+	assert_eq(settings.settings_changed_count, 1,
+		"settings_changed should fire once when unlock notifications change")
+
+
+func test_set_unlock_notifications_no_signal_when_same_value() -> void:
+	settings.set_unlock_notifications_enabled(true)
+	assert_true(settings.are_unlock_notifications_enabled(),
+		"Unlock notifications should remain enabled")
+	assert_eq(settings.settings_changed_count, 0,
+		"settings_changed should not fire when unlock notification value is unchanged")
 
 
 # ============================================================================

--- a/tests/unit/test_unlock_notification_manager.gd
+++ b/tests/unit/test_unlock_notification_manager.gd
@@ -73,6 +73,13 @@ class MockUnlockManager extends Node:
 		return item_type == 7 or item_type == 8 or item_type == 9
 
 
+class MockGameplaySettings extends Node:
+	var unlock_notifications_enabled: bool = true
+
+	func are_unlock_notifications_enabled() -> bool:
+		return unlock_notifications_enabled
+
+
 func test_unlock_notification_manager_script_exists() -> void:
 	assert_not_null(load(NOTIFICATION_MANAGER_SCRIPT),
 		"UnlockNotificationManager autoload script should exist")
@@ -198,6 +205,42 @@ func test_toast_animation_keeps_label_opaque_after_entry() -> void:
 		"Fallback text label should remain fully opaque after the slide-in animation")
 	assert_gt(background.modulate.a, 0.95,
 		"Only the background fade target should be fully visible after entry")
+
+
+func test_show_unlock_notification_skips_queue_when_setting_disabled() -> void:
+	var script: GDScript = load(NOTIFICATION_MANAGER_SCRIPT)
+	assert_not_null(script, "UnlockNotificationManager script should load")
+	var manager: CanvasLayer = autofree(script.new())
+	var gameplay_settings: MockGameplaySettings = autofree(MockGameplaySettings.new())
+	gameplay_settings.name = "GameplaySettings"
+	gameplay_settings.unlock_notifications_enabled = false
+	get_tree().root.add_child(gameplay_settings)
+	add_child(manager)
+	await get_tree().process_frame
+
+	manager.show_unlock_notification("Бронированная кожа", "active_item")
+
+	assert_eq(manager._pending_notifications.size(), 0,
+		"Disabled unlock notifications should not queue toast messages")
+
+
+func test_show_unlock_notification_queues_when_setting_enabled() -> void:
+	var script: GDScript = load(NOTIFICATION_MANAGER_SCRIPT)
+	assert_not_null(script, "UnlockNotificationManager script should load")
+	var manager: CanvasLayer = autofree(script.new())
+	var gameplay_settings: MockGameplaySettings = autofree(MockGameplaySettings.new())
+	gameplay_settings.name = "GameplaySettings"
+	gameplay_settings.unlock_notifications_enabled = true
+	get_tree().root.add_child(gameplay_settings)
+	add_child(manager)
+	await get_tree().process_frame
+
+	manager.show_unlock_notification("Бронированная кожа", "active_item")
+
+	assert_eq(manager._pending_notifications.size(), 0,
+		"Enabled unlock notifications should be consumed by the visible toast immediately")
+	assert_eq(manager._animation_phase, "entering",
+		"Enabled unlock notifications should start the toast animation")
 
 
 func test_collects_only_locked_items_with_met_conditions() -> void:


### PR DESCRIPTION
## Summary
- Added a Gameplay settings toggle for unlock toast notifications, enabled by default.
- Persisted the preference through `GameplaySettings` and used it to suppress unlock toast queueing when disabled.
- Added English/Russian translation text and updated targeted unit coverage for the setting, menu model, and notification manager behavior.

Fixes Jhon-Crow/godot-topdown-MVP#1883

## How to reproduce
1. Open Settings -> Gameplay.
2. Turn off `Unlock Notifications`.
3. Trigger an Armory unlock condition.
4. The Armory unlock toast should not appear; turning the setting back on restores the toast.

## Tests
- `git diff --check`
- Not run: GUT suite, because no `godot`/`godot4` executable is installed in this environment.
