### PR TITLE
fix: silenced pistol reload sound range 900px → 100px (Issue #1897)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T07:06:11.928Z for PR creation at branch issue-1897-b0feffc3d4a1 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1897

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T07:06:11.928Z for PR creation at branch issue-1897-b0feffc3d4a1 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1897

--- a/Scripts/Components/LevelInitFallback.cs
+++ b/Scripts/Components/LevelInitFallback.cs
@@ -1156,8 +1156,18 @@ public partial class LevelInitFallback : Node
         {
             var soundPropagation = GetNodeOrNull("/root/SoundPropagation");
             if (soundPropagation != null && soundPropagation.HasMethod("emit_player_reload"))
-                soundPropagation.Call("emit_player_reload", _player.GlobalPosition, _player);
+            {
+                // Issue #1897: silenced pistol reload is nearly inaudible (100px vs default 900px)
+                float reloadSoundRange = IsSilencedPistolEquipped() ? 100.0f : -1.0f;
+                soundPropagation.Call("emit_player_reload", _player.GlobalPosition, _player, reloadSoundRange);
+            }
         }
+    }
+
+    private bool IsSilencedPistolEquipped()
+    {
+        var weapon = GetCurrentWeaponNode();
+        return weapon?.Name == "SilencedPistol";
     }
 
     private void OnPlayerReloadCompleted()

--- a/scripts/autoload/sound_propagation.gd
+++ b/scripts/autoload/sound_propagation.gd
@@ -278,8 +278,9 @@ func emit_enemy_gunshot(position: Vector2, source_node: Node2D = null) -> void:
 
 ## Convenience method to emit a reload sound from the player.
 ## This sound propagates through walls and alerts enemies even behind cover.
-func emit_player_reload(position: Vector2, source_node: Node2D = null) -> void:
-	emit_sound(SoundType.RELOAD, position, SourceType.PLAYER, source_node)
+## Use custom_range to override the default 900px distance (e.g. 100px for silenced pistol).
+func emit_player_reload(position: Vector2, source_node: Node2D = null, custom_range: float = -1.0) -> void:
+	emit_sound(SoundType.RELOAD, position, SourceType.PLAYER, source_node, custom_range)
 
 
 ## Convenience method to emit an empty click sound from the player.

--- a/tests/unit/test_sound_propagation.gd
+++ b/tests/unit/test_sound_propagation.gd
@@ -661,3 +661,62 @@ func test_casing_kick_does_not_reach_listener_beyond_range() -> void:
 		"Casing kick should not reach listener at 1000 pixels (beyond 900 range)")
 
 	listener.queue_free()
+
+
+# =====================================================
+# Issue #1897: Silenced pistol reload range (100px)
+# =====================================================
+
+func test_silenced_pistol_reload_uses_custom_100px_range() -> void:
+	# Listener at 150px should NOT hear silenced pistol reload (custom 100px range)
+	var far_listener := MockListener.new()
+	far_listener.global_position = Vector2(150, 0)
+	add_child(far_listener)
+
+	_sound_propagation.register_listener(far_listener)
+
+	_sound_propagation.emit_player_reload(Vector2.ZERO, null, 100.0)
+
+	assert_eq(far_listener.get_sound_count(), 0,
+		"Silenced pistol reload (100px) should not reach listener at 150px")
+
+	far_listener.queue_free()
+
+
+func test_silenced_pistol_reload_heard_within_100px() -> void:
+	# Listener at 50px SHOULD hear silenced pistol reload (custom 100px range)
+	var close_listener := MockListener.new()
+	close_listener.global_position = Vector2(50, 0)
+	add_child(close_listener)
+
+	_sound_propagation.register_listener(close_listener)
+
+	_sound_propagation.emit_player_reload(Vector2.ZERO, null, 100.0)
+
+	assert_eq(close_listener.get_sound_count(), 1,
+		"Silenced pistol reload (100px) should reach listener at 50px")
+
+	close_listener.queue_free()
+
+
+func test_silenced_pistol_reload_not_heard_at_default_reload_range() -> void:
+	# Listener at 700px would hear a normal 900px reload, but not the 100px silenced one
+	var listener := MockListener.new()
+	listener.global_position = Vector2(700, 0)
+	add_child(listener)
+
+	_sound_propagation.register_listener(listener)
+
+	# Default reload (900px) - listener hears it
+	_sound_propagation.emit_player_reload(Vector2.ZERO, null)
+	assert_eq(listener.get_sound_count(), 1,
+		"Default reload (900px) should reach listener at 700px")
+
+	listener.clear_sounds()
+
+	# Silenced pistol reload (100px) - listener does NOT hear it
+	_sound_propagation.emit_player_reload(Vector2.ZERO, null, 100.0)
+	assert_eq(listener.get_sound_count(), 0,
+		"Silenced pistol reload (100px) should not reach listener at 700px")
+
+	listener.queue_free()


### PR DESCRIPTION
## Problem

The silenced pistol reload sound was propagating to enemies at the default RELOAD range of **900px**, the same as loud weapons like the assault rifle. Since the pistol is suppressed, the mechanical sound of reloading should be nearly inaudible — only enemies within 100px should hear it.

## Root Cause

`LevelInitFallback.OnPlayerReloadStarted()` called `emit_player_reload()` with no custom range, always using the default 900px value from `PROPAGATION_DISTANCES[SoundType.RELOAD]`. The function had no way to pass a weapon-specific range.

## Fix

1. **`scripts/autoload/sound_propagation.gd`** — Added optional `custom_range` parameter to `emit_player_reload()` (mirrors existing `emit_sound()` signature).
2. **`Scripts/Components/LevelInitFallback.cs`** — Added `IsSilencedPistolEquipped()` helper; passes `100.0f` when the silenced pistol is active, falling back to `-1.0f` (default 900px) for all other weapons.

## How to Reproduce

Equip silenced pistol → reload (press R twice) → observe debug overlay showing sound circle radius. Before fix: 900px. After fix: 100px.

## Tests

Three new unit tests in `tests/unit/test_sound_propagation.gd`:
- `test_silenced_pistol_reload_uses_custom_100px_range` — listener at 150px does NOT hear 100px reload
- `test_silenced_pistol_reload_heard_within_100px` — listener at 50px DOES hear 100px reload
- `test_silenced_pistol_reload_not_heard_at_default_reload_range` — confirms 100px vs 900px contrast


Fixes Jhon-Crow/godot-topdown-MVP#1897