### PR TITLE
feat: update unlock conditions (issue #1892)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T07:05:35.835Z for PR creation at branch issue-1892-265a7caad0c0 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1892

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T07:05:35.835Z for PR creation at branch issue-1892-265a7caad0c0 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1892

--- a/resources/translations/translations.csv
+++ b/resources/translations/translations.csv
@@ -272,6 +272,7 @@ UNLOCK_COND_SHOTS_SPECIAL_WEAPONS,"Fire %d shots with shotgun, ASVK, or revolver
 UNLOCK_COND_TOTAL_DEATHS,Die %d times,Умри %d раз
 UNLOCK_COND_NO_DAMAGE_LEVELS,Complete %d level(s) without taking damage,Пройди %d уровень(уровней) без урона
 UNLOCK_COND_RANK_A_LEVELS,Complete %d level(s) at rank A or higher,Пройди %d уровень(уровней) на ранге A или выше
+UNLOCK_COND_RANK_S_LEVELS,Complete %d level(s) at rank S,Пройди %d уровень(уровней) на ранге S
 UNLOCK_COND_WALL_KILLS,Get %d kills through walls,Получи %d убийств сквозь стены
 UNLOCK_COND_SILENCED_PISTOL_LEVEL,Complete any level with the silenced pistol,Пройди любой уровень с глушителем
 UNLOCK_COND_PROGRESS,Progress: %d / %d,Прогресс: %d / %d

--- a/scripts/autoload/active_item_manager.gd
+++ b/scripts/autoload/active_item_manager.gd
@@ -51,8 +51,8 @@ var collected_passive_items: Array = []
 ## FINE_MOTOR_SKILLS (650 shots with shotgun, sniper rifle, or revolver),
 ## ARMORED_SKIN (100 total deaths), COMBAT_DISPOSITION (complete 1 level without damage),
 ## RECOIL_COMPENSATOR (Labyrinth S), EXPERIMENTAL_SAMPLE (complete at least one level on every difficulty),
-## EXTENDED_MAGAZINE (Building B+), AUTO_RELOAD (any level with silenced pistol),
-## DRILLING_BULLETS (50 kills through walls), DASH (Decadence A+),
+## EXTENDED_MAGAZINE (Polygon S + Double Corridor S), AUTO_RELOAD (any level with silenced pistol),
+## DRILLING_BULLETS (15 kills through walls), DASH (Decadence A+),
 ## BREACHING_CHARGES (Labyrinth Complex any grade), GRENADE_BAG (Railway Station any grade),
 ## BFF_PENDANT (Winter Forest any grade) have unlock conditions
 ## (Issue #894, Issue #1000, Issue #1053, Issue #1196, Issue #1346, Issue #1389, Issue #1423, Issue #1426, Issue #1624).
@@ -63,16 +63,16 @@ var unlocked_active_items: Dictionary = {
 	ActiveItemType.TELEPORT_BRACERS: false,    # Condition: Double Corridor D+ (Issue #1000 req.3)
 	ActiveItemType.BFF_PENDANT: false,         # Condition: complete Winter Forest on any grade (Issue #1624 req.9)
 	ActiveItemType.INVISIBILITY_SUIT: false,   # Condition: Beach S + Building S (Issue #1000 req.5)
-	ActiveItemType.BREAKER_BULLETS: false,     # Condition: 7 levels completed at rank A or higher (Issue #1589 req.3)
+	ActiveItemType.BREAKER_BULLETS: false,     # Condition: 7 unique maps completed at rank S (Issue #1892 req.2)
 	ActiveItemType.FORCE_FIELD: false,         # Condition: complete Factory on any grade (Issue #1589 req.2)
 	ActiveItemType.TRAJECTORY_GLASSES: false,  # Condition: City D+ (Issue #1053 req.1)
 	ActiveItemType.LASER_SIGHT: false,         # Condition: 400 kills without laser sight equipped (Issue #1196, updated by Issue #1589)
-	ActiveItemType.EXTENDED_MAGAZINE: false,   # Condition: Building B+ (Issue #1624 req.1)
+	ActiveItemType.EXTENDED_MAGAZINE: false,   # Condition: Polygon S + Double Corridor S (Issue #1892 req.1)
 	ActiveItemType.LOUDSPEAKER: true,          # No unlock condition — freely available from start, not selected by default (Issue #959, #1691)
 	ActiveItemType.BREACHING_CHARGES: false,   # Condition: complete Labyrinth Complex on any grade (Issue #1624 req.6)
 	ActiveItemType.ARMORED_SKIN: false,        # Condition: 100 total deaths (Issue #1389)
 	ActiveItemType.AUTO_RELOAD: false,         # Condition: complete any level with silenced pistol (Issue #1624 req.2)
-	ActiveItemType.DRILLING_BULLETS: false,    # Condition: 50 kills through walls (Issue #1624 req.3)
+	ActiveItemType.DRILLING_BULLETS: false,    # Condition: 15 kills through walls (Issue #1892 req.3)
 	ActiveItemType.RECOIL_COMPENSATOR: false,  # Condition: Labyrinth S (Issue #1423 req.2)
 	ActiveItemType.COMBAT_DISPOSITION: false,  # Condition: complete 1 level without taking damage (Issue #1389)
 	ActiveItemType.EXPERIMENTAL_SAMPLE: false,   # Condition: complete at least one level on every difficulty (Issue #1426)

--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -27,6 +27,10 @@ var no_damage_levels_completed: int = 0
 ## Persists across sessions — used as the unlock condition for Breaker Bullets (Issue #1589).
 var levels_completed_rank_a_or_higher: int = 0
 
+## Cumulative unique maps completed at rank S.
+## Persists across sessions — used as the unlock condition for Breaker Bullets (Issue #1892).
+var levels_completed_rank_s: int = 0
+
 ## Cumulative kills made through walls (using Drilling Bullets or any wall-piercing effect).
 ## Persists across sessions — used as the unlock condition for Drilling Bullets (Issue #1624).
 var kills_through_wall: int = 0
@@ -131,6 +135,10 @@ signal levels_completed_rank_a_or_higher_updated(new_count: int)
 ## Signal emitted when kills_through_wall changes (for wall-kill unlock checks).
 ## Issue #1624.
 signal kills_through_wall_updated(new_count: int)
+
+## Signal emitted when levels_completed_rank_s changes (for S-rank unlock checks).
+## Issue #1892.
+signal levels_completed_rank_s_updated(new_count: int)
 
 ## Signal emitted when levels_completed_with_silenced_pistol changes.
 ## Issue #1624.
@@ -915,6 +923,18 @@ func _on_score_calculated(score_data: Dictionary) -> void:
 			_log_to_file("Rank-A level completed (new unique map) — levels_completed_rank_a_or_higher: %d" % levels_completed_rank_a_or_higher)
 		else:
 			_log_to_file("Rank-A level completed (already counted for this map) — levels_completed_rank_a_or_higher unchanged: %d" % levels_completed_rank_a_or_higher)
+	# Track unique maps completed at rank S for Breaker Bullets unlock (Issue #1892).
+	if rank == "S":
+		var already_counted_s: bool = false
+		var progress_manager_s: Node = get_node_or_null("/root/ProgressManager")
+		if progress_manager_s and progress_manager_s.has_method("is_level_completed_rank_s_any_difficulty"):
+			var current_scene_s: Node = get_tree().current_scene
+			if current_scene_s and not current_scene_s.scene_file_path.is_empty():
+				already_counted_s = progress_manager_s.is_level_completed_rank_s_any_difficulty(current_scene_s.scene_file_path)
+		if not already_counted_s:
+			levels_completed_rank_s += 1
+			levels_completed_rank_s_updated.emit(levels_completed_rank_s)
+			_log_to_file("Rank-S level completed (new unique map) — levels_completed_rank_s: %d" % levels_completed_rank_s)
 	# Track levels completed with silenced pistol for Auto Reload unlock (Issue #1624).
 	if selected_weapon == "silenced_pistol":
 		levels_completed_with_silenced_pistol += 1

--- a/scripts/autoload/persist_manager.gd
+++ b/scripts/autoload/persist_manager.gd
@@ -32,6 +32,7 @@ const KEY_SHOTS_FIRED_SPECIAL_WEAPONS := "shots_fired_special_weapons"  # Issue 
 const KEY_TOTAL_DEATHS := "total_deaths"  # Issue #1389
 const KEY_NO_DAMAGE_LEVELS_COMPLETED := "no_damage_levels_completed"  # Issue #1389
 const KEY_LEVELS_COMPLETED_RANK_A_OR_HIGHER := "levels_completed_rank_a_or_higher"  # Issue #1589
+const KEY_LEVELS_COMPLETED_RANK_S := "levels_completed_rank_s"  # Issue #1892
 const KEY_KILLS_THROUGH_WALL := "kills_through_wall"  # Issue #1624
 const KEY_LEVELS_COMPLETED_WITH_SILENCED_PISTOL := "levels_completed_with_silenced_pistol"  # Issue #1624
 
@@ -191,6 +192,8 @@ func _connect_signals() -> void:
 			game_manager.no_damage_levels_completed_updated.connect(_on_no_damage_levels_completed_updated)
 		if game_manager.has_signal("levels_completed_rank_a_or_higher_updated"):
 			game_manager.levels_completed_rank_a_or_higher_updated.connect(_on_levels_completed_rank_a_or_higher_updated)
+		if game_manager.has_signal("levels_completed_rank_s_updated"):
+			game_manager.levels_completed_rank_s_updated.connect(_on_levels_completed_rank_s_updated)
 		if game_manager.has_signal("kills_through_wall_updated"):
 			game_manager.kills_through_wall_updated.connect(_on_kills_through_wall_updated)
 		if game_manager.has_signal("levels_completed_with_silenced_pistol_updated"):
@@ -284,6 +287,10 @@ func _on_no_damage_levels_completed_updated(_new_count: int) -> void:
 
 
 func _on_levels_completed_rank_a_or_higher_updated(_new_count: int) -> void:
+	_save_state()
+
+
+func _on_levels_completed_rank_s_updated(_new_count: int) -> void:
 	_save_state()
 
 
@@ -383,6 +390,9 @@ func _save_state_with_level(level_path: String) -> void:
 		# Save rank-A level stats (Issue #1589)
 		config.set_value(SECTION_KILL_STATS, KEY_LEVELS_COMPLETED_RANK_A_OR_HIGHER,
 				game_manager.get("levels_completed_rank_a_or_higher") if game_manager.get("levels_completed_rank_a_or_higher") != null else 0)
+		# Save rank-S level stats (Issue #1892)
+		config.set_value(SECTION_KILL_STATS, KEY_LEVELS_COMPLETED_RANK_S,
+				game_manager.get("levels_completed_rank_s") if game_manager.get("levels_completed_rank_s") != null else 0)
 		# Save wall-kill stats (Issue #1624)
 		config.set_value(SECTION_KILL_STATS, KEY_KILLS_THROUGH_WALL,
 				game_manager.get("kills_through_wall") if game_manager.get("kills_through_wall") != null else 0)
@@ -473,6 +483,11 @@ func _load_state() -> void:
 			var saved_rank_a: int = config.get_value(SECTION_KILL_STATS, KEY_LEVELS_COMPLETED_RANK_A_OR_HIGHER, 0)
 			game_manager.levels_completed_rank_a_or_higher = saved_rank_a
 			_log_to_file("Restored levels_completed_rank_a_or_higher: %d" % saved_rank_a)
+		# Restore rank-S level stats (Issue #1892)
+		if config.has_section_key(SECTION_KILL_STATS, KEY_LEVELS_COMPLETED_RANK_S):
+			var saved_rank_s: int = config.get_value(SECTION_KILL_STATS, KEY_LEVELS_COMPLETED_RANK_S, 0)
+			game_manager.levels_completed_rank_s = saved_rank_s
+			_log_to_file("Restored levels_completed_rank_s: %d" % saved_rank_s)
 		# Restore wall-kill stats (Issue #1624)
 		if config.has_section_key(SECTION_KILL_STATS, KEY_KILLS_THROUGH_WALL):
 			var saved_wall_kills: int = config.get_value(SECTION_KILL_STATS, KEY_KILLS_THROUGH_WALL, 0)
@@ -578,6 +593,7 @@ func clear_all_saves() -> void:
 		game_manager.total_deaths = 0  # Issue #1389
 		game_manager.no_damage_levels_completed = 0  # Issue #1389
 		game_manager.levels_completed_rank_a_or_higher = 0  # Issue #1589
+		game_manager.levels_completed_rank_s = 0  # Issue #1892
 		game_manager.kills_through_wall = 0  # Issue #1624
 		game_manager.levels_completed_with_silenced_pistol = 0  # Issue #1624
 

--- a/scripts/autoload/progress_manager.gd
+++ b/scripts/autoload/progress_manager.gd
@@ -134,6 +134,19 @@ func is_level_completed_rank_a_or_higher_any_difficulty(level_path: String) -> b
 	return false
 
 
+## Check if a level has been completed at rank S on any difficulty.
+## Used by GameManager to count each unique map at most once toward the Breaker Bullets
+## unlock condition (Issue #1892).
+## @param level_path: The scene file path of the level.
+## @return: True if the level has been completed with rank S on any difficulty.
+func is_level_completed_rank_s_any_difficulty(level_path: String) -> bool:
+	for difficulty_name in _get_all_difficulty_names():
+		var rank: String = get_best_rank(level_path, difficulty_name)
+		if rank == "S":
+			return true
+	return false
+
+
 ## Get the best rank for a level across all difficulties.
 ## @param level_path: The scene file path of the level.
 ## @return: Dictionary with difficulty names as keys and rank strings as values.

--- a/scripts/autoload/unlock_manager.gd
+++ b/scripts/autoload/unlock_manager.gd
@@ -97,12 +97,6 @@ const UNLOCK_CONDITIONS: Dictionary = {
 		"grenades": [],
 		"active_items": [16]  # ActiveItemManager.ActiveItemType.RECOIL_COMPENSATOR = 16 (Issue #1423 req.2)
 	},
-	"res://scenes/levels/RevolverLevel.tscn:A": {
-		"min_rank": "A",
-		"weapons": [],
-		"grenades": [],
-		"active_items": [10]  # ActiveItemManager.ActiveItemType.EXTENDED_MAGAZINE = 10 (Issue #1692 req.1)
-	},
 	"res://scenes/levels/DecadenceLevel.tscn:A+": {
 		"min_rank": "A+",
 		"weapons": [],
@@ -195,17 +189,17 @@ const KILL_UNLOCK_CONDITIONS: Array[Dictionary] = [
 		"active_items": [17]  # ActiveItemManager.ActiveItemType.COMBAT_DISPOSITION = 17
 	},
 	{
-		# 7 levels completed at rank A or higher → unlock Breaker Bullets (Issue #1589 req.3)
-		"stat": "levels_completed_rank_a_or_higher",
+		# 7 unique maps completed at rank S → unlock Breaker Bullets (Issue #1892 req.2)
+		"stat": "levels_completed_rank_s",
 		"min_kills": 7,
 		"weapons": [],
 		"grenades": [],
 		"active_items": [6]  # ActiveItemManager.ActiveItemType.BREAKER_BULLETS = 6
 	},
 	{
-		# 50 kills through walls (any weapon) → unlock Drilling Bullets (Issue #1624 req.3)
+		# 15 kills through walls (any weapon) → unlock Drilling Bullets (Issue #1892 req.3)
 		"stat": "kills_through_wall",
-		"min_kills": 50,
+		"min_kills": 15,
 		"weapons": [],
 		"grenades": [],
 		"active_items": [15]  # ActiveItemManager.ActiveItemType.DRILLING_BULLETS = 15
@@ -228,6 +222,16 @@ const KILL_UNLOCK_CONDITIONS: Array[Dictionary] = [
 ##   - "active_items": List of active item type ints to unlock
 ## Issue #1000: req.5 and req.8
 const MULTI_UNLOCK_CONDITIONS: Array[Dictionary] = [
+	{
+		# Polygon S + Double Corridor S → Extended Magazine (Issue #1892 req.1)
+		"levels": [
+			{"path": "res://scenes/levels/TestTier.tscn", "min_rank": "S"},
+			{"path": "res://scenes/levels/RevolverLevel.tscn", "min_rank": "S"}
+		],
+		"weapons": [],
+		"grenades": [],
+		"active_items": [10]  # ActiveItemManager.ActiveItemType.EXTENDED_MAGAZINE = 10
+	},
 	{
 		# Beach S + Building S → Invisibility (Issue #1000 req.5)
 		"levels": [
@@ -278,6 +282,8 @@ func _ready() -> void:
 			game_manager.no_damage_levels_completed_updated.connect(_on_no_damage_levels_completed_updated)
 		if game_manager.has_signal("levels_completed_rank_a_or_higher_updated"):
 			game_manager.levels_completed_rank_a_or_higher_updated.connect(_on_levels_completed_rank_a_or_higher_updated)
+		if game_manager.has_signal("levels_completed_rank_s_updated"):
+			game_manager.levels_completed_rank_s_updated.connect(_on_levels_completed_rank_s_updated)
 		if game_manager.has_signal("kills_through_wall_updated"):
 			game_manager.kills_through_wall_updated.connect(_on_kills_through_wall_updated)
 		if game_manager.has_signal("levels_completed_with_silenced_pistol_updated"):
@@ -360,13 +366,23 @@ func _on_no_damage_levels_completed_updated(_new_count: int) -> void:
 
 
 ## Called when GameManager emits levels_completed_rank_a_or_higher_updated.
-## Checks if the Breaker Bullets rank-A condition is now satisfied.
 ## Issue #1589.
 func _on_levels_completed_rank_a_or_higher_updated(_new_count: int) -> void:
 	for kill_condition in KILL_UNLOCK_CONDITIONS:
 		if kill_condition.get("stat", "") == "levels_completed_rank_a_or_higher" and is_kill_condition_met(kill_condition):
 			items_unlocked_by_kill_condition.emit()
-			_log("Rank-A level condition met — Breaker Bullets now available to unlock in armory")
+			_log("Rank-A level condition met — items now available to unlock in armory")
+			break
+
+
+## Called when GameManager emits levels_completed_rank_s_updated.
+## Checks if the Breaker Bullets rank-S condition is now satisfied.
+## Issue #1892.
+func _on_levels_completed_rank_s_updated(_new_count: int) -> void:
+	for kill_condition in KILL_UNLOCK_CONDITIONS:
+		if kill_condition.get("stat", "") == "levels_completed_rank_s" and is_kill_condition_met(kill_condition):
+			items_unlocked_by_kill_condition.emit()
+			_log("Rank-S level condition met — Breaker Bullets now available to unlock in armory")
 			break
 
 
@@ -1086,6 +1102,8 @@ func _build_kill_condition_description(kill_condition: Dictionary) -> String:
 		return tr("UNLOCK_COND_NO_DAMAGE_LEVELS") % min_kills
 	if stat == "levels_completed_rank_a_or_higher":
 		return tr("UNLOCK_COND_RANK_A_LEVELS") % min_kills
+	if stat == "levels_completed_rank_s":
+		return tr("UNLOCK_COND_RANK_S_LEVELS") % min_kills
 	if stat == "kills_through_wall":
 		return tr("UNLOCK_COND_WALL_KILLS") % min_kills
 	if stat == "levels_completed_with_silenced_pistol":

--- a/scripts/ui/unlock_table_menu.gd
+++ b/scripts/ui/unlock_table_menu.gd
@@ -348,6 +348,10 @@ func _populate_table() -> void:
 			map_display = "%d / %d levels without damage" % [current_kills, min_kills]
 		elif stat == "levels_completed_rank_a_or_higher":
 			map_display = "%d / %d levels at rank A or higher" % [current_kills, min_kills]
+		elif stat == "levels_completed_rank_s":
+			map_display = "%d / %d levels at rank S" % [current_kills, min_kills]
+		elif stat == "kills_through_wall":
+			map_display = "%d / %d kills through walls" % [current_kills, min_kills]
 		else:
 			map_display = "%d / %d kills (no Laser Sight)" % [current_kills, min_kills]
 

--- a/tests/unit/test_unlock_manager.gd
+++ b/tests/unit/test_unlock_manager.gd
@@ -50,8 +50,9 @@ class MockGameManager:
 	var shots_fired_special_weapons: int = 0     # Condition: 650 → Fine Motor Skills (Issue #1346)
 	var total_deaths: int = 0                    # Condition: 100 → Armored Skin (Issue #1389)
 	var no_damage_levels_completed: int = 0      # Condition: 1 → Combat Disposition (Issue #1389)
-	var levels_completed_rank_a_or_higher: int = 0  # Condition: 7 → Breaker Bullets (Issue #1589 req.3)
-	var kills_through_wall: int = 0              # Condition: 50 → Drilling Bullets (Issue #1624 req.3)
+	var levels_completed_rank_a_or_higher: int = 0  # Condition: 7 → (legacy, kept for other uses)
+	var levels_completed_rank_s: int = 0            # Condition: 7 → Breaker Bullets (Issue #1892 req.2)
+	var kills_through_wall: int = 0              # Condition: 15 → Drilling Bullets (Issue #1892 req.3)
 	var levels_completed_with_silenced_pistol: int = 0  # Condition: 1 → Auto Reload (Issue #1624 req.2)
 
 	var unlocked_signals: Array = []
@@ -73,16 +74,16 @@ class MockActiveItemManager:
 		3: false,  # TELEPORT_BRACERS — condition: Double Corridor F+ (Issue #1000)
 		4: false,  # BFF_PENDANT — condition: complete Winter Forest (Issue #1624 req.9)
 		5: false,  # INVISIBILITY_SUIT — condition: Beach S + Building S (Issue #1000)
-		6: false,  # BREAKER_BULLETS — condition: 7 levels at rank A or higher (Issue #1589 req.3)
+		6: false,  # BREAKER_BULLETS — condition: 7 unique maps at rank S (Issue #1892 req.2)
 		7: false,  # FORCE_FIELD — condition: complete Factory on any grade (Issue #1589 req.2)
 		8: false,  # TRAJECTORY_GLASSES — condition: City F+ (Issue #1692 req.2)
 		9: false,  # LASER_SIGHT — condition: 400 kills without laser sight equipped (Issue #1196)
-		10: false, # EXTENDED_MAGAZINE — condition: Double Corridor A+ (Issue #1692 req.1)
+		10: false, # EXTENDED_MAGAZINE — condition: Polygon S + Double Corridor S (Issue #1892 req.1)
 		11: true,  # LOUDSPEAKER — no condition, freely available from start (Issue #959)
 		12: false, # BREACHING_CHARGES — condition: complete Labyrinth Complex (Issue #1624 req.6)
 		13: false, # ARMORED_SKIN — condition: 100 total deaths (Issue #1389)
 		14: false, # AUTO_RELOAD — condition: complete any level with silenced pistol (Issue #1624 req.2)
-		15: false, # DRILLING_BULLETS — condition: 50 kills through walls (Issue #1624 req.3)
+		15: false, # DRILLING_BULLETS — condition: 15 kills through walls (Issue #1892 req.3)
 		16: false, # RECOIL_COMPENSATOR — condition: Labyrinth S (Issue #1423 req.2)
 		17: false, # COMBAT_DISPOSITION — condition: complete any level without damage (Issue #1389)
 		18: false, # EXPERIMENTAL_SAMPLE — condition: one level on every difficulty (Issue #1426)
@@ -204,12 +205,6 @@ class TestableUnlockManager extends Node:
 			"grenades": [],
 			"active_items": [16]  # RECOIL_COMPENSATOR (Issue #1423 req.2)
 		},
-		"res://scenes/levels/RevolverLevel.tscn:A": {
-			"min_rank": "A",
-			"weapons": [],
-			"grenades": [],
-			"active_items": [10]  # EXTENDED_MAGAZINE (Issue #1692 req.1)
-		},
 		"res://scenes/levels/DecadenceLevel.tscn:A+": {
 			"min_rank": "A+",
 			"weapons": [],
@@ -243,6 +238,16 @@ class TestableUnlockManager extends Node:
 	}
 
 	const MULTI_UNLOCK_CONDITIONS: Array[Dictionary] = [
+		{
+			# Polygon S + Double Corridor S → Extended Magazine (Issue #1892 req.1)
+			"levels": [
+				{"path": "res://scenes/levels/TestTier.tscn", "min_rank": "S"},
+				{"path": "res://scenes/levels/RevolverLevel.tscn", "min_rank": "S"}
+			],
+			"weapons": [],
+			"grenades": [],
+			"active_items": [10]  # EXTENDED_MAGAZINE
+		},
 		{
 			"levels": [
 				{"path": "res://scenes/levels/BeachLevel.tscn", "min_rank": "S"},
@@ -309,17 +314,17 @@ class TestableUnlockManager extends Node:
 			"active_items": [17]  # COMBAT_DISPOSITION
 		},
 		{
-			# 7 levels completed at rank A or higher → unlock Breaker Bullets (Issue #1589 req.3)
-			"stat": "levels_completed_rank_a_or_higher",
+			# 7 unique maps completed at rank S → unlock Breaker Bullets (Issue #1892 req.2)
+			"stat": "levels_completed_rank_s",
 			"min_kills": 7,
 			"weapons": [],
 			"grenades": [],
 			"active_items": [6]   # BREAKER_BULLETS
 		},
 		{
-			# 50 kills through walls → unlock Drilling Bullets (Issue #1624 req.3)
+			# 15 kills through walls → unlock Drilling Bullets (Issue #1892 req.3)
 			"stat": "kills_through_wall",
-			"min_kills": 50,
+			"min_kills": 15,
 			"weapons": [],
 			"grenades": [],
 			"active_items": [15]  # DRILLING_BULLETS
@@ -1056,36 +1061,45 @@ func test_teleport_condition_met_after_double_corridor_f() -> void:
 
 
 # ============================================================================
-# New unlock condition tests (Issue #1692)
+# New unlock condition tests (Issue #1892)
 # ============================================================================
 
 
-func test_double_corridor_a_unlocks_extended_magazine() -> void:
-	# Issue #1692 req.1: Double Corridor A+ → Extended Magazine
-	progress_manager.set_rank("res://scenes/levels/RevolverLevel.tscn", "Normal", "A")
-	assert_true(unlock_manager.is_active_item_condition_met(10),  # EXTENDED_MAGAZINE = 10
-		"Extended Magazine condition should be met after Double Corridor grade A (Issue #1692)")
-
-
-func test_double_corridor_s_unlocks_extended_magazine() -> void:
-	# Issue #1692 req.1: Double Corridor S also satisfies the A+ condition
+func test_polygon_s_and_double_corridor_s_unlocks_extended_magazine() -> void:
+	# Issue #1892 req.1: Polygon S + Double Corridor S → Extended Magazine
+	progress_manager.set_rank("res://scenes/levels/TestTier.tscn", "Normal", "S")
 	progress_manager.set_rank("res://scenes/levels/RevolverLevel.tscn", "Normal", "S")
 	assert_true(unlock_manager.is_active_item_condition_met(10),  # EXTENDED_MAGAZINE = 10
-		"Extended Magazine condition should be met after Double Corridor grade S (Issue #1692)")
+		"Extended Magazine condition should be met after Polygon S + Double Corridor S (Issue #1892)")
 
 
-func test_double_corridor_b_does_not_unlock_extended_magazine() -> void:
-	# Issue #1692 req.1: Double Corridor B is below A, should NOT unlock Extended Magazine
-	progress_manager.set_rank("res://scenes/levels/RevolverLevel.tscn", "Normal", "B")
+func test_double_corridor_s_alone_does_not_unlock_extended_magazine() -> void:
+	# Issue #1892 req.1: Double Corridor S alone is not enough — Polygon S also required
+	progress_manager.set_rank("res://scenes/levels/RevolverLevel.tscn", "Normal", "S")
 	assert_false(unlock_manager.is_active_item_condition_met(10),  # EXTENDED_MAGAZINE = 10
-		"Extended Magazine should NOT be unlocked with Double Corridor grade B (requires A+)")
+		"Extended Magazine should NOT be unlocked by Double Corridor S alone (requires both maps at S)")
 
 
-func test_extended_magazine_not_unlocked_without_double_corridor() -> void:
-	# Issue #1692 req.1: Extended Magazine requires Double Corridor, not Building
+func test_polygon_s_alone_does_not_unlock_extended_magazine() -> void:
+	# Issue #1892 req.1: Polygon S alone is not enough — Double Corridor S also required
+	progress_manager.set_rank("res://scenes/levels/TestTier.tscn", "Normal", "S")
+	assert_false(unlock_manager.is_active_item_condition_met(10),  # EXTENDED_MAGAZINE = 10
+		"Extended Magazine should NOT be unlocked by Polygon S alone (requires both maps at S)")
+
+
+func test_polygon_a_and_double_corridor_s_does_not_unlock_extended_magazine() -> void:
+	# Issue #1892 req.1: Both must be S rank — A on one is not enough
+	progress_manager.set_rank("res://scenes/levels/TestTier.tscn", "Normal", "A")
+	progress_manager.set_rank("res://scenes/levels/RevolverLevel.tscn", "Normal", "S")
+	assert_false(unlock_manager.is_active_item_condition_met(10),  # EXTENDED_MAGAZINE = 10
+		"Extended Magazine should NOT be unlocked when Polygon is only A rank (requires S)")
+
+
+func test_extended_magazine_not_unlocked_without_correct_levels() -> void:
+	# Issue #1892 req.1: Extended Magazine requires Polygon + Double Corridor, not Building
 	progress_manager.set_rank("res://scenes/levels/BuildingLevel.tscn", "Normal", "S")
 	assert_false(unlock_manager.is_active_item_condition_met(10),  # EXTENDED_MAGAZINE = 10
-		"Extended Magazine should NOT be unlocked by Building completion (moved to Double Corridor in Issue #1692)")
+		"Extended Magazine should NOT be unlocked by Building completion alone")
 
 
 # ============================================================================
@@ -1632,18 +1646,19 @@ func test_fine_motor_skills_condition_met_at_threshold() -> void:
 
 
 func test_breaker_bullets_condition_not_met_below_threshold() -> void:
-	# Issue #1622: 6 out of 7 required A-rank levels → partial progress, no glow
-	game_manager.levels_completed_rank_a_or_higher = 6
+	# Issue #1892 req.2: 6 out of 7 required S-rank maps → partial progress, no glow
+	game_manager.levels_completed_rank_s = 6
 	assert_false(unlock_manager.is_kill_condition_met(unlock_manager.KILL_UNLOCK_CONDITIONS[4]),
-		"Breaker Bullets condition should NOT be met with only 6/7 A-rank levels")
+		"Breaker Bullets condition should NOT be met with only 6/7 S-rank maps")
 	assert_false(unlock_manager.has_any_available_unlock(),
-		"has_any_available_unlock should return false with 6/7 A-rank levels")
+		"has_any_available_unlock should return false with 6/7 S-rank maps")
 
 
 func test_breaker_bullets_condition_met_at_threshold() -> void:
-	game_manager.levels_completed_rank_a_or_higher = 7  # At threshold
+	# Issue #1892 req.2: 7 unique S-rank maps → Breaker Bullets unlocks
+	game_manager.levels_completed_rank_s = 7  # At threshold
 	assert_true(unlock_manager.is_kill_condition_met(unlock_manager.KILL_UNLOCK_CONDITIONS[4]),
-		"Breaker Bullets condition should be met at exactly 7 A-rank levels")
+		"Breaker Bullets condition should be met at exactly 7 S-rank maps")
 	assert_true(unlock_manager.has_any_available_unlock(),
 		"has_any_available_unlock should return true when Breaker Bullets condition is met")
 
@@ -1719,6 +1734,8 @@ class DescriptionUnlockManager extends Node:
 			return tr("UNLOCK_COND_NO_DAMAGE_LEVELS") % min_kills
 		if stat == "levels_completed_rank_a_or_higher":
 			return tr("UNLOCK_COND_RANK_A_LEVELS") % min_kills
+		if stat == "levels_completed_rank_s":
+			return tr("UNLOCK_COND_RANK_S_LEVELS") % min_kills
 		if stat == "kills_through_wall":
 			return tr("UNLOCK_COND_WALL_KILLS") % min_kills
 		if stat == "levels_completed_with_silenced_pistol":


### PR DESCRIPTION
## Summary

Implements all three unlock condition changes from issue #1892:

1. **Extended Magazine** (`EXTENDED_MAGAZINE`) — moved from "Double Corridor A" (single-level condition) to a **multi-level condition**: requires both **Polygon S** and **Double Corridor S**.
2. **Breaker Bullets** (`BREAKER_BULLETS`) — changed from "7 maps at rank A or higher" to **7 unique maps at rank S**. Added a new `levels_completed_rank_s` stat to `GameManager` (with signal, persistence in `PersistManager`, and deduplication via `ProgressManager.is_level_completed_rank_s_any_difficulty`).
3. **Drilling Bullets** (`DRILLING_BULLETS`) — wall-kill threshold reduced from **50 → 15**.

## Changes

- `scripts/autoload/unlock_manager.gd`: moved Extended Magazine to `MULTI_UNLOCK_CONDITIONS`, updated Breaker Bullets stat to `levels_completed_rank_s`, reduced Drilling Bullets `min_kills` to 15, added signal handler and description string support for new stat.
- `scripts/autoload/game_manager.gd`: added `levels_completed_rank_s` var + `levels_completed_rank_s_updated` signal + tracking in `_on_score_calculated`.
- `scripts/autoload/progress_manager.gd`: added `is_level_completed_rank_s_any_difficulty` for deduplication.
- `scripts/autoload/persist_manager.gd`: save/load/reset for `levels_completed_rank_s`.
- `scripts/autoload/active_item_manager.gd`: updated comments.
- `scripts/ui/unlock_table_menu.gd`: display support for `levels_completed_rank_s` and `kills_through_wall`.
- `resources/translations/translations.csv`: added `UNLOCK_COND_RANK_S_LEVELS` translation key.
- `tests/unit/test_unlock_manager.gd`: updated mock data and test cases to reflect all three new conditions.

## Test plan

- [ ] Verify Extended Magazine is NOT unlocked by Double Corridor A (old behavior)
- [ ] Verify Extended Magazine IS unlocked after completing both Polygon S + Double Corridor S
- [ ] Verify Breaker Bullets requires 7 maps at S rank (not A rank)
- [ ] Verify Drilling Bullets unlocks after 15 wall kills (not 50)
- [ ] Run unit tests: `tests/unit/test_unlock_manager.gd`


Fixes Jhon-Crow/godot-topdown-MVP#1892