### PR TITLE
fix: grenade tutorial hint must not disappear via auto-dismiss timer

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T07:06:42.633Z for PR creation at branch issue-1889-ae942b7eaf85 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1889

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T07:06:42.633Z for PR creation at branch issue-1889-ae942b7eaf85 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1889

--- a/scripts/components/weapon_hints_component.gd
+++ b/scripts/components/weapon_hints_component.gd
@@ -980,9 +980,16 @@ func _extend_hint_strikethrough(hint_key: String, progress: float) -> void:
 
 
 ## Called when the global dismiss timer times out — clear all remaining hints.
+## The grenade hint is excluded: it must only be dismissed when the throw is performed.
 func _on_dismiss_timer_timeout() -> void:
 	_log_to_file("Auto-dismiss timer: clearing all remaining hints for %s" % _current_weapon_id)
-	dismiss_hints()
+	if _hint_labels.has(HINT_KEY_GRENADE):
+		var keys_to_dismiss: Array = _hint_labels.keys().filter(func(k): return k != HINT_KEY_GRENADE)
+		for key in keys_to_dismiss:
+			_dismiss_hint(key)
+		_log_to_file("Auto-dismiss timer: grenade hint kept active (waiting for throw)")
+	else:
+		dismiss_hints()
 
 
 ## Add a single hint label with Labyrinth-style BBCode, shadows, fade-in, and strikethrough Line2D.

--- a/tests/unit/test_weapon_hints_component.gd
+++ b/tests/unit/test_weapon_hints_component.gd
@@ -532,3 +532,41 @@ func test_shotgun_full_reload_dismisses_after_shell_loaded_then_closed() -> void
 
 	assert_true(comp._animating_hints.has(WeaponHintsComp.HINT_KEY_BOLT_CYCLE),
 		"Closing after loading a shell should dismiss the shotgun full reload hint")
+
+
+func test_auto_dismiss_timer_does_not_dismiss_active_grenade_hint() -> void:
+	# Regression test for Issue #1889: grenade tutorial must not disappear via the
+	# auto-dismiss timer — only the grenade_thrown signal should dismiss it.
+	var comp := WeaponHintsComp.new()
+	add_child_autofree(comp)
+	comp._hints_active = true
+
+	# Simulate grenade hint active alongside another hint
+	comp._hint_labels[WeaponHintsComp.HINT_KEY_GRENADE] = RichTextLabel.new()
+	comp._hint_labels["other"] = RichTextLabel.new()
+	comp._animating_hints.clear()
+
+	# Fire the auto-dismiss callback directly (simulates timer expiry)
+	comp._on_dismiss_timer_timeout()
+
+	assert_true(comp._hint_labels.has(WeaponHintsComp.HINT_KEY_GRENADE),
+		"Grenade hint must survive auto-dismiss timer (Issue #1889)")
+	assert_false(comp._hint_labels.has("other"),
+		"Non-grenade hints should be dismissed by the auto-dismiss timer")
+
+
+func test_auto_dismiss_timer_dismisses_all_hints_when_no_grenade_hint() -> void:
+	var comp := WeaponHintsComp.new()
+	add_child_autofree(comp)
+	comp._hints_active = true
+
+	comp._hint_labels["reload"] = RichTextLabel.new()
+	comp._hint_labels["fire_mode"] = RichTextLabel.new()
+	comp._animating_hints.clear()
+
+	comp._on_dismiss_timer_timeout()
+
+	assert_false(comp._hint_labels.has("reload"),
+		"Reload hint should be dismissed when no grenade hint is active")
+	assert_false(comp._hint_labels.has("fire_mode"),
+		"Fire-mode hint should be dismissed when no grenade hint is active")


### PR DESCRIPTION
## Problem

Closes #1889.

The grenade throw tutorial hint was disappearing prematurely on all maps that use `WeaponHintsComponent`. A global auto-dismiss timer (8 s) fires in `_on_dismiss_timer_timeout` and calls `dismiss_hints()`, which cleared **all** hints — including the grenade throw tutorial — even while the player was still mid-sequence.

The grenade hint should only disappear when the player actually throws the grenade (`grenade_thrown` signal → `_on_player_grenade_thrown`).

## Root cause

`scripts/components/weapon_hints_component.gd` — `_on_dismiss_timer_timeout` (line ~983) called `dismiss_hints()` unconditionally, which dismissed every hint including `HINT_KEY_GRENADE`.

## Fix

`_on_dismiss_timer_timeout` now checks whether the grenade hint is currently shown. If it is, only non-grenade hints are dismissed; the grenade hint is left alive until `_on_player_grenade_thrown` fires.

## How to reproduce the bug (before fix)

1. Start any map that shows weapon hints.
2. Equip a grenade and press G to begin the throw tutorial.
3. Wait ~8 seconds without completing the throw.
4. The grenade tutorial disappears even though no throw occurred.

## Test plan

- `test_auto_dismiss_timer_does_not_dismiss_active_grenade_hint` — verifies grenade hint survives timer expiry (regression guard for #1889).
- `test_auto_dismiss_timer_dismisses_all_hints_when_no_grenade_hint` — verifies normal hints are still cleared when no grenade hint is active.
- All existing grenade hint tests remain green.