### PR TITLE
fix(#1893): add Sewer/WinterForest/Railway to C# fallback next-level progression

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T07:06:52.143Z for PR creation at branch issue-1893-8fe526bc9047 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1893

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T07:06:52.143Z for PR creation at branch issue-1893-8fe526bc9047 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1893

--- a/Scripts/Components/LevelInitFallback.cs
+++ b/Scripts/Components/LevelInitFallback.cs
@@ -1499,6 +1499,9 @@ public partial class LevelInitFallback : Node
             "res://scenes/levels/FactoryLevel.tscn",
             "res://scenes/levels/DecadenceLevel.tscn",
             "res://scenes/levels/Labyrinth2Level.tscn",
+            "res://scenes/levels/SewerLevel.tscn",
+            "res://scenes/levels/WinterForestLevel.tscn",
+            "res://scenes/levels/RailwayStationLevel.tscn",
         };
         for (int i = 0; i < levelPaths.Length; i++)
         {

--- a/scripts/levels/labyrinth2_level.gd
+++ b/scripts/levels/labyrinth2_level.gd
@@ -1157,7 +1157,7 @@ func _get_next_level_path() -> String:
 	if current_scene and current_scene.scene_file_path:
 		current_scene_path = current_scene.scene_file_path
 
-	# Level ordering (matching LevelsMenu.LEVELS) — Labyrinth Complex is last
+	# Level ordering (matching LevelsMenu.LEVELS)
 	var level_paths: Array[String] = [
 		"res://scenes/levels/LabyrinthLevel.tscn",
 		"res://scenes/levels/BuildingLevel.tscn",


### PR DESCRIPTION
## Summary

Fixes #1893 — no "Next Level" button on the score screen after Labyrinth Complex.

## Root Cause

`Labyrinth2Level.tscn` includes a `LevelInitFallback` C# node that takes over score-screen rendering when the GDScript `_ready()` fails (Godot 4.3 binary tokenization bug). The C# `GetNextLevelPath()` had a hardcoded level array that **stopped at Labyrinth2Level** — it was never updated when Sewer, Winter Forest, and Railway Station were added to the game. As a result, the C# fallback treated Labyrinth Complex as the final level and skipped the Next Level button.

The GDScript `_get_next_level_path()` already had the correct 14-level array; only the C# mirror was stale.

## Changes

- `Scripts/Components/LevelInitFallback.cs` — add `SewerLevel.tscn`, `WinterForestLevel.tscn`, `RailwayStationLevel.tscn` to `GetNextLevelPath()` array to match `LevelsMenu.LEVELS` and the GDScript implementation.
- `scripts/levels/labyrinth2_level.gd` — remove stale comment "Labyrinth Complex is last".

## How to reproduce the issue

1. Trigger the GDScript fallback path (or run an exported build where tokenization can fail)
2. Complete Labyrinth Complex — reach exit after clearing all enemies
3. Score screen appears with no "→ Next Level" button (only Restart / Level Select)

## Fix verification

After this change, `GetNextLevelPath()` returns `SewerLevel.tscn` when called from Labyrinth Complex, so the Next Level button is created correctly in both GDScript and C# code paths.