### PR TITLE
Update unlock toast layout

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-18T00:46:20.553Z for PR creation at branch issue-1885-e264429a84f6 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1885

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T00:46:20.553Z for PR creation at branch issue-1885-e264429a84f6 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1885

--- a/docs/case-studies/issue-1885/unlock-toast-analysis.md
+++ b/docs/case-studies/issue-1885/unlock-toast-analysis.md
@@ -1,0 +1,54 @@
+# Issue 1885: Unlock Toast Layout
+
+## Problem
+
+Unlock notifications previously placed the generic unlock message and item name
+in one label, for example `Открыт предмет Бронированная кожа !`. Longer item,
+weapon, and grenade names can exceed the available toast width and become hard to
+read.
+
+## Repository Findings
+
+- The toast is built programmatically in
+  `scripts/autoload/unlock_notification_manager.gd`.
+- The experimental menu already provides a manual `show_unlock_notification`
+  path for checking long sample names.
+- Existing regression tests in `tests/unit/test_unlock_notification_manager.gd`
+  cover text content, animation opacity, shine layering, and explicit exported
+  layout sizing.
+
+## External Research
+
+- Godot 4 `RichTextLabel` supports BBCode sizing such as `[font_size]`, which
+  could render a smaller item name inside one text node.
+- A two-label layout is still preferable here because the current toast already
+  uses `Label` controls, has explicit fallback shadow labels for exported builds,
+  and needs predictable sizing inside fixed toast dimensions.
+
+Reference:
+https://docs.godotengine.org/en/stable/tutorials/ui/bbcode_in_richtextlabel.html
+
+## Considered Solutions
+
+1. Keep one `Label` and enable wrapping.
+   This reduces clipping risk but still gives the item name the same visual
+   priority as the generic message.
+
+2. Replace the label with one `RichTextLabel` using BBCode font size tags.
+   This supports mixed sizes but would introduce a different text control and
+   require extra care around BBCode escaping and minimum sizing.
+
+3. Use a vertical text stack: generic unlock line above a smaller item-name
+   label.
+   This matches the issue request, keeps existing `Label` behavior, and gives
+   tests direct access to each line.
+
+## Implemented Approach
+
+The toast now renders:
+
+- first line: generic text, for example `Открыт предмет !`;
+- second line: item, weapon, or grenade name in a smaller font.
+
+The shadow fallback labels mirror the same two-line structure, preserving the
+existing exported-build visibility guard.

--- a/scripts/autoload/unlock_notification_manager.gd
+++ b/scripts/autoload/unlock_notification_manager.gd
@@ -134,6 +134,8 @@ var _shine_overlay: ColorRect = null
 var _icon_rect: TextureRect = null
 var _message_label: Label = null
 var _message_shadow_label: Label = null
+var _item_name_label: Label = null
+var _item_name_shadow_label: Label = null
 var _active_tween: Tween = null
 
 
@@ -148,21 +150,22 @@ func _ready() -> void:
 ## Builds the user-facing text. Falls back to Russian to match the issue text when
 ## compiled translation resources have not been regenerated yet.
 func build_notification_text(kind: String, item_name: String) -> String:
-	var clean_kind: String = kind.strip_edges()
+	var header: String = build_notification_header_text(kind)
 	var clean_name: String = item_name.strip_edges()
+	if clean_name.is_empty():
+		return header
+	return "%s\n%s" % [header, clean_name]
+
+
+func build_notification_header_text(kind: String) -> String:
+	var clean_kind: String = kind.strip_edges()
 	var template: String = tr(NOTIFICATION_TEMPLATE_KEY)
 	if template == NOTIFICATION_TEMPLATE_KEY or template.is_empty():
 		template = "Открыт %s !"
-	return template % _build_notification_subject(clean_kind, clean_name)
-
-
-func _build_notification_subject(kind: String, item_name: String) -> String:
 	var kind_label: String = get_unlock_kind_display_name(kind)
 	if kind_label.is_empty():
-		return item_name
-	if item_name.is_empty():
-		return kind_label
-	return "%s %s" % [kind_label, item_name]
+		kind_label = clean_kind
+	return template % kind_label
 
 
 func get_unlock_kind_display_name(kind: String) -> String:
@@ -291,7 +294,7 @@ func _build_ui() -> void:
 	_message_label.name = "MessageLabel"
 	_message_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_message_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-	_message_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	_message_label.vertical_alignment = VERTICAL_ALIGNMENT_BOTTOM
 	_message_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	_message_label.clip_text = true
 	_message_label.add_theme_font_size_override("font_size", 20)
@@ -299,7 +302,28 @@ func _build_ui() -> void:
 	_message_label.add_theme_color_override("font_shadow_color", Color(0.0, 0.0, 0.0, 0.75))
 	_message_label.add_theme_constant_override("shadow_offset_x", 1)
 	_message_label.add_theme_constant_override("shadow_offset_y", 1)
-	row.add_child(_message_label)
+	var text_column := VBoxContainer.new()
+	text_column.name = "TextColumn"
+	text_column.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	text_column.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	text_column.alignment = BoxContainer.ALIGNMENT_CENTER
+	text_column.add_theme_constant_override("separation", 0)
+	row.add_child(text_column)
+	text_column.add_child(_message_label)
+
+	_item_name_label = Label.new()
+	_item_name_label.name = "ItemNameLabel"
+	_item_name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_item_name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	_item_name_label.vertical_alignment = VERTICAL_ALIGNMENT_TOP
+	_item_name_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_item_name_label.clip_text = true
+	_item_name_label.add_theme_font_size_override("font_size", 15)
+	_item_name_label.add_theme_color_override("font_color", Color(0.86, 0.78, 0.52, 1.0))
+	_item_name_label.add_theme_color_override("font_shadow_color", Color(0.0, 0.0, 0.0, 0.75))
+	_item_name_label.add_theme_constant_override("shadow_offset_x", 1)
+	_item_name_label.add_theme_constant_override("shadow_offset_y", 1)
+	text_column.add_child(_item_name_label)
 
 	_message_shadow_label = Label.new()
 	_message_shadow_label.name = "MessageShadowLabel"
@@ -315,6 +339,21 @@ func _build_ui() -> void:
 	_message_shadow_label.add_theme_constant_override("shadow_offset_x", 2)
 	_message_shadow_label.add_theme_constant_override("shadow_offset_y", 2)
 	_toast.add_child(_message_shadow_label)
+
+	_item_name_shadow_label = Label.new()
+	_item_name_shadow_label.name = "ItemNameShadowLabel"
+	_item_name_shadow_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_item_name_shadow_label.z_index = 20
+	_item_name_shadow_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+	_item_name_shadow_label.vertical_alignment = VERTICAL_ALIGNMENT_TOP
+	_item_name_shadow_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_item_name_shadow_label.clip_text = true
+	_item_name_shadow_label.add_theme_font_size_override("font_size", 15)
+	_item_name_shadow_label.add_theme_color_override("font_color", Color(0.86, 0.78, 0.52, 1.0))
+	_item_name_shadow_label.add_theme_color_override("font_shadow_color", Color(0.0, 0.0, 0.0, 0.9))
+	_item_name_shadow_label.add_theme_constant_override("shadow_offset_x", 2)
+	_item_name_shadow_label.add_theme_constant_override("shadow_offset_y", 2)
+	_toast.add_child(_item_name_shadow_label)
 
 	_position_toast(false)
 
@@ -475,11 +514,13 @@ func _show_next_notification() -> void:
 
 	_is_showing = true
 	var notification: Dictionary = _pending_notifications.pop_front()
-	_message_label.text = build_notification_text(
-		notification.get("kind", ""),
-		notification.get("item_name", ""))
+	_message_label.text = build_notification_header_text(notification.get("kind", ""))
+	if _item_name_label:
+		_item_name_label.text = notification.get("item_name", "").strip_edges()
 	if _message_shadow_label:
 		_message_shadow_label.text = _message_label.text
+	if _item_name_shadow_label and _item_name_label:
+		_item_name_shadow_label.text = _item_name_label.text
 	_position_toast(false)
 	_toast.modulate = Color.WHITE
 	if _toast_background:
@@ -490,6 +531,10 @@ func _show_next_notification() -> void:
 		_message_label.modulate = Color.WHITE
 	if _message_shadow_label:
 		_message_shadow_label.modulate = Color.WHITE
+	if _item_name_label:
+		_item_name_label.modulate = Color.WHITE
+	if _item_name_shadow_label:
+		_item_name_shadow_label.modulate = Color.WHITE
 	if _icon_rect:
 		_icon_rect.modulate = Color(1.0, 0.84, 0.22, 1.0)
 	_toast.show()
@@ -552,12 +597,21 @@ func _position_toast(visible_position: bool) -> void:
 				maxf(0.0, TOAST_HEIGHT - TOAST_CONTENT_TOP_MARGIN - TOAST_CONTENT_BOTTOM_MARGIN))
 	if _message_shadow_label:
 		var icon_column_width: float = 42.0 + ARMORY_ICON_TEXT_GAP
+		var label_width: float = maxf(0.0, toast_width - TOAST_CONTENT_LEFT_MARGIN - TOAST_CONTENT_RIGHT_MARGIN - icon_column_width)
+		var label_height: float = maxf(0.0, TOAST_HEIGHT - TOAST_CONTENT_TOP_MARGIN - TOAST_CONTENT_BOTTOM_MARGIN)
 		_message_shadow_label.position = Vector2(
 			TOAST_CONTENT_LEFT_MARGIN + icon_column_width,
 			TOAST_CONTENT_TOP_MARGIN)
 		_message_shadow_label.size = Vector2(
-			maxf(0.0, toast_width - TOAST_CONTENT_LEFT_MARGIN - TOAST_CONTENT_RIGHT_MARGIN - icon_column_width),
-			maxf(0.0, TOAST_HEIGHT - TOAST_CONTENT_TOP_MARGIN - TOAST_CONTENT_BOTTOM_MARGIN))
+			label_width,
+			label_height * 0.52)
+		if _item_name_shadow_label:
+			_item_name_shadow_label.position = Vector2(
+				TOAST_CONTENT_LEFT_MARGIN + icon_column_width,
+				TOAST_CONTENT_TOP_MARGIN + label_height * 0.52)
+			_item_name_shadow_label.size = Vector2(
+				label_width,
+				label_height * 0.48)
 
 
 func _get_hidden_y() -> float:

--- a/tests/unit/test_unlock_notification_manager.gd
+++ b/tests/unit/test_unlock_notification_manager.gd
@@ -85,8 +85,10 @@ func test_notification_uses_requested_opened_text() -> void:
 
 	var previous_locale: String = TranslationServer.get_locale()
 	TranslationServer.set_locale("ru")
-	assert_eq(manager.build_notification_text("weapon", "Дробовик"), "Открыт оружие Дробовик !",
-		"Toast text should include the unlocked weapon category and name")
+	assert_eq(manager.build_notification_header_text("weapon"), "Открыт оружие !",
+		"Toast header should include only the unlocked weapon category")
+	assert_eq(manager.build_notification_text("weapon", "Дробовик"), "Открыт оружие !\nДробовик",
+		"Combined fallback text should split the category header and item name onto separate lines")
 	TranslationServer.set_locale(previous_locale)
 
 
@@ -97,9 +99,11 @@ func test_notification_text_includes_active_item_category_and_name() -> void:
 
 	var previous_locale: String = TranslationServer.get_locale()
 	TranslationServer.set_locale("ru")
+	assert_eq(manager.build_notification_header_text("active_item"), "Открыт предмет !",
+		"Toast header should include only the item category")
 	assert_eq(manager.build_notification_text("active_item", "Бронированная кожа"),
-		"Открыт предмет Бронированная кожа !",
-		"Toast text should include the item category and Armored Skin name")
+		"Открыт предмет !\nБронированная кожа",
+		"Combined fallback text should put the Armored Skin name on the second line")
 	TranslationServer.set_locale(previous_locale)
 
 
@@ -110,10 +114,41 @@ func test_notification_text_includes_grenade_category_and_name() -> void:
 
 	var previous_locale: String = TranslationServer.get_locale()
 	TranslationServer.set_locale("ru")
+	assert_eq(manager.build_notification_header_text("grenade"), "Открыт граната !",
+		"Toast header should include only the grenade category")
 	assert_eq(manager.build_notification_text("grenade", "Наступательная"),
-		"Открыт граната Наступательная !",
-		"Toast text should include the grenade category and name")
+		"Открыт граната !\nНаступательная",
+		"Combined fallback text should put the grenade name on the second line")
 	TranslationServer.set_locale(previous_locale)
+
+
+func test_toast_uses_smaller_second_line_for_long_item_names() -> void:
+	var script: GDScript = load(NOTIFICATION_MANAGER_SCRIPT)
+	assert_not_null(script, "UnlockNotificationManager script should load")
+	var manager: CanvasLayer = autofree(script.new())
+	add_child(manager)
+	await get_tree().process_frame
+
+	manager.show_unlock_notification("Очень длинное название предмета с несколькими словами", "active_item")
+	await wait_seconds(manager.SLIDE_DURATION + 0.1)
+
+	var header_label: Label = manager.get_node("UnlockNotificationRoot/UnlockToast/ContentMargin/ContentRow/TextColumn/MessageLabel")
+	var item_name_label: Label = manager.get_node("UnlockNotificationRoot/UnlockToast/ContentMargin/ContentRow/TextColumn/ItemNameLabel")
+	var header_shadow_label: Label = manager.get_node("UnlockNotificationRoot/UnlockToast/MessageShadowLabel")
+	var item_name_shadow_label: Label = manager.get_node("UnlockNotificationRoot/UnlockToast/ItemNameShadowLabel")
+
+	assert_eq(header_label.text, "Открыт предмет !",
+		"Header label should keep the generic unlock text without the long item name")
+	assert_eq(item_name_label.text, "Очень длинное название предмета с несколькими словами",
+		"Item name should render on the second line in its own label")
+	assert_eq(header_shadow_label.text, header_label.text,
+		"Fallback shadow header should mirror the visible header text")
+	assert_eq(item_name_shadow_label.text, item_name_label.text,
+		"Fallback shadow item label should mirror the visible second line")
+	assert_lt(
+		item_name_label.get_theme_font_size("font_size"),
+		header_label.get_theme_font_size("font_size"),
+		"Second-line item name should use a smaller font than the generic unlock text")
 
 
 func test_display_duration_is_four_seconds() -> void:
@@ -139,8 +174,11 @@ func test_gold_text_remains_above_shine_overlay() -> void:
 	var background: Panel = toast.get_node("ToastBackground")
 	var content_margin: MarginContainer = toast.get_node("ContentMargin")
 	var content_row: HBoxContainer = content_margin.get_node("ContentRow")
-	var label: Label = content_margin.get_node("ContentRow/MessageLabel")
+	var text_column: VBoxContainer = content_margin.get_node("ContentRow/TextColumn")
+	var label: Label = text_column.get_node("MessageLabel")
+	var item_name_label: Label = text_column.get_node("ItemNameLabel")
 	var shadow_label: Label = toast.get_node("MessageShadowLabel")
+	var item_name_shadow_label: Label = toast.get_node("ItemNameShadowLabel")
 	var font_color: Color = label.get_theme_color("font_color")
 	var row_gap: int = content_row.get_theme_constant("separation")
 
@@ -154,6 +192,8 @@ func test_gold_text_remains_above_shine_overlay() -> void:
 		"Content should render above the toast background")
 	assert_gt(shadow_label.z_index, shine_overlay.z_index,
 		"Fallback text label should render above the shine overlay in exported builds")
+	assert_gt(item_name_shadow_label.z_index, shine_overlay.z_index,
+		"Fallback item name label should render above the shine overlay in exported builds")
 	assert_eq(row_gap, int(manager.ARMORY_ICON_TEXT_GAP),
 		"Content row should use the configured Armory icon/text gap")
 	assert_ge(row_gap, 24,
@@ -164,10 +204,20 @@ func test_gold_text_remains_above_shine_overlay() -> void:
 		"Content row should have explicit width so the label is not clipped to zero")
 	assert_gt(content_row.size.y, 0.0,
 		"Content row should have explicit height so the label is visible")
+	assert_gt(text_column.size.x, 0.0,
+		"Text column should have explicit width so both toast lines are visible")
+	assert_gt(item_name_label.get_theme_font_size("font_size"), 0,
+		"Item name label should have an explicit font size")
+	assert_lt(item_name_label.get_theme_font_size("font_size"), label.get_theme_font_size("font_size"),
+		"Item name label should be smaller than the generic unlock line")
 	assert_gt(shadow_label.size.x, 0.0,
 		"Fallback text label should have explicit width independent of nested containers")
 	assert_gt(shadow_label.size.y, 0.0,
 		"Fallback text label should have explicit height independent of nested containers")
+	assert_gt(item_name_shadow_label.size.x, 0.0,
+		"Fallback item name label should have explicit width independent of nested containers")
+	assert_gt(item_name_shadow_label.size.y, 0.0,
+		"Fallback item name label should have explicit height independent of nested containers")
 	assert_gt(font_color.r, 0.9, "Toast text should use a visible gold color")
 	assert_gt(font_color.g, 0.75, "Toast text should use a visible gold color")
 	assert_gt(font_color.b, 0.25, "Toast text should use a visible gold color")
@@ -186,8 +236,10 @@ func test_toast_animation_keeps_label_opaque_after_entry() -> void:
 
 	var toast: Control = manager.get_node("UnlockNotificationRoot/UnlockToast")
 	var background: Panel = toast.get_node("ToastBackground")
-	var label: Label = toast.get_node("ContentMargin/ContentRow/MessageLabel")
+	var label: Label = toast.get_node("ContentMargin/ContentRow/TextColumn/MessageLabel")
+	var item_name_label: Label = toast.get_node("ContentMargin/ContentRow/TextColumn/ItemNameLabel")
 	var shadow_label: Label = toast.get_node("MessageShadowLabel")
+	var item_name_shadow_label: Label = toast.get_node("ItemNameShadowLabel")
 
 	assert_eq(manager._animation_phase, "visible",
 		"Toast should enter the stable visible phase after the slide-in animation")
@@ -195,12 +247,20 @@ func test_toast_animation_keeps_label_opaque_after_entry() -> void:
 		"Toast parent should remain opaque during the stable visible phase")
 	assert_eq(label.modulate.a, 1.0,
 		"Message label should remain fully opaque after the slide-in animation")
-	assert_eq(label.text, "Открыт предмет Бронированная кожа !",
-		"Stable visible toast should keep the requested Armored Skin text")
-	assert_eq(shadow_label.text, "Открыт предмет Бронированная кожа !",
-		"Fallback text label should mirror the requested Armored Skin text")
+	assert_eq(label.text, "Открыт предмет !",
+		"Stable visible toast should keep the requested generic item text")
+	assert_eq(item_name_label.text, "Бронированная кожа",
+		"Stable visible toast should keep the requested Armored Skin name on the second line")
+	assert_eq(shadow_label.text, "Открыт предмет !",
+		"Fallback text label should mirror the requested generic item text")
+	assert_eq(item_name_shadow_label.text, "Бронированная кожа",
+		"Fallback item label should mirror the requested Armored Skin name")
 	assert_eq(shadow_label.modulate.a, 1.0,
 		"Fallback text label should remain fully opaque after the slide-in animation")
+	assert_eq(item_name_label.modulate.a, 1.0,
+		"Item name label should remain fully opaque after the slide-in animation")
+	assert_eq(item_name_shadow_label.modulate.a, 1.0,
+		"Fallback item name label should remain fully opaque after the slide-in animation")
 	assert_gt(background.modulate.a, 0.95,
 		"Only the background fade target should be fully visible after entry")
 


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/godot-topdown-MVP#1885.

- Split unlock toasts into a generic first line and a smaller item-name second line.
- Kept the exported-build shadow fallback labels in sync with the new two-line layout.
- Added regression coverage for long unlock names and updated existing unlock notification tests.
- Added the requested case-study notes in `docs/case-studies/issue-1885/unlock-toast-analysis.md`.

## Reproduction

Before this change, `UnlockNotificationManager.show_unlock_notification("Бронированная кожа", "active_item")` rendered the generic message and item name in one full-size label, which made longer names easy to clip or crowd in the fixed toast width.

## Verification

- `git diff --check`
- `dotnet build` passed with existing warnings

I could not run the GUT suite locally because no `godot`/`godot4` executable is available on PATH in this environment. The focused regression test was added to `tests/unit/test_unlock_notification_manager.gd` for CI/Godot execution.
