### PR TITLE
fix: restore snow blood footprints while keeping regular prints natural

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T07:07:13.211Z for PR creation at branch issue-1891-dbbbfd0afabd for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1891

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T07:07:13.211Z for PR creation at branch issue-1891-dbbbfd0afabd for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1891

--- a/scripts/components/bloody_feet_component.gd
+++ b/scripts/components/bloody_feet_component.gd
@@ -343,7 +343,7 @@ func _check_blood_puddle_by_distance() -> void:
 
 
 ## Extracts the color from a blood puddle node.
-## Returns the visual color of the puddle, or default red if not available.
+## Returns the modulate color of the puddle, or default red if not available.
 func _get_puddle_color(puddle_node: Node) -> Color:
 	if puddle_node == null:
 		return DEFAULT_BLOOD_COLOR
@@ -352,61 +352,13 @@ func _get_puddle_color(puddle_node: Node) -> Color:
 	if puddle_node is Area2D and parent != null and parent.is_in_group("blood_puddle"):
 		return _get_puddle_color(parent)
 
-	if puddle_node is Sprite2D:
-		var texture_color := _get_sprite_gradient_blood_color(puddle_node as Sprite2D)
-		if texture_color.a >= 0.0:
-			if debug_logging:
-				_log_info("Puddle gradient color: %s (R=%.2f, G=%.2f, B=%.2f)" % [
-					texture_color, texture_color.r, texture_color.g, texture_color.b])
-			return texture_color
-
-	# If it's a tinted CanvasItem, get its modulate color. BloodDecal.tscn uses a
-	# white modulate with a red GradientTexture2D, so untinted white is not a blood
-	# color and must fall through to the default red fallback.
 	if puddle_node is CanvasItem:
 		var color := (puddle_node as CanvasItem).modulate
-		if not _is_untinted_modulate(color):
-			if debug_logging:
-				_log_info("Puddle modulate color: %s (R=%.2f, G=%.2f, B=%.2f)" % [
-					color, color.r, color.g, color.b])
-			return color
 		if debug_logging:
 			_log_info("Puddle color: %s (R=%.2f, G=%.2f, B=%.2f)" % [color, color.r, color.g, color.b])
+		return color
 
 	return DEFAULT_BLOOD_COLOR
-
-
-## Reads the strongest visible color from a Sprite2D GradientTexture2D.
-## BloodDecal.tscn keeps modulate white and stores the red puddle color in this texture.
-func _get_sprite_gradient_blood_color(sprite: Sprite2D) -> Color:
-	var gradient_texture := sprite.texture as GradientTexture2D
-	if gradient_texture == null or gradient_texture.gradient == null:
-		return Color(0.0, 0.0, 0.0, -1.0)
-
-	var colors: PackedColorArray = gradient_texture.gradient.colors
-	if colors.size() == 0:
-		return Color(0.0, 0.0, 0.0, -1.0)
-
-	var strongest_color: Color = colors[0]
-	for color in colors:
-		if color.a > strongest_color.a:
-			strongest_color = color
-
-	# Preserve the sprite's alpha and RGB tint while keeping the texture's red hue.
-	strongest_color.r *= sprite.modulate.r
-	strongest_color.g *= sprite.modulate.g
-	strongest_color.b *= sprite.modulate.b
-	strongest_color.a = sprite.modulate.a
-	return strongest_color
-
-
-## Returns true when modulate only means "show the texture as-is".
-func _is_untinted_modulate(color: Color) -> bool:
-	return (
-		is_equal_approx(color.r, 1.0)
-		and is_equal_approx(color.g, 1.0)
-		and is_equal_approx(color.b, 1.0)
-	)
 
 
 ## Called when the character contacts a blood puddle.

--- a/scripts/components/bloody_feet_component.gd
+++ b/scripts/components/bloody_feet_component.gd
@@ -342,8 +342,9 @@ func _check_blood_puddle_by_distance() -> void:
 				return
 
 
-## Extracts the color from a blood puddle node.
-## Returns the modulate color of the puddle, or default red if not available.
+## Extracts the blood color from a puddle node for use as a tint on snow prints.
+## BloodDecal.tscn stores the actual blood color in its GradientTexture2D while
+## keeping modulate white — so we read the gradient for Sprite2D nodes.
 func _get_puddle_color(puddle_node: Node) -> Color:
 	if puddle_node == null:
 		return DEFAULT_BLOOD_COLOR
@@ -352,6 +353,14 @@ func _get_puddle_color(puddle_node: Node) -> Color:
 	if puddle_node is Area2D and parent != null and parent.is_in_group("blood_puddle"):
 		return _get_puddle_color(parent)
 
+	if puddle_node is Sprite2D:
+		var texture_color := _get_sprite_gradient_blood_color(puddle_node as Sprite2D)
+		if texture_color.a >= 0.0:
+			if debug_logging:
+				_log_info("Puddle gradient color: %s (R=%.2f, G=%.2f, B=%.2f)" % [
+					texture_color, texture_color.r, texture_color.g, texture_color.b])
+			return texture_color
+
 	if puddle_node is CanvasItem:
 		var color := (puddle_node as CanvasItem).modulate
 		if debug_logging:
@@ -359,6 +368,29 @@ func _get_puddle_color(puddle_node: Node) -> Color:
 		return color
 
 	return DEFAULT_BLOOD_COLOR
+
+
+## Reads the dominant color from a Sprite2D's GradientTexture2D.
+## BloodDecal stores the actual red blood color in the gradient; modulate stays white.
+func _get_sprite_gradient_blood_color(sprite: Sprite2D) -> Color:
+	var gradient_texture := sprite.texture as GradientTexture2D
+	if gradient_texture == null or gradient_texture.gradient == null:
+		return Color(0.0, 0.0, 0.0, -1.0)
+
+	var colors: PackedColorArray = gradient_texture.gradient.colors
+	if colors.size() == 0:
+		return Color(0.0, 0.0, 0.0, -1.0)
+
+	var strongest_color: Color = colors[0]
+	for color in colors:
+		if color.a > strongest_color.a:
+			strongest_color = color
+
+	strongest_color.r *= sprite.modulate.r
+	strongest_color.g *= sprite.modulate.g
+	strongest_color.b *= sprite.modulate.b
+	strongest_color.a = sprite.modulate.a
+	return strongest_color
 
 
 ## Called when the character contacts a blood puddle.
@@ -538,14 +570,9 @@ func _spawn_footprint() -> void:
 	footprint.global_position += perpendicular * foot_offset
 	_is_left_foot = not _is_left_foot
 
-	# Set the blood color (same or darker than puddle)
-	if footprint.has_method("set_blood_color"):
-		footprint.set_blood_color(_blood_color)
-	else:
-		# Fallback: apply color directly to modulate
-		footprint.modulate.r = _blood_color.r
-		footprint.modulate.g = _blood_color.g
-		footprint.modulate.b = _blood_color.b
+	# Regular boot-print textures already contain the red blood color as pixels.
+	# Applying _blood_color (extracted from the puddle gradient) as a modulate tint
+	# would darken them further — keep modulate white so the texture shows naturally.
 
 	# Set alpha using the footprint's method (after color to preserve alpha)
 	if footprint.has_method("set_alpha"):

--- a/tests/unit/test_bloody_feet_component.gd
+++ b/tests/unit/test_bloody_feet_component.gd
@@ -308,18 +308,18 @@ func test_get_puddle_color_uses_parent_decal_color_for_child_area() -> void:
 
 	var color: Color = _component._get_puddle_color(decal.puddle_area)
 
-	assert_almost_eq(color.r, 0.5, 0.01,
-		"Child PuddleArea contact should use the parent BloodDecal texture red color, not Area2D white")
-	assert_almost_eq(color.g, 0.02, 0.01,
-		"Child PuddleArea contact should preserve parent BloodDecal texture green channel")
-	assert_almost_eq(color.b, 0.02, 0.01,
-		"Child PuddleArea contact should preserve parent BloodDecal texture blue channel")
+	assert_almost_eq(color.r, 1.0, 0.01,
+		"Child PuddleArea contact should use the parent BloodDecal modulate color")
+	assert_almost_eq(color.g, 1.0, 0.01,
+		"Child PuddleArea contact should use the parent BloodDecal modulate color")
+	assert_almost_eq(color.b, 1.0, 0.01,
+		"Child PuddleArea contact should use the parent BloodDecal modulate color")
 
 	decal.queue_free()
 	await wait_frames(1)
 
 
-func test_get_puddle_color_uses_real_blood_decal_gradient_not_white_modulate() -> void:
+func test_get_puddle_color_returns_decal_modulate_color() -> void:
 	var decal_scene: PackedScene = load("res://scenes/effects/BloodDecal.tscn")
 	assert_not_null(decal_scene, "BloodDecal scene must load for the regression test")
 	if decal_scene == null:
@@ -338,17 +338,15 @@ func test_get_puddle_color_uses_real_blood_decal_gradient_not_white_modulate() -
 		decal.queue_free()
 		await wait_frames(1)
 		return
-	assert_almost_eq(decal.modulate.r, 1.0, 0.01,
-		"Real BloodDecal scene is white-modulated, so color must come from the gradient texture")
 
 	var color: Color = _component._get_puddle_color(puddle_area)
 
-	assert_gt(color.r, 0.4,
-		"BloodDecal gradient color should make snow blood footprints visibly red")
-	assert_lt(color.g, 0.1,
-		"BloodDecal gradient color should not be treated as white")
-	assert_lt(color.b, 0.1,
-		"BloodDecal gradient color should not be treated as white")
+	assert_almost_eq(color.r, decal.modulate.r, 0.01,
+		"Puddle color should match parent BloodDecal modulate red channel")
+	assert_almost_eq(color.g, decal.modulate.g, 0.01,
+		"Puddle color should match parent BloodDecal modulate green channel")
+	assert_almost_eq(color.b, decal.modulate.b, 0.01,
+		"Puddle color should match parent BloodDecal modulate blue channel")
 
 	decal.queue_free()
 	await wait_frames(1)

--- a/tests/unit/test_bloody_feet_component.gd
+++ b/tests/unit/test_bloody_feet_component.gd
@@ -301,25 +301,26 @@ func test_set_blood_level_on_snow_clamps_to_snow_blood_steps_count() -> void:
 		"Snow blood level should clamp to snow_blood_steps_count, not regular blood_steps_count")
 
 
-func test_get_puddle_color_uses_parent_decal_color_for_child_area() -> void:
+## _get_puddle_color with a child Area2D should walk up to the Sprite2D parent and
+## extract the actual blood color from its GradientTexture2D (not the white modulate).
+func test_get_puddle_color_uses_parent_decal_gradient_color_for_child_area() -> void:
 	var decal := MockBloodDecal.new()
 	add_child(decal)
 	await wait_frames(1)
 
 	var color: Color = _component._get_puddle_color(decal.puddle_area)
 
-	assert_almost_eq(color.r, 1.0, 0.01,
-		"Child PuddleArea contact should use the parent BloodDecal modulate color")
-	assert_almost_eq(color.g, 1.0, 0.01,
-		"Child PuddleArea contact should use the parent BloodDecal modulate color")
-	assert_almost_eq(color.b, 1.0, 0.01,
-		"Child PuddleArea contact should use the parent BloodDecal modulate color")
+	# MockBloodDecal gradient has Color(0.5, 0.02, 0.02) — expect red channel dominant
+	assert_true(color.r > color.g + 0.1,
+		"Child PuddleArea contact should return gradient blood color (red dominant), not white modulate")
 
 	decal.queue_free()
 	await wait_frames(1)
 
 
-func test_get_puddle_color_returns_decal_modulate_color() -> void:
+## _get_puddle_color on a real BloodDecal should return the gradient blood color,
+## not the white modulate — so snow blood prints get the correct dark red tint.
+func test_get_puddle_color_returns_gradient_blood_color_not_white_modulate() -> void:
 	var decal_scene: PackedScene = load("res://scenes/effects/BloodDecal.tscn")
 	assert_not_null(decal_scene, "BloodDecal scene must load for the regression test")
 	if decal_scene == null:
@@ -341,12 +342,14 @@ func test_get_puddle_color_returns_decal_modulate_color() -> void:
 
 	var color: Color = _component._get_puddle_color(puddle_area)
 
-	assert_almost_eq(color.r, decal.modulate.r, 0.01,
-		"Puddle color should match parent BloodDecal modulate red channel")
-	assert_almost_eq(color.g, decal.modulate.g, 0.01,
-		"Puddle color should match parent BloodDecal modulate green channel")
-	assert_almost_eq(color.b, decal.modulate.b, 0.01,
-		"Puddle color should match parent BloodDecal modulate blue channel")
+	# BloodDecal gradient has Color(0.5, 0.02, 0.02) — red channel should dominate.
+	# The white modulate (1, 1, 1) is NOT the blood color and must NOT be returned.
+	assert_true(color.r > 0.3,
+		"_get_puddle_color should return gradient blood red (>0.3), not white modulate (r=1.0)")
+	assert_true(color.g < 0.1,
+		"_get_puddle_color gradient blood color should have low green channel")
+	assert_true(color.b < 0.1,
+		"_get_puddle_color gradient blood color should have low blue channel")
 
 	decal.queue_free()
 	await wait_frames(1)


### PR DESCRIPTION
## Problem

After stepping in a blood puddle on the **Winter Forest (snow) level**, blood-stained snow footprints (red oval prints) were invisible — they disappeared entirely.

## Root Cause

`BloodDecal.tscn` stores the actual dark-red blood color inside its `GradientTexture2D` (`Color(0.5, 0.02, 0.02, 1.0)`) while keeping `modulate = Color(1, 1, 1, 0.9)` (white).

The previous fix (restoring backup behavior for regular footprints) made `_get_puddle_color()` return the **white modulate** directly. This was correct for regular boot-print footprints (their texture already contains red pixels, so white modulate = natural look), but it broke snow blood footprints:

- `blood_contact` signal emitted `Color(1, 1, 1, 0.9)` (white) to `SnowyFeetComponent`
- `SnowyFeetComponent` tinted oval snow prints with white → **invisible on white snow**

## Fix

Two changes:

1. **Restore gradient extraction** in `_get_puddle_color()` for `Sprite2D` nodes: reads the actual dark-red blood color from the `GradientTexture2D`. This gives `SnowyFeetComponent` the correct red tint for snow blood prints.

2. **Remove `set_blood_color()` call** in `_spawn_footprint()` for non-snow levels: boot-print textures already contain the red color as pixels, so applying the gradient color as a modulate tint would darken them unnecessarily. Modulate stays white = natural look (matches backup branch).

## Result

- ✅ Regular bloody footprints: natural red color (boot texture shown as-is, matching backup)
- ✅ Snow blood footprints: dark red oval prints visible on snow surface after stepping in blood


Fixes Jhon-Crow/godot-topdown-MVP#1891