### PR TITLE
fix: strikethrough line position in grenade tutorial hint (#1890)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T07:06:20.997Z for PR creation at branch issue-1890-a4693aac264e for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1890

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T07:06:20.997Z for PR creation at branch issue-1890-a4693aac264e for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1890

--- a/scripts/components/weapon_hints_component.gd
+++ b/scripts/components/weapon_hints_component.gd
@@ -1045,10 +1045,11 @@ func _setup_strikethrough_lines(hint_key: String, label: RichTextLabel) -> void:
 	if not is_instance_valid(label):
 		return
 
-	const LINE_HEIGHT := 26.0
-
+	# Issue #1890: Use get_line_count() for the actual rendered line count instead of
+	# estimating from content_height / constant, which overcounts when the real line
+	# height differs from the hard-coded value and shifts strikethroughs above the text.
 	var content_height := label.get_content_height()
-	var line_count := maxi(1, roundi(content_height / LINE_HEIGHT))
+	var line_count := maxi(1, label.get_line_count())
 	_hint_line_counts[hint_key] = line_count
 
 	var line_widths: Array = []
@@ -1076,9 +1077,10 @@ func _setup_strikethrough_lines(hint_key: String, label: RichTextLabel) -> void:
 			line_widths.append(fallback_width)
 	_hint_line_widths[hint_key] = line_widths
 
+	var actual_line_height := float(content_height) / float(line_count)
 	var lines: Array = []
 	for line_idx in range(line_count):
-		var line_y := line_idx * LINE_HEIGHT + LINE_HEIGHT * 0.55
+		var line_y := line_idx * actual_line_height + actual_line_height * 0.5
 		var seg := Line2D.new()
 		seg.name = "StrikeLine_%s_%d" % [hint_key, line_idx]
 		seg.width = 1.5

--- a/scripts/levels/labyrinth_level.gd
+++ b/scripts/levels/labyrinth_level.gd
@@ -2863,12 +2863,11 @@ func _setup_tutorial_strikethrough_lines(hint_key: String, label: RichTextLabel)
 	if not is_instance_valid(label):
 		return
 
-	# Get font metrics. Font size is 20, typical line height with spacing is ~26px.
-	const LINE_HEIGHT := 26.0  # Font size + default line spacing
-
-	# Calculate number of lines based on content height vs line height.
+	# Issue #1890: Use get_line_count() for the actual rendered line count instead of
+	# estimating from content_height / constant, which overcounts when the real line
+	# height differs from the hard-coded value and shifts strikethroughs above the text.
 	var content_height := label.get_content_height()
-	var line_count := maxi(1, roundi(content_height / LINE_HEIGHT))
+	var line_count := maxi(1, label.get_line_count())
 	_tutorial_hint_line_counts[hint_key] = line_count
 
 	# Issue #1080: Compute per-line text widths using font metrics.
@@ -2902,10 +2901,11 @@ func _setup_tutorial_strikethrough_lines(hint_key: String, label: RichTextLabel)
 	_tutorial_hint_line_widths[hint_key] = line_widths
 
 	# Create one Line2D per text line to avoid diagonal connectors between lines.
+	var actual_line_height := float(content_height) / float(line_count)
 	var lines: Array = []
 	for line_idx in range(line_count):
-		# Vertical center of each line: ~55% of line height.
-		var line_y := line_idx * LINE_HEIGHT + LINE_HEIGHT * 0.55
+		# Vertical center of each line: 50% of actual line height.
+		var line_y := line_idx * actual_line_height + actual_line_height * 0.5
 		var seg := Line2D.new()
 		seg.name = "StrikeLine_%s_%d" % [hint_key, line_idx]
 		seg.width = 1.5

--- a/scripts/levels/tutorial_level.gd
+++ b/scripts/levels/tutorial_level.gd
@@ -1995,12 +1995,11 @@ func _setup_strikethrough_lines(hint_key: String, label: RichTextLabel) -> void:
 	if not is_instance_valid(label):
 		return
 
-	# Get font metrics. Font size is 20, typical line height with spacing is ~26px.
-	const LINE_HEIGHT := 26.0  # Font size + default line spacing
-
-	# Calculate number of lines based on content height vs line height.
+	# Issue #1890: Use get_line_count() for the actual rendered line count instead of
+	# estimating from content_height / constant, which overcounts when the real line
+	# height differs from the hard-coded value and shifts strikethroughs above the text.
 	var content_height := label.get_content_height()
-	var line_count := maxi(1, roundi(content_height / LINE_HEIGHT))
+	var line_count := maxi(1, label.get_line_count())
 	_hint_line_counts[hint_key] = line_count
 
 	# Issue #1080: Compute per-line text widths using font metrics.
@@ -2034,10 +2033,11 @@ func _setup_strikethrough_lines(hint_key: String, label: RichTextLabel) -> void:
 	_hint_line_widths[hint_key] = line_widths
 
 	# Create one Line2D per text line to avoid diagonal connectors between lines.
+	var actual_line_height := float(content_height) / float(line_count)
 	var lines: Array = []
 	for line_idx in range(line_count):
-		# Vertical center of each line: ~55% of line height.
-		var line_y := line_idx * LINE_HEIGHT + LINE_HEIGHT * 0.55
+		# Vertical center of each line: 50% of actual line height.
+		var line_y := line_idx * actual_line_height + actual_line_height * 0.5
 		var seg := Line2D.new()
 		seg.name = "StrikeLine_%s_%d" % [hint_key, line_idx]
 		seg.width = 1.5

--- a/tests/unit/test_labyrinth_grenade_tutorial.gd
+++ b/tests/unit/test_labyrinth_grenade_tutorial.gd
@@ -365,3 +365,41 @@ func test_training_revolver_open_close_rolls_hint_back_before_insert() -> void:
 		"Training revolver open/close without insertion must roll the hint back")
 	assert_true(content.contains("_reset_hint_strikethrough(HINT_RELOAD)"),
 		"Training revolver rollback must clear partial strikethrough progress")
+
+
+## Issue #1890: Strikethrough line must use get_line_count() and actual line height so the
+## line stays centered on each text row instead of drifting above later rows.
+func test_tutorial_strikethrough_line_y_uses_actual_line_height() -> void:
+	var file := FileAccess.open("res://scripts/levels/tutorial_level.gd", FileAccess.READ)
+	if file == null:
+		pass_test("tutorial_level.gd not accessible in test environment (OK)")
+		return
+	var content := file.get_as_text()
+	file.close()
+
+	assert_true(content.contains("label.get_line_count()"),
+		"Issue #1890: tutorial_level must use label.get_line_count() for accurate line count, not content_height / constant")
+	assert_false(content.contains("roundi(content_height / LINE_HEIGHT)"),
+		"Issue #1890: tutorial_level must not estimate line count from a hardcoded LINE_HEIGHT constant")
+	assert_true(content.contains("actual_line_height := float(content_height) / float(line_count)"),
+		"Issue #1890: tutorial_level must derive actual_line_height from content_height so strikethrough y matches real text rows")
+	assert_true(content.contains("actual_line_height * 0.5"),
+		"Issue #1890: strikethrough y must be placed at the vertical center (50%) of each actual line")
+
+
+func test_labyrinth_strikethrough_line_y_uses_actual_line_height() -> void:
+	var file := FileAccess.open("res://scripts/levels/labyrinth_level.gd", FileAccess.READ)
+	if file == null:
+		pass_test("labyrinth_level.gd not accessible in test environment (OK)")
+		return
+	var content := file.get_as_text()
+	file.close()
+
+	assert_true(content.contains("label.get_line_count()"),
+		"Issue #1890: labyrinth_level must use label.get_line_count() for accurate line count, not content_height / constant")
+	assert_false(content.contains("roundi(content_height / LINE_HEIGHT)"),
+		"Issue #1890: labyrinth_level must not estimate line count from a hardcoded LINE_HEIGHT constant")
+	assert_true(content.contains("actual_line_height := float(content_height) / float(line_count)"),
+		"Issue #1890: labyrinth_level must derive actual_line_height from content_height so strikethrough y matches real text rows")
+	assert_true(content.contains("actual_line_height * 0.5"),
+		"Issue #1890: strikethrough y must be placed at the vertical center (50%) of each actual line")


### PR DESCRIPTION
## Summary

Fixes #1890: The strikethrough line in grenade (and other multi-line) tutorial hints shifted progressively higher for each subsequent step, ending up above the text entirely for the last step.

**Root cause:** `_setup_strikethrough_lines` estimated the number of rendered lines using `roundi(content_height / 26.0)`. When the actual per-line height in the Godot 4 RichTextLabel differs from the hardcoded `26.0` constant, the count is overcounted (e.g., 4 lines reported instead of 3). The Line2D nodes are then spaced 26px apart, but the actual text lines are further apart, so lines 1+ drift above their corresponding text.

**Fix:** Replace `roundi(content_height / LINE_HEIGHT)` with `label.get_line_count()` (the accurate Godot 4 API), and derive `actual_line_height = content_height / line_count` so each Line2D is centered exactly on its rendered text row.

## Files changed

- `scripts/levels/tutorial_level.gd` — `_setup_strikethrough_lines`
- `scripts/levels/labyrinth_level.gd` — `_setup_tutorial_strikethrough_lines`
- `scripts/components/weapon_hints_component.gd` — `_setup_strikethrough_lines`
- `tests/unit/test_labyrinth_grenade_tutorial.gd` — two new tests verifying the fix

## Test plan

- [ ] New unit tests in `test_labyrinth_grenade_tutorial.gd` verify that `get_line_count()` is used and the hardcoded constant is gone
- [ ] Play the tutorial level and progress through grenade throw steps — strikethrough should remain centered on each text row at all steps
- [ ] Play the labyrinth level grenade tutorial — same verification