### PR TITLE
Fix drone grenade throw-before-pilot flow

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T07:08:04.089Z for PR creation at branch issue-1896-4e2c95bc79b4 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1896

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T07:08:04.089Z for PR creation at branch issue-1896-4e2c95bc79b4 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1896

--- a/Scripts/Characters/Player.Grenade.cs
+++ b/Scripts/Characters/Player.Grenade.cs
@@ -489,6 +489,8 @@ public partial class Player
         // Without this fix, the grenade lands ~60px short of the target.
         _activeGrenade.GlobalPosition = safeSpawnPosition;
 
+        PassDroneThrowAimPoint(targetPos);
+
         // FIX for Issue #432: Mark grenade as thrown BEFORE unfreezing to avoid race condition.
         // If MarkAsThrown() is called after unfreezing, the BodyEntered signal could fire
         // before IsThrown is set, causing impact detection to fail.
@@ -789,6 +791,8 @@ public partial class Player
         Vector2 spawnPosition = GetSafeGrenadeSpawnPosition(GlobalPosition, intendedSpawnPosition, throwDirection);
         _activeGrenade.GlobalPosition = spawnPosition;
 
+        PassDroneThrowAimPoint(dragEnd);
+
         // FIX for Issue #432: ALWAYS set velocity directly in C# as primary mechanism.
         // GDScript methods called via Call() may silently fail in exported builds.
         // Calculate throw speed using the same formula as GDScript
@@ -844,6 +848,24 @@ public partial class Player
 
         // Reset state (grenade is now independent)
         ResetGrenadeState();
+    }
+
+    /// <summary>
+    /// Pass the world-space throw target to DroneGrenade before launch.
+    /// </summary>
+    /// <param name="aimPoint">Mouse cursor world position the drone should fly to before piloting.</param>
+    private void PassDroneThrowAimPoint(Vector2 aimPoint)
+    {
+        if (_activeGrenade == null || !IsInstanceValid(_activeGrenade))
+        {
+            return;
+        }
+
+        if (_activeGrenade.HasMethod("set_aim_point"))
+        {
+            _activeGrenade.Call("set_aim_point", aimPoint);
+            LogToFile($"[Player.Grenade] Drone aim point set to {aimPoint}");
+        }
     }
 
     /// <summary>

--- a/docs/case-studies/issue-1896/case-study.md
+++ b/docs/case-studies/issue-1896/case-study.md
@@ -1,0 +1,129 @@
+# Case Study: Issue #1896 — Drone Grenade Throw-Before-Pilot Mechanic Not Working
+
+## Overview
+
+**Issue:** [#1896 — update граната дрон](https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1896)  
+**PR:** [#1906](https://github.com/Jhon-Crow/godot-topdown-MVP/pull/1906)  
+**Game log:** `game_log_20260420_120715.txt` (attached by Jhon-Crow on 2026-04-20)  
+**Reported symptom:** Drone spawns next to player and immediately enters pilot mode — no ballistic throw phase.
+
+---
+
+## Timeline of Events
+
+| Time | Event |
+|------|-------|
+| 2026-04-20 | Issue #1896 filed: requests 50% speed boost + throw-before-pilot mechanic |
+| 2026-04-20T07:15 | PR #1906 opened with implementation in `drone_grenade.gd` and unit tests |
+| 2026-04-20T07:20 | PR marked ready to merge, CI passing |
+| 2026-04-20T09:09 | Jhon-Crow tests in-game and reports: throw phase not working at all; attaches `game_log_20260420_120715.txt` |
+| 2026-04-20T09:10 | AI work session restarted |
+
+---
+
+## Sequence of Events During a Drone Throw (from game log)
+
+```
+12:07:27  [GrenadeBase] Grenade created at (0, 0) (frozen)
+12:07:27  [DroneGrenade] Ready
+12:07:27  [DroneGrenade] Pin pulled — drone will launch on throw
+12:07:32  [Player.Grenade.Simple] Throwing! Target: (666.05, 1545.04), Distance: 410.1, Speed: 496.0
+12:07:32  [GrenadeBase] Simple mode throw! Dir: (0.999999, 0.001552), Speed: 496.0
+12:07:32  [DroneGrenade] PILOTING phase started at (255.97, 1544.41)   ← BUG: should be THROWING
+12:07:32  [DroneGrenade] Drone launched at (255.97, 1544.41)
+```
+
+**Key observation:** The log shows `PILOTING phase started` directly after throw — the `THROWING` phase is never entered. The target position `(666.05, 1545.04)` was known to the player code but never forwarded to the drone.
+
+---
+
+## Root Cause Analysis
+
+### The Bug
+
+`DroneGrenade._launch_drone()` enters the `THROWING` phase only when `_aim_point != Vector2.ZERO`:
+
+```gdscript
+# drone_grenade.gd line 164
+if _aim_point != Vector2.ZERO:
+    _drone_state = DroneState.THROWING   # ← only reachable if set_aim_point() was called
+    ...
+else:
+    _start_piloting()                    # ← always reached because _aim_point = Vector2.ZERO
+```
+
+`set_aim_point(world_pos)` was implemented in `drone_grenade.gd` but **never called** from `player.gd`. The player's grenade-throwing code (`_throw_simple_grenade` and `_throw_grenade`) knew the target position (`target_pos` / `drag_end`) but passed it only to the physics throw — not to the drone's state machine.
+
+### Why Unit Tests Passed
+
+Unit tests (`test_drone_grenade.gd`) call `drone.set_aim_point(...)` directly before each throw. They test the drone in isolation and correctly verify the THROWING state. But the integration path — player code → grenade throw — never called `set_aim_point()`.
+
+This is a classic **unit test / integration gap**: the component works in isolation, but the caller never uses the new API.
+
+### Root Cause (one sentence)
+
+`player.gd`'s `_throw_simple_grenade()` and `_throw_grenade()` functions had the mouse cursor position available but never called `_active_grenade.set_aim_point(target_pos)` before invoking the throw, leaving `DroneGrenade._aim_point` at `Vector2.ZERO` and causing the drone to skip the THROWING phase entirely.
+
+---
+
+## Evidence
+
+### Game Log (lines 1190–1199)
+```
+[Player.Grenade.Simple] Throwing! Target: (666.0539, 1545.0447), Distance: 410.1, Speed: 496.0
+[GrenadeBase] Simple mode throw! Dir: (0.999999, 0.001552), Speed: 496.0
+[DroneGrenade] PILOTING phase started at (255.9691, 1544.408)   ← wrong state
+[DroneGrenade] Drone launched at (255.9691, 1544.408)
+```
+No `THROWING phase started` log line ever appears across the entire 2985-line log.
+
+### Code Search
+```
+$ grep -rn "set_aim_point" scripts/
+scripts/projectiles/drone_grenade.gd:143:func set_aim_point(world_pos: Vector2) -> void:
+```
+Zero call sites found — only the definition existed.
+
+---
+
+## Fix Applied
+
+Two call sites added in `scripts/characters/player.gd`:
+
+**1. Simple mode (`_throw_simple_grenade`, line ~1931):**
+```gdscript
+# Issue #1896: pass the mouse cursor world position so DroneGrenade can fly there first.
+if _active_grenade.has_method("set_aim_point"):
+    _active_grenade.set_aim_point(target_pos)
+```
+
+**2. Velocity-based mode (`_throw_grenade`, line ~2094):**
+```gdscript
+# Issue #1896: pass the mouse cursor world position so DroneGrenade can fly there first.
+if _active_grenade.has_method("set_aim_point"):
+    _active_grenade.set_aim_point(drag_end)
+```
+
+Both use `has_method()` guard so non-drone grenades are unaffected.
+
+---
+
+## Lessons Learned
+
+1. **New API methods on components must be wired up at every call site.** Adding `set_aim_point()` to `DroneGrenade` without adding a matching call in `player.gd` created a silent no-op.
+
+2. **Unit tests that test components in isolation can miss integration bugs.** The test called `set_aim_point()` directly; the real throwing code did not.
+
+3. **Log-first debugging is effective.** The game log provided an unambiguous trace: `PILOTING phase started` appearing immediately after throw (with no `THROWING phase started` line) pinpointed the issue within minutes.
+
+4. **Fallback-to-legacy patterns hide missing calls.** The "if `_aim_point == Vector2.ZERO`, start piloting immediately" fallback was added for backward compatibility but masked the missing caller setup — the drone silently fell back to old behavior with no warning.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `scripts/characters/player.gd` | Added `set_aim_point(target_pos)` call before throw in `_throw_simple_grenade()` and `set_aim_point(drag_end)` in `_throw_grenade()` |
+| `docs/case-studies/issue-1896/case-study.md` | This document |
+| `docs/case-studies/issue-1896/game_log_20260420_120715.txt` | Original game log from Jhon-Crow |

--- a/docs/case-studies/issue-1896/case-study.md
+++ b/docs/case-studies/issue-1896/case-study.md
@@ -1,122 +1,200 @@
-# Case Study: Issue #1896 — Drone Grenade Throw-Before-Pilot Mechanic Not Working
+# Case Study: Issue #1896 — Drone Grenade Throw-Before-Pilot Mechanic
 
 ## Overview
 
 **Issue:** [#1896 — update граната дрон](https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1896)  
 **PR:** [#1906](https://github.com/Jhon-Crow/godot-topdown-MVP/pull/1906)  
-**Game log:** `game_log_20260420_120715.txt` (attached by Jhon-Crow on 2026-04-20)  
-**Reported symptom:** Drone spawns next to player and immediately enters pilot mode — no ballistic throw phase.
+**Attached logs preserved in this folder:**
+
+- `game_log_20260420_120715.txt` — first failed retest attached at 2026-04-20T09:09Z.
+- `game_log_20260420_123426.txt` — second failed retest attached at 2026-04-20T09:35Z.
+
+**Original requirements:**
+
+1. Increase drone grenade speed by 50%.
+2. Throw the drone like a grenade toward the aim point first; only after a successful throw should player drone control begin. If it collides before reaching the throw aim point, it explodes immediately.
+
+**Reported symptom:** the drone still spawned near the player and entered piloting immediately, with no visible throw-before-pilot phase.
 
 ---
 
-## Timeline of Events
+## Timeline
 
-| Time | Event |
-|------|-------|
-| 2026-04-20 | Issue #1896 filed: requests 50% speed boost + throw-before-pilot mechanic |
-| 2026-04-20T07:15 | PR #1906 opened with implementation in `drone_grenade.gd` and unit tests |
-| 2026-04-20T07:20 | PR marked ready to merge, CI passing |
-| 2026-04-20T09:09 | Jhon-Crow tests in-game and reports: throw phase not working at all; attaches `game_log_20260420_120715.txt` |
-| 2026-04-20T09:10 | AI work session restarted |
+| Time (UTC) | Event |
+|------------|-------|
+| 2026-04-20 | Issue #1896 filed. |
+| 2026-04-20T07:15 | PR #1906 opened with `DroneGrenade` state machine and unit tests. |
+| 2026-04-20T09:09 | Jhon-Crow reported the first failure: “throw-before-pilot не работает”; attached `game_log_20260420_120715.txt`. |
+| 2026-04-20T09:13 | First follow-up fix added `set_aim_point()` calls to `scripts/characters/player.gd`. |
+| 2026-04-20T09:35 | Jhon-Crow reported the second failure: “всё по старому, не кидается”; attached `game_log_20260420_123426.txt`. |
+| 2026-04-20T09:37+ | Second investigation found that the tested runtime path was C# `Scripts/Characters/Player.Grenade.cs`, not GDScript `scripts/characters/player.gd`. |
 
 ---
 
-## Sequence of Events During a Drone Throw (from game log)
+## Evidence From Logs
 
+### First Failed Retest
+
+From `game_log_20260420_120715.txt`:
+
+```text
+[12:07:32] [Player.Grenade.Simple] Throwing! Target: (666.0539, 1545.0447), Distance: 410,1, Speed: 496,0, Friction: 300,0
+[12:07:32] [GrenadeBase] Simple mode throw! Dir: (0.999999, 0.001552), Speed: 496.0
+[12:07:32] [DroneGrenade] PILOTING phase started at (255.9691, 1544.408)
+[12:07:32] [DroneGrenade] Drone launched at (255.9691, 1544.408)
 ```
-12:07:27  [GrenadeBase] Grenade created at (0, 0) (frozen)
-12:07:27  [DroneGrenade] Ready
-12:07:27  [DroneGrenade] Pin pulled — drone will launch on throw
-12:07:32  [Player.Grenade.Simple] Throwing! Target: (666.05, 1545.04), Distance: 410.1, Speed: 496.0
-12:07:32  [GrenadeBase] Simple mode throw! Dir: (0.999999, 0.001552), Speed: 496.0
-12:07:32  [DroneGrenade] PILOTING phase started at (255.97, 1544.41)   ← BUG: should be THROWING
-12:07:32  [DroneGrenade] Drone launched at (255.97, 1544.41)
+
+### Second Failed Retest
+
+From `game_log_20260420_123426.txt`:
+
+```text
+[12:34:32] [Player.Grenade.Simple] Throwing! Target: (790.8414, 257.69128), Distance: 589,0, Speed: 594,5, Friction: 300,0
+[12:34:32] [Player.Grenade.Simple] C# set velocity directly: dir=(0.9874949, -0.15765108), speed=594,5, spawn=(209.2497, 350.54092)
+[12:34:32] [DroneGrenade] PILOTING phase started at (209.2497, 350.5409)
+[12:34:32] [DroneGrenade] Drone launched at (209.2497, 350.5409)
 ```
 
-**Key observation:** The log shows `PILOTING phase started` directly after throw — the `THROWING` phase is never entered. The target position `(666.05, 1545.04)` was known to the player code but never forwarded to the drone.
+The second log repeats the same signature twice:
+
+- `Throwing! Target: ...` proves the player throw code has the world-space aim point.
+- `C# set velocity directly` identifies the active path as `Scripts/Characters/Player.Grenade.cs`.
+- `PILOTING phase started` appears immediately.
+- `THROWING phase started` never appears.
 
 ---
 
-## Root Cause Analysis
+## Root Cause
 
-### The Bug
+The drone state machine was correct but its new API was only wired in the GDScript player path.
 
-`DroneGrenade._launch_drone()` enters the `THROWING` phase only when `_aim_point != Vector2.ZERO`:
+`DroneGrenade._launch_drone()` enters `THROWING` only when `_aim_point` is set:
 
 ```gdscript
-# drone_grenade.gd line 164
 if _aim_point != Vector2.ZERO:
-    _drone_state = DroneState.THROWING   # ← only reachable if set_aim_point() was called
-    ...
+    _drone_state = DroneState.THROWING
+    _throw_target = _aim_point
 else:
-    _start_piloting()                    # ← always reached because _aim_point = Vector2.ZERO
+    _start_piloting()
 ```
 
-`set_aim_point(world_pos)` was implemented in `drone_grenade.gd` but **never called** from `player.gd`. The player's grenade-throwing code (`_throw_simple_grenade` and `_throw_grenade`) knew the target position (`target_pos` / `drag_end`) but passed it only to the physics throw — not to the drone's state machine.
+The first follow-up fix added:
 
-### Why Unit Tests Passed
+```gdscript
+_active_grenade.set_aim_point(target_pos)
+```
 
-Unit tests (`test_drone_grenade.gd`) call `drone.set_aim_point(...)` directly before each throw. They test the drone in isolation and correctly verify the THROWING state. But the integration path — player code → grenade throw — never called `set_aim_point()`.
+to `scripts/characters/player.gd`, but the logs are produced by the C# player partial. The string:
 
-This is a classic **unit test / integration gap**: the component works in isolation, but the caller never uses the new API.
+```text
+[Player.Grenade.Simple] C# set velocity directly
+```
 
-### Root Cause (one sentence)
+exists in `Scripts/Characters/Player.Grenade.cs`, and that file still had zero `set_aim_point` call sites. Therefore the exported/tested path left `_aim_point == Vector2.ZERO`, so `DroneGrenade` fell back to immediate `PILOTING` every time.
 
-`player.gd`'s `_throw_simple_grenade()` and `_throw_grenade()` functions had the mouse cursor position available but never called `_active_grenade.set_aim_point(target_pos)` before invoking the throw, leaving `DroneGrenade._aim_point` at `Vector2.ZERO` and causing the drone to skip the THROWING phase entirely.
+### Why The First Fix Did Not Change The Retest
+
+There are two player implementations in this project:
+
+- `scripts/characters/player.gd`
+- `Scripts/Characters/Player.Grenade.cs` / `Scripts/Characters/Player.cs`
+
+The PR initially fixed only the GDScript implementation. The user's runtime was using the C# implementation, which directly sets grenade velocity and then calls GDScript grenade hooks. That C# code needed to call the GDScript method `set_aim_point` before the drone was unfrozen or launched.
 
 ---
 
-## Evidence
+## Additional Facts Checked Online
 
-### Game Log (lines 1190–1199)
-```
-[Player.Grenade.Simple] Throwing! Target: (666.0539, 1545.0447), Distance: 410.1, Speed: 496.0
-[GrenadeBase] Simple mode throw! Dir: (0.999999, 0.001552), Speed: 496.0
-[DroneGrenade] PILOTING phase started at (255.9691, 1544.408)   ← wrong state
-[DroneGrenade] Drone launched at (255.9691, 1544.408)
-```
-No `THROWING phase started` log line ever appears across the entire 2985-line log.
+Official Godot documentation confirms the interop assumptions used in the fix:
 
-### Code Search
-```
-$ grep -rn "set_aim_point" scripts/
-scripts/projectiles/drone_grenade.gd:143:func set_aim_point(world_pos: Vector2) -> void:
-```
-Zero call sites found — only the definition existed.
+- Godot C# projects can communicate with GDScript nodes through `Call(...)`; the cross-language scripting docs show C# calling a GDScript node method with `myGDScriptNode.Call("print_node_name", this)`:
+  https://docs.godotengine.org/en/3.3/getting_started/scripting/cross_language_scripting.html
+- Godot's C# docs note that `Get()`, `Set()`, `Call()` and `Connect()` rely on Godot API naming conventions, including `snake_case` names for dynamically called methods. This supports calling `"set_aim_point"` from C#:
+  https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_basics.html
+- `RigidBody2D.freeze` disables gravity and forces; setting the drone aim point before unfreezing avoids a fallback launch path running while the aim point is still unset:
+  https://docs.godotengine.org/en/stable/classes/class_rigidbody2d.html
 
 ---
 
 ## Fix Applied
 
-Two call sites added in `scripts/characters/player.gd`:
+### C# Runtime Path
 
-**1. Simple mode (`_throw_simple_grenade`, line ~1931):**
-```gdscript
-# Issue #1896: pass the mouse cursor world position so DroneGrenade can fly there first.
-if _active_grenade.has_method("set_aim_point"):
-    _active_grenade.set_aim_point(target_pos)
+`Scripts/Characters/Player.Grenade.cs` now passes the world-space throw target to any active grenade that implements `set_aim_point`:
+
+```csharp
+private void PassDroneThrowAimPoint(Vector2 aimPoint)
+{
+    if (_activeGrenade == null || !IsInstanceValid(_activeGrenade))
+    {
+        return;
+    }
+
+    if (_activeGrenade.HasMethod("set_aim_point"))
+    {
+        _activeGrenade.Call("set_aim_point", aimPoint);
+        LogToFile($"[Player.Grenade] Drone aim point set to {aimPoint}");
+    }
+}
 ```
 
-**2. Velocity-based mode (`_throw_grenade`, line ~2094):**
-```gdscript
-# Issue #1896: pass the mouse cursor world position so DroneGrenade can fly there first.
-if _active_grenade.has_method("set_aim_point"):
-    _active_grenade.set_aim_point(drag_end)
+The helper is called in both C# throw paths:
+
+- `ThrowSimpleGrenade()` passes `targetPos`.
+- `ThrowGrenade(Vector2 dragEnd)` passes `dragEnd`.
+
+Both calls happen after the safe spawn position is assigned and before `_activeGrenade.Freeze = false` / `throw_grenade_*` calls. That ordering prevents `DroneGrenade` from launching with `_aim_point == Vector2.Zero`.
+
+### Existing GDScript Path
+
+The previous fix remains in `scripts/characters/player.gd`, so both player implementations now pass the aim point.
+
+---
+
+## Tests
+
+`tests/unit/test_drone_grenade.gd` now covers:
+
+- Drone state machine behavior: aim point enters `THROWING`, reaches target then enters `PILOTING`, throw-phase collision explodes.
+- C# interop regression: `ThrowSimpleGrenade()` must call `PassDroneThrowAimPoint(targetPos)` before unfreezing and before `throw_grenade_simple`.
+- C# interop regression: `ThrowGrenade(Vector2 dragEnd)` must call `PassDroneThrowAimPoint(dragEnd)` before unfreezing and before `throw_grenade_with_direction`.
+- C# interop regression: helper must call the snake_case GDScript method `set_aim_point`.
+
+These tests fail against the earlier PR state because `Player.Grenade.cs` did not contain any `set_aim_point` handoff.
+
+---
+
+## Expected Runtime Signature After Fix
+
+For a successful drone throw, logs should show:
+
+```text
+[Player.Grenade] Drone aim point set to (...)
+[DroneGrenade] THROWING phase started toward (...)
+[DroneGrenade] Drone launched at (...)
 ```
 
-Both use `has_method()` guard so non-drone grenades are unaffected.
+Only after the drone reaches the throw target should it log:
+
+```text
+[DroneGrenade] Throw target reached — switching to PILOTING
+[DroneGrenade] PILOTING phase started at (...)
+```
+
+If the drone collides with a wall or enemy during the throw phase, expected logs include:
+
+```text
+[DroneGrenade] Throw collision with '...' — exploding!
+```
 
 ---
 
 ## Lessons Learned
 
-1. **New API methods on components must be wired up at every call site.** Adding `set_aim_point()` to `DroneGrenade` without adding a matching call in `player.gd` created a silent no-op.
-
-2. **Unit tests that test components in isolation can miss integration bugs.** The test called `set_aim_point()` directly; the real throwing code did not.
-
-3. **Log-first debugging is effective.** The game log provided an unambiguous trace: `PILOTING phase started` appearing immediately after throw (with no `THROWING phase started` line) pinpointed the issue within minutes.
-
-4. **Fallback-to-legacy patterns hide missing calls.** The "if `_aim_point == Vector2.ZERO`, start piloting immediately" fallback was added for backward compatibility but masked the missing caller setup — the drone silently fell back to old behavior with no warning.
+1. Component unit tests were not enough because they called `set_aim_point()` directly. The regression lived in the caller integration.
+2. This codebase has parallel GDScript and C# player paths. Gameplay fixes touching player behavior must check both.
+3. Log strings are useful runtime fingerprints. The `C# set velocity directly` line identified the actual implementation used in the user's exported build.
+4. Backward-compatible fallback behavior (`_aim_point == Vector2.ZERO` => immediate piloting) hid the missing caller setup. Future fallback paths should log enough state to distinguish intentional legacy behavior from missing setup.
 
 ---
 
@@ -124,6 +202,9 @@ Both use `has_method()` guard so non-drone grenades are unaffected.
 
 | File | Change |
 |------|--------|
-| `scripts/characters/player.gd` | Added `set_aim_point(target_pos)` call before throw in `_throw_simple_grenade()` and `set_aim_point(drag_end)` in `_throw_grenade()` |
-| `docs/case-studies/issue-1896/case-study.md` | This document |
-| `docs/case-studies/issue-1896/game_log_20260420_120715.txt` | Original game log from Jhon-Crow |
+| `scripts/projectiles/drone_grenade.gd` | Drone speed 400 -> 600 and throw/pilot state machine from the original implementation. |
+| `scripts/characters/player.gd` | GDScript player passes `set_aim_point()` before throw. |
+| `Scripts/Characters/Player.Grenade.cs` | C# player now passes `set_aim_point()` before unfreezing/calling grenade throw hooks. |
+| `tests/unit/test_drone_grenade.gd` | Added C# interop regression tests. |
+| `docs/case-studies/issue-1896/game_log_20260420_120715.txt` | First failed retest log preserved. |
+| `docs/case-studies/issue-1896/game_log_20260420_123426.txt` | Second failed retest log preserved. |

--- a/docs/case-studies/issue-1896/game_log_20260420_120715.txt
+++ b/docs/case-studies/issue-1896/game_log_20260420_120715.txt
@@ -1,0 +1,2985 @@
+[12:07:15] [INFO] ============================================================
+[12:07:15] [INFO] GAME LOG STARTED
+[12:07:15] [INFO] ============================================================
+[12:07:15] [INFO] Timestamp: 2026-04-20T12:07:15
+[12:07:15] [INFO] Log file: I:/Загрузки/godot exe/дрон/game_log_20260420_120715.txt
+[12:07:15] [INFO] Executable: I:/Загрузки/godot exe/дрон/Godot-Top-Down-Template.exe
+[12:07:15] [INFO] OS: Windows
+[12:07:15] [INFO] Debug build: false
+[12:07:15] [INFO] Engine version: 4.3-stable (official)
+[12:07:15] [INFO] Project: Godot Top-Down Template
+[12:07:15] [INFO] Build info: not available (build_info.cfg not found)
+[12:07:15] [INFO] ------------------------------------------------------------
+[12:07:15] [INFO] [GameManager] GameManager ready
+[12:07:15] [INFO] [ScoreManager] ScoreManager ready
+[12:07:15] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:07:15] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[12:07:15] [INFO] [DifficultyManager] Loaded difficulty: Gunslinger (value: 5)
+[12:07:15] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[12:07:15] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[12:07:15] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[12:07:15] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[12:07:15] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[12:07:15] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:07:15] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[12:07:15] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[12:07:15] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[12:07:15] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[12:07:15] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[12:07:15] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[12:07:15] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[12:07:15] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:07:15] [INFO] [LastChance] Last chance shader loaded successfully
+[12:07:15] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[12:07:15] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[12:07:15] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[12:07:15] [INFO] [LastChance]   Sepia intensity: 0.70
+[12:07:15] [INFO] [LastChance]   Brightness: 0.60
+[12:07:15] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[12:07:15] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[12:07:15] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[12:07:15] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[12:07:15] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DroneGrenade.tscn
+[12:07:15] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: false, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: false, FPS drop logging: true, All weapons unlocked: false, All maps unlocked: true, Global stuck max time: 20.0s, Nav mesh visible: false, Search path visible: false, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false, Enemy path visible: false, Cover raycast visible: false, Tactical group: false, Cover infinite rays: true, Cover sector rays: true, Roguelike unlocked: false
+[12:07:15] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[12:07:15] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.50, music: 1.00
+[12:07:15] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true, revolver_aim_assist: true, unlock_notifications: true, combo_font_size: 140
+[12:07:15] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[12:07:15] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[12:07:15] [INFO] [CinemaEffects] Created effects layer at layer 99
+[12:07:15] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[12:07:15] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[12:07:15] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[12:07:15] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[12:07:15] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[12:07:15] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[12:07:15] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[12:07:15] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[12:07:15] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[12:07:15] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[12:07:15] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[12:07:15] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[12:07:15] [INFO] [GrenadeTimerHelper] Autoload ready
+[12:07:15] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:07:15] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[12:07:15] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[12:07:15] [INFO] [PowerFantasy]   Kill effect duration: 600ms
+[12:07:15] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[12:07:15] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[12:07:15] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[12:07:15] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[12:07:15] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[12:07:15] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[12:07:15] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[12:07:15] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[12:07:15] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[12:07:15] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[12:07:15] [INFO] [ProgressManager] ProgressManager ready, loaded 4 entries
+[12:07:15] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[12:07:15] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:07:15] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[12:07:15] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[12:07:15] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[12:07:15] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[12:07:15] [INFO] [SceneLoader] SceneLoader initialized
+[12:07:15] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[12:07:15] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[12:07:15] [INFO] [PersistManager] Restored unlocked weapon: mini_uzi
+[12:07:15] [INFO] [PersistManager] Restored kills_without_laser_sight: 55
+[12:07:15] [INFO] [PersistManager] Restored shots_fired_special_weapons: 0
+[12:07:15] [INFO] [PersistManager] Restored total_deaths: 1
+[12:07:15] [INFO] [PersistManager] Restored no_damage_levels_completed: 1
+[12:07:15] [INFO] [PersistManager] Restored levels_completed_rank_a_or_higher: 4
+[12:07:15] [INFO] [PersistManager] Restored kills_through_wall: 0
+[12:07:15] [INFO] [PersistManager] Restored levels_completed_with_silenced_pistol: 0
+[12:07:15] [INFO] [GameManager] Weapon selected: ak_gl
+[12:07:15] [INFO] [PersistManager] Restored selected weapon: ak_gl
+[12:07:15] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[12:07:15] [INFO] [PersistManager] Restored unlocked grenade type: 4
+[12:07:15] [INFO] [PersistManager] Restored selected grenade type: 0
+[12:07:15] [INFO] [PersistManager] Restored unlocked active item type: 0
+[12:07:15] [INFO] [PersistManager] Restored unlocked active item type: 11
+[12:07:15] [INFO] [PersistManager] Restored selected active item type: 0
+[12:07:15] [INFO] [PersistManager] Loudspeaker progress restored: level 1, levels_completed=0
+[12:07:15] [INFO] [PersistManager] State loaded successfully
+[12:07:15] [INFO] [PersistManager] PersistManager ready
+[12:07:15] [INFO] [UnlockManager] UnlockManager ready
+[12:07:15] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["makarov_pm", "silenced_pistol", "ak_gl", "sniper", "revolver", "shotgun"]
+[12:07:15] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, warm_lights: true, ai: true
+[12:07:15] [INFO] [LocalizationSettings] Loaded 2 translation(s)
+[12:07:15] [INFO] [LocalizationSettings] LocalizationSettings initialized — locale: en
+[12:07:15] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_condition
+[12:07:15] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_kill_condition
+[12:07:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:15] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[12:07:15] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[12:07:15] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[12:07:15] [ENEMY] [Enemy1] Death animation component initialized
+[12:07:15] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[12:07:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:15] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[12:07:15] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[12:07:15] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[12:07:15] [ENEMY] [Enemy2] Death animation component initialized
+[12:07:15] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[12:07:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:15] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[12:07:15] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[12:07:15] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[12:07:15] [ENEMY] [Enemy3] Death animation component initialized
+[12:07:15] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[12:07:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:15] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[12:07:15] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[12:07:15] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[12:07:15] [ENEMY] [Enemy4] Death animation component initialized
+[12:07:15] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[12:07:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:15] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[12:07:15] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[12:07:15] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[12:07:15] [ENEMY] [Enemy5] Death animation component initialized
+[12:07:15] [ENEMY] [Enemy5] [Gunslinger] Enemy glow applied
+[12:07:15] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:15] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:07:15] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:07:15] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:07:15] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[12:07:15] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:07:15] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:07:15] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:07:15] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:07:15] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:07:15] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:07:15] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:07:15] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:07:15] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:07:15] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[12:07:15] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:07:15] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:07:15] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:07:15] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:07:15] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:07:15] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:07:15] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:07:15] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:07:15] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:07:15] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:07:15] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:07:15] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:07:15] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:07:15] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:07:15] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:07:15] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:07:15] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:07:15] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:07:15] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:07:15] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:07:15] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:07:15] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:07:15] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:07:15] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:07:15] [INFO] [Player.Jammer] JammerHUD initialized
+[12:07:15] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:07:15] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[12:07:15] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:07:15] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[12:07:15] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[12:07:15] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[12:07:15] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[12:07:15] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[12:07:15] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[12:07:15] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[12:07:15] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[12:07:15] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[12:07:15] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[12:07:15] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/210
+[12:07:15] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[12:07:15] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/210
+[12:07:15] [INFO] [GameManager] set_player() called with: <CharacterBody2D#86922757902> (class: CharacterBody2D)
+[12:07:15] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:07:15] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:07:15] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:07:15] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:07:15] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[12:07:15] [INFO] [ScoreManager] Level started with 5 enemies
+[12:07:15] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[12:07:16] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[12:07:16] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[12:07:16] [INFO] [ReplayManager] Replay data cleared
+[12:07:16] [INFO] [LabyrinthLevel] Previous replay data cleared
+[12:07:16] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:07:16] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:07:16] [INFO] [ReplayManager] Level: LabyrinthLevel
+[12:07:16] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:07:16] [INFO] [ReplayManager] Enemies count: 5
+[12:07:16] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:07:16] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[12:07:16] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[12:07:16] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[12:07:16] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[12:07:16] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[12:07:16] [INFO] [LabyrinthLevel] Replay recording started successfully
+[12:07:16] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[12:07:16] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[12:07:16] [INFO] [CinemaEffects] Found player node: Player
+[12:07:16] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:07:16] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/BuildingLevel.tscn
+[12:07:16] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/BuildingLevel.tscn
+[12:07:16] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[12:07:16] [INFO] [UnlockManager] Restored saved unlock for weapon: mini_uzi
+[12:07:16] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[12:07:16] [INFO] [UnlockManager] Skipped restore for weapon 'ak_gl' (condition not met — treating as corrupt save)
+[12:07:16] [INFO] [UnlockManager] Restored saved unlock for grenade type: 4
+[12:07:16] [INFO] [UnlockNotificationManager] Suppressed 5 already-available startup unlock notification(s)
+[12:07:16] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[12:07:16] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[12:07:16] [ENEMY] [Enemy1] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[12:07:16] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[12:07:16] [ENEMY] [Enemy2] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[12:07:16] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[12:07:16] [ENEMY] [Enemy3] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[12:07:16] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[12:07:16] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[12:07:16] [ENEMY] [Enemy4] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[12:07:16] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[12:07:16] [ENEMY] [Enemy5] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 1, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:07:16] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:07:16] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:07:16] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:07:16] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=315.0°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:07:16] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:07:16] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:07:16] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:07:16] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:07:16] [INFO] [PenultimateHit] Shader warmup complete in 1238 ms
+[12:07:16] [INFO] [LastChance] Shader warmup complete in 1237 ms
+[12:07:16] [INFO] [CinemaEffects] Cinema shader warmup complete in 1116 ms
+[12:07:16] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1107 ms
+[12:07:16] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[12:07:16] [INFO] [FlashbangPlayer] Shader warmup complete in 1104 ms
+[12:07:16] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:07:16] [INFO] [SceneLoader] ERROR: Invalid resource (falling back to sync): res://scenes/levels/BuildingLevel.tscn
+[12:07:16] [INFO] [SceneLoader] Using synchronous load fallback
+[12:07:16] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[12:07:16] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[12:07:16] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[12:07:16] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[12:07:16] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[12:07:16] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:16] [INFO] [SceneLoader] Sync fallback scene changed successfully: res://scenes/levels/BuildingLevel.tscn
+[12:07:16] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[12:07:16] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:07:16] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:16] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:07:16] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:07:16] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[12:07:16] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:07:16] [INFO] [BlackMetalEffectsManager] Scene changed to: BuildingLevel
+[12:07:16] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:07:16] [INFO] [PersistManager] Startup navigation complete — arrived at: res://scenes/levels/BuildingLevel.tscn
+[12:07:16] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:16] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/BuildingLevel.tscn
+[12:07:16] [ENEMY] [Enemy1] Death animation component initialized
+[12:07:16] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[12:07:16] [ENEMY] [Enemy2] Death animation component initialized
+[12:07:16] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[12:07:16] [ENEMY] [Enemy3] Death animation component initialized
+[12:07:16] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[12:07:16] [ENEMY] [Enemy4] Death animation component initialized
+[12:07:16] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[12:07:16] [ENEMY] [Grenadier] Death animation component initialized
+[12:07:16] [ENEMY] [Grenadier] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[12:07:16] [ENEMY] [Enemy6] Death animation component initialized
+[12:07:16] [ENEMY] [Enemy6] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[12:07:16] [ENEMY] [Enemy7] Death animation component initialized
+[12:07:16] [ENEMY] [Enemy7] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[12:07:16] [ENEMY] [Enemy8] Death animation component initialized
+[12:07:16] [ENEMY] [Enemy8] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[12:07:16] [ENEMY] [Enemy9] Death animation component initialized
+[12:07:16] [ENEMY] [Enemy9] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[12:07:16] [ENEMY] [Enemy10] Death animation component initialized
+[12:07:16] [ENEMY] [Enemy10] [Gunslinger] Enemy glow applied
+[12:07:16] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:16] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:07:16] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:07:16] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:07:16] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[12:07:16] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:07:16] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:07:16] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:07:16] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:07:16] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:07:16] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:07:16] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:07:16] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:07:16] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:07:16] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[12:07:16] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:07:16] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:07:16] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:07:16] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:07:16] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:07:16] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:07:16] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:07:16] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:07:16] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:07:16] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:07:16] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:07:16] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:07:16] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:07:16] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:07:16] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:07:16] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:07:16] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:07:16] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:07:16] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:07:16] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:07:16] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:07:16] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:07:16] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:07:16] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:07:16] [INFO] [Player.Jammer] JammerHUD initialized
+[12:07:16] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:07:16] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[12:07:16] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:07:16] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:07:16] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:07:16] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[12:07:16] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[12:07:16] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[12:07:16] [INFO] [CinemaEffects] Found player node: Player
+[12:07:16] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[12:07:16] [ENEMY] [Enemy1] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 2, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[12:07:16] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[12:07:16] [ENEMY] [Enemy2] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 1, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[12:07:16] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[12:07:16] [ENEMY] [Enemy3] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 1, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[12:07:16] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[12:07:16] [ENEMY] [Enemy4] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 1, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[12:07:16] [INFO] [BloodyFeet:Grenadier] Snow surface detector created on Grenadier
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[12:07:16] [ENEMY] [Grenadier] Registered as sound listener
+[12:07:16] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 1, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[12:07:16] [INFO] [BloodyFeet:Enemy6] Snow surface detector created on Enemy6
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[12:07:16] [ENEMY] [Enemy6] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[12:07:16] [INFO] [BloodyFeet:Enemy7] Snow surface detector created on Enemy7
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[12:07:16] [ENEMY] [Enemy7] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy7] Spawned at (1700, 870), hp: 1, behavior: PATROL
+[12:07:16] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[12:07:16] [INFO] [BloodyFeet:Enemy8] Snow surface detector created on Enemy8
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[12:07:16] [ENEMY] [Enemy8] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 1, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[12:07:16] [INFO] [BloodyFeet:Enemy9] Snow surface detector created on Enemy9
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[12:07:16] [ENEMY] [Enemy9] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[12:07:16] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[12:07:16] [INFO] [BloodyFeet:Enemy10] Snow surface detector created on Enemy10
+[12:07:16] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[12:07:16] [ENEMY] [Enemy10] Registered as sound listener
+[12:07:16] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 1, behavior: PATROL
+[12:07:16] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:07:16] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:07:16] [INFO] [LevelInitFallback] ConfigureBuildingCameraLimits: limits set — left=64 top=64 right=2464 bottom=2064 — Issue #1684
+[12:07:16] [INFO] [LevelInitFallback] GDScript _ready() did NOT execute - performing C# fallback initialization
+[12:07:16] [INFO] [LevelInitFallback] Полигон loaded (C# fallback) - Tactical Combat Arena
+[12:07:16] [INFO] [LevelInitFallback] Found Environment/Enemies node with 10 children
+[12:07:16] [INFO] [LevelInitFallback] Child 'Enemy1': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Child 'Enemy2': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Child 'Enemy3': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Child 'Enemy4': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Child 'Grenadier': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Child 'Enemy6': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Child 'Enemy7': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Child 'Enemy8': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Child 'Enemy9': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Child 'Enemy10': has_died_signal=True
+[12:07:16] [INFO] [LevelInitFallback] Enemy tracking complete: 10 enemies registered
+[12:07:16] [INFO] [LevelInitFallback] Realistic visibility component added to player (night mode)
+[12:07:16] [INFO] [GameManager] set_player() called with: <CharacterBody2D#154350390998> (class: CharacterBody2D)
+[12:07:16] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:07:16] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:07:16] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:07:16] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:07:16] [INFO] [LevelInitFallback] HUD ammo refreshed (fallback initial weapon setup): AKGL 30/450
+[12:07:16] [INFO] [LevelInitFallback] BuildingLevel: Power Fantasy mode - AKGL magazines multiplied by 4x
+[12:07:16] [INFO] [LevelInitFallback] BuildingLevel: AKGL magazines reinitialized to 8 (C# fallback)
+[12:07:16] [INFO] [LevelInitFallback] HUD ammo refreshed (level-specific fallback ammo config): AKGL 30/210
+[12:07:16] [INFO] [LevelInitFallback] Re-applied auto-reload magazine reduction after fallback ammo config for AKGL
+[12:07:16] [INFO] [LevelInitFallback] HUD ammo refreshed (post fallback level ammo config): AKGL 30/210
+[12:07:16] [INFO] [LevelInitFallback] HUD ammo refreshed (post fallback debug UI setup): AKGL 30/210
+[12:07:16] [INFO] [ScoreManager] Level started with 10 enemies
+[12:07:16] [INFO] [LevelInitFallback] ScoreManager initialized with 10 enemies
+[12:07:16] [INFO] [LevelInitFallback] Exit zone created at position (120, 1250)
+[12:07:16] [INFO] [ReplayManager] Replay data cleared
+[12:07:16] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:07:16] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:07:16] [INFO] [ReplayManager] Level: BuildingLevel
+[12:07:16] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:07:16] [INFO] [ReplayManager] Enemies count: 10
+[12:07:16] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:07:16] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[12:07:16] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[12:07:16] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[12:07:16] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[12:07:16] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[12:07:16] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[12:07:16] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[12:07:16] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[12:07:16] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[12:07:16] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[12:07:16] [INFO] [LevelInitFallback] Replay recording started with 10 enemies
+[12:07:16] [INFO] [LevelInitFallback] Weapon hints component already exists - skipping fallback setup
+[12:07:16] [INFO] [LevelInitFallback] GDScript properties synced
+[12:07:16] [INFO] [LevelInitFallback] Warm ceiling lights placed in all rooms (C# fallback)
+[12:07:17] [INFO] [LevelInitFallback] Baking navigation mesh (C# fallback)...
+[12:07:17] [INFO] [LevelInitFallback] Navigation mesh baked successfully (C# fallback) — poly_count=97, vertex_count=138
+[12:07:17] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[12:07:17] [ENEMY] [Enemy10] Patrol points snapped to navmesh (Issue #1216)
+[12:07:17] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[12:07:17] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[12:07:17] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[12:07:17] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[12:07:17] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[12:07:17] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[12:07:17] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:07:17] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:07:17] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:07:17] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:07:17] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:07:17] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:07:17] [INFO] [LastChance] Found player: Player
+[12:07:17] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:07:17] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:07:17] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:07:17] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:07:17] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 1933 ms
+[12:07:17] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[12:07:18] [ENEMY] [Enemy10] ROT_CHANGE: none -> P4:velocity, state=IDLE, target=0.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[12:07:18] [ENEMY] [Enemy10] PATROL corner check: angle 90.0°
+[12:07:18] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=0.0°, player=(450,1250), corner_timer=0.30
+[12:07:18] [INFO] [Player] Invincibility mode: ON
+[12:07:18] [INFO] [GameManager] Invincibility mode toggled: ON
+[12:07:18] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[12:07:19] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=54.4°, player=(450,1250), corner_timer=-0.02
+[12:07:19] [ENEMY] [Enemy10] PATROL corner check: angle -90.0°
+[12:07:19] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=51.6°, player=(450,1250), corner_timer=0.30
+[12:07:19] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[12:07:20] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[12:07:21] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[12:07:22] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:22] [INFO] [PersistManager] Last level saved: res://scenes/levels/TestTier.tscn
+[12:07:22] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/TestTier.tscn
+[12:07:22] [INFO] [SceneLoader] Background load started successfully
+[12:07:22] [INFO] [SceneLoader] Background load complete: res://scenes/levels/TestTier.tscn
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Enemy10 (remaining: 9)
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Enemy9 (remaining: 8)
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Enemy8 (remaining: 7)
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Enemy7 (remaining: 6)
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Enemy6 (remaining: 5)
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Grenadier (remaining: 4)
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[12:07:22] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[12:07:22] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:22] [INFO] [SceneLoader] Scene changed successfully
+[12:07:22] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy1] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy1] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy1] BloodyFeetComponent ready on GuardEnemy1
+[12:07:22] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:07:22] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:22] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:07:22] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:07:22] [INFO] [CinemaEffects] Scene changed to: TestTier
+[12:07:22] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:07:22] [INFO] [BlackMetalEffectsManager] Scene changed to: TestTier
+[12:07:22] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:07:22] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:22] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/TestTier.tscn
+[12:07:22] [ENEMY] [GuardEnemy1] Death animation component initialized
+[12:07:22] [ENEMY] [GuardEnemy1] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy2] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy2] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy2] BloodyFeetComponent ready on GuardEnemy2
+[12:07:22] [ENEMY] [GuardEnemy2] Death animation component initialized
+[12:07:22] [ENEMY] [GuardEnemy2] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy3] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy3] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy3] BloodyFeetComponent ready on GuardEnemy3
+[12:07:22] [ENEMY] [GuardEnemy3] Death animation component initialized
+[12:07:22] [ENEMY] [GuardEnemy3] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy4] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy4] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy4] BloodyFeetComponent ready on GuardEnemy4
+[12:07:22] [ENEMY] [GuardEnemy4] Death animation component initialized
+[12:07:22] [ENEMY] [GuardEnemy4] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy5] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy5] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy5] BloodyFeetComponent ready on GuardEnemy5
+[12:07:22] [ENEMY] [GuardEnemy5] Death animation component initialized
+[12:07:22] [ENEMY] [GuardEnemy5] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy6] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy6] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy6] BloodyFeetComponent ready on GuardEnemy6
+[12:07:22] [ENEMY] [GuardEnemy6] Death animation component initialized
+[12:07:22] [ENEMY] [GuardEnemy6] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy1] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy1] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy1] BloodyFeetComponent ready on PatrolEnemy1
+[12:07:22] [ENEMY] [PatrolEnemy1] Death animation component initialized
+[12:07:22] [ENEMY] [PatrolEnemy1] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy2] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy2] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy2] BloodyFeetComponent ready on PatrolEnemy2
+[12:07:22] [ENEMY] [PatrolEnemy2] Death animation component initialized
+[12:07:22] [ENEMY] [PatrolEnemy2] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy3] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy3] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy3] BloodyFeetComponent ready on PatrolEnemy3
+[12:07:22] [ENEMY] [PatrolEnemy3] Death animation component initialized
+[12:07:22] [ENEMY] [PatrolEnemy3] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy4] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy4] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy4] BloodyFeetComponent ready on PatrolEnemy4
+[12:07:22] [ENEMY] [PatrolEnemy4] Death animation component initialized
+[12:07:22] [ENEMY] [PatrolEnemy4] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy1] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy1] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy1] BloodyFeetComponent ready on RpgEnemy1
+[12:07:22] [ENEMY] [RpgEnemy1] Death animation component initialized
+[12:07:22] [ENEMY] [RpgEnemy1] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy2] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy2] Found EnemyModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy2] BloodyFeetComponent ready on RpgEnemy2
+[12:07:22] [ENEMY] [RpgEnemy2] Death animation component initialized
+[12:07:22] [ENEMY] [RpgEnemy2] [Gunslinger] Enemy glow applied
+[12:07:22] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:22] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:07:22] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:07:22] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:07:22] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Flashbang
+[12:07:22] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:07:22] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:07:22] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:07:22] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:07:22] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:07:22] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:07:22] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:07:22] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:07:22] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:07:22] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[12:07:22] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:07:22] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:07:22] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:07:22] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:07:22] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:07:22] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:07:22] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:07:22] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:07:22] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:07:22] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:07:22] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:07:22] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:07:22] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:07:22] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:07:22] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:07:22] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:07:22] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:07:22] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:07:22] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:07:22] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:07:22] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:07:22] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:07:22] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:07:22] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:07:22] [INFO] [Player.Jammer] JammerHUD initialized
+[12:07:22] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:07:22] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[12:07:22] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:07:22] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:07:22] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:07:22] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[12:07:22] [INFO] [GameManager] set_player() called with: <CharacterBody2D#253000423057> (class: CharacterBody2D)
+[12:07:22] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:07:22] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:07:22] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:07:22] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:07:22] [INFO] [ScoreManager] Level started with 12 enemies
+[12:07:22] [INFO] [TestTier] ReplayManager found as C# autoload - verified OK
+[12:07:22] [INFO] [ReplayManager] Replay data cleared
+[12:07:22] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:07:22] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:07:22] [INFO] [ReplayManager] Level: TestTier
+[12:07:22] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:07:22] [INFO] [ReplayManager] Enemies count: 12
+[12:07:22] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:07:22] [INFO] [ReplayManager]   Enemy 0: GuardEnemy1
+[12:07:22] [INFO] [ReplayManager]   Enemy 1: GuardEnemy2
+[12:07:22] [INFO] [ReplayManager]   Enemy 2: GuardEnemy3
+[12:07:22] [INFO] [ReplayManager]   Enemy 3: GuardEnemy4
+[12:07:22] [INFO] [ReplayManager]   Enemy 4: GuardEnemy5
+[12:07:22] [INFO] [ReplayManager]   Enemy 5: GuardEnemy6
+[12:07:22] [INFO] [ReplayManager]   Enemy 6: PatrolEnemy1
+[12:07:22] [INFO] [ReplayManager]   Enemy 7: PatrolEnemy2
+[12:07:22] [INFO] [ReplayManager]   Enemy 8: PatrolEnemy3
+[12:07:22] [INFO] [ReplayManager]   Enemy 9: PatrolEnemy4
+[12:07:22] [INFO] [ReplayManager]   Enemy 10: RpgEnemy1
+[12:07:22] [INFO] [ReplayManager]   Enemy 11: RpgEnemy2
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy1] Blood detector created and attached to GuardEnemy1
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy1] Snow surface detector created on GuardEnemy1
+[12:07:22] [INFO] [CinemaEffects] Found player node: Player
+[12:07:22] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:07:22] [INFO] [SoundPropagation] Registered listener: GuardEnemy1 (total: 1)
+[12:07:22] [ENEMY] [GuardEnemy1] Registered as sound listener
+[12:07:22] [ENEMY] [GuardEnemy1] Spawned at (2800, 600), hp: 1, behavior: GUARD
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy2] Blood detector created and attached to GuardEnemy2
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy2] Snow surface detector created on GuardEnemy2
+[12:07:22] [INFO] [SoundPropagation] Registered listener: GuardEnemy2 (total: 2)
+[12:07:22] [ENEMY] [GuardEnemy2] Registered as sound listener
+[12:07:22] [ENEMY] [GuardEnemy2] Spawned at (2800, 1000), hp: 1, behavior: GUARD
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy3] Blood detector created and attached to GuardEnemy3
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy3] Snow surface detector created on GuardEnemy3
+[12:07:22] [INFO] [SoundPropagation] Registered listener: GuardEnemy3 (total: 3)
+[12:07:22] [ENEMY] [GuardEnemy3] Registered as sound listener
+[12:07:22] [ENEMY] [GuardEnemy3] Spawned at (3400, 600), hp: 1, behavior: GUARD
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy4] Blood detector created and attached to GuardEnemy4
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy4] Snow surface detector created on GuardEnemy4
+[12:07:22] [INFO] [SoundPropagation] Registered listener: GuardEnemy4 (total: 4)
+[12:07:22] [ENEMY] [GuardEnemy4] Registered as sound listener
+[12:07:22] [ENEMY] [GuardEnemy4] Spawned at (3400, 1000), hp: 2, behavior: GUARD
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy5] Blood detector created and attached to GuardEnemy5
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy5] Snow surface detector created on GuardEnemy5
+[12:07:22] [INFO] [SoundPropagation] Registered listener: GuardEnemy5 (total: 5)
+[12:07:22] [ENEMY] [GuardEnemy5] Registered as sound listener
+[12:07:22] [ENEMY] [GuardEnemy5] Spawned at (3000, 2100), hp: 1, behavior: GUARD
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy6] Blood detector created and attached to GuardEnemy6
+[12:07:22] [INFO] [BloodyFeet:GuardEnemy6] Snow surface detector created on GuardEnemy6
+[12:07:22] [INFO] [SoundPropagation] Registered listener: GuardEnemy6 (total: 6)
+[12:07:22] [ENEMY] [GuardEnemy6] Registered as sound listener
+[12:07:22] [ENEMY] [GuardEnemy6] Spawned at (3000, 2400), hp: 1, behavior: GUARD
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy1] Blood detector created and attached to PatrolEnemy1
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy1] Snow surface detector created on PatrolEnemy1
+[12:07:22] [INFO] [SoundPropagation] Registered listener: PatrolEnemy1 (total: 7)
+[12:07:22] [ENEMY] [PatrolEnemy1] Registered as sound listener
+[12:07:22] [ENEMY] [PatrolEnemy1] Spawned at (2400, 800), hp: 1, behavior: PATROL
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy2] Blood detector created and attached to PatrolEnemy2
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy2] Snow surface detector created on PatrolEnemy2
+[12:07:22] [INFO] [SoundPropagation] Registered listener: PatrolEnemy2 (total: 8)
+[12:07:22] [ENEMY] [PatrolEnemy2] Registered as sound listener
+[12:07:22] [ENEMY] [PatrolEnemy2] Spawned at (2400, 2300), hp: 1, behavior: PATROL
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy3] Blood detector created and attached to PatrolEnemy3
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy3] Snow surface detector created on PatrolEnemy3
+[12:07:22] [INFO] [SoundPropagation] Registered listener: PatrolEnemy3 (total: 9)
+[12:07:22] [ENEMY] [PatrolEnemy3] Registered as sound listener
+[12:07:22] [ENEMY] [PatrolEnemy3] Spawned at (2800, 1544), hp: 1, behavior: PATROL
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy4] Blood detector created and attached to PatrolEnemy4
+[12:07:22] [INFO] [BloodyFeet:PatrolEnemy4] Snow surface detector created on PatrolEnemy4
+[12:07:22] [INFO] [SoundPropagation] Registered listener: PatrolEnemy4 (total: 10)
+[12:07:22] [ENEMY] [PatrolEnemy4] Registered as sound listener
+[12:07:22] [ENEMY] [PatrolEnemy4] Spawned at (3600, 1544), hp: 2, behavior: PATROL
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy1] Blood detector created and attached to RpgEnemy1
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy1] Snow surface detector created on RpgEnemy1
+[12:07:22] [INFO] [SoundPropagation] Registered listener: RpgEnemy1 (total: 11)
+[12:07:22] [ENEMY] [RpgEnemy1] Registered as sound listener
+[12:07:22] [ENEMY] [RpgEnemy1] Spawned at (3700, 1400), hp: 1, behavior: GUARD
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy2] Blood detector created and attached to RpgEnemy2
+[12:07:22] [INFO] [BloodyFeet:RpgEnemy2] Snow surface detector created on RpgEnemy2
+[12:07:22] [INFO] [SoundPropagation] Registered listener: RpgEnemy2 (total: 12)
+[12:07:22] [ENEMY] [RpgEnemy2] Registered as sound listener
+[12:07:22] [ENEMY] [RpgEnemy2] Spawned at (2000, 2200), hp: 1, behavior: GUARD
+[12:07:22] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:07:22] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:07:22] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 12) - skipping fallback
+[12:07:22] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=12
+[12:07:22] [ENEMY] [PatrolEnemy2] Patrol points snapped to navmesh (Issue #1216)
+[12:07:22] [ENEMY] [PatrolEnemy3] Patrol points snapped to navmesh (Issue #1216)
+[12:07:22] [ENEMY] [PatrolEnemy4] Patrol points snapped to navmesh (Issue #1216)
+[12:07:22] [ENEMY] [GuardEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:22] [ENEMY] [GuardEnemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:22] [ENEMY] [GuardEnemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:22] [ENEMY] [GuardEnemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:22] [ENEMY] [RpgEnemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:22] [ENEMY] [RpgEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:22] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:07:22] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:07:22] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:07:22] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:07:22] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:07:22] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:07:22] [INFO] [LastChance] Found player: Player
+[12:07:22] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:07:22] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:07:22] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:07:22] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:07:23] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=12
+[12:07:24] [INFO] [PauseMenu] Armory button pressed
+[12:07:24] [INFO] [PauseMenu] Creating new armory menu instance
+[12:07:24] [INFO] [PauseMenu] armory_menu_scene resource path: res://scenes/ui/ArmoryMenu.tscn
+[12:07:24] [INFO] [PauseMenu] Instance created, class: CanvasLayer, name: ArmoryMenu
+[12:07:24] [INFO] [PauseMenu] Script attached: res://scripts/ui/armory_menu.gd
+[12:07:24] [INFO] [PauseMenu] back_pressed signal exists on instance
+[12:07:24] [INFO] [PauseMenu] back_pressed signal connected
+[12:07:24] [INFO] [ArmoryMenu] weapon=ak_gl caliber_name=7.62x39mm
+[12:07:24] [INFO] [PauseMenu] Armory menu instance added as child, is_inside_tree: true
+[12:07:24] [INFO] [PauseMenu] _populate_weapon_grid method exists
+[12:07:24] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=12
+[12:07:25] [INFO] [ArmoryMenu] weapon=ak_gl caliber_name=7.62x39mm
+[12:07:25] [INFO] [GrenadeManager] Grenade type changed from Flashbang to Drone
+[12:07:25] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:25] [INFO] [GameManager] restart_scene() — starting scene reload
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy2 (remaining: 11)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy1 (remaining: 10)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy4 (remaining: 9)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy3 (remaining: 8)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy2 (remaining: 7)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy1 (remaining: 6)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy6 (remaining: 5)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy5 (remaining: 4)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy4 (remaining: 3)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy3 (remaining: 2)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy2 (remaining: 1)
+[12:07:25] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy1 (remaining: 0)
+[12:07:25] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:25] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=12
+[12:07:25] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=12
+[12:07:25] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=12
+[12:07:25] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:07:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy1] Footprint scene loaded
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy1] Found EnemyModel for facing direction
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy1] BloodyFeetComponent ready on GuardEnemy1
+[12:07:25] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:07:25] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:25] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:07:25] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:07:25] [INFO] [CinemaEffects] Scene changed to: TestTier
+[12:07:25] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:07:25] [INFO] [BlackMetalEffectsManager] Scene changed to: TestTier
+[12:07:25] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:07:25] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:25] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/TestTier.tscn
+[12:07:25] [ENEMY] [GuardEnemy1] Death animation component initialized
+[12:07:25] [ENEMY] [GuardEnemy1] [Gunslinger] Enemy glow applied
+[12:07:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy2] Footprint scene loaded
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy2] Found EnemyModel for facing direction
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy2] BloodyFeetComponent ready on GuardEnemy2
+[12:07:25] [ENEMY] [GuardEnemy2] Death animation component initialized
+[12:07:25] [ENEMY] [GuardEnemy2] [Gunslinger] Enemy glow applied
+[12:07:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy3] Footprint scene loaded
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy3] Found EnemyModel for facing direction
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy3] BloodyFeetComponent ready on GuardEnemy3
+[12:07:25] [ENEMY] [GuardEnemy3] Death animation component initialized
+[12:07:25] [ENEMY] [GuardEnemy3] [Gunslinger] Enemy glow applied
+[12:07:25] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy4] Footprint scene loaded
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy4] Found EnemyModel for facing direction
+[12:07:25] [INFO] [BloodyFeet:GuardEnemy4] BloodyFeetComponent ready on GuardEnemy4
+[12:07:26] [ENEMY] [GuardEnemy4] Death animation component initialized
+[12:07:26] [ENEMY] [GuardEnemy4] [Gunslinger] Enemy glow applied
+[12:07:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy5] Footprint scene loaded
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy5] Found EnemyModel for facing direction
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy5] BloodyFeetComponent ready on GuardEnemy5
+[12:07:26] [ENEMY] [GuardEnemy5] Death animation component initialized
+[12:07:26] [ENEMY] [GuardEnemy5] [Gunslinger] Enemy glow applied
+[12:07:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy6] Footprint scene loaded
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy6] Found EnemyModel for facing direction
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy6] BloodyFeetComponent ready on GuardEnemy6
+[12:07:26] [ENEMY] [GuardEnemy6] Death animation component initialized
+[12:07:26] [ENEMY] [GuardEnemy6] [Gunslinger] Enemy glow applied
+[12:07:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy1] Footprint scene loaded
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy1] Found EnemyModel for facing direction
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy1] BloodyFeetComponent ready on PatrolEnemy1
+[12:07:26] [ENEMY] [PatrolEnemy1] Death animation component initialized
+[12:07:26] [ENEMY] [PatrolEnemy1] [Gunslinger] Enemy glow applied
+[12:07:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy2] Footprint scene loaded
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy2] Found EnemyModel for facing direction
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy2] BloodyFeetComponent ready on PatrolEnemy2
+[12:07:26] [ENEMY] [PatrolEnemy2] Death animation component initialized
+[12:07:26] [ENEMY] [PatrolEnemy2] [Gunslinger] Enemy glow applied
+[12:07:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy3] Footprint scene loaded
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy3] Found EnemyModel for facing direction
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy3] BloodyFeetComponent ready on PatrolEnemy3
+[12:07:26] [ENEMY] [PatrolEnemy3] Death animation component initialized
+[12:07:26] [ENEMY] [PatrolEnemy3] [Gunslinger] Enemy glow applied
+[12:07:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy4] Footprint scene loaded
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy4] Found EnemyModel for facing direction
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy4] BloodyFeetComponent ready on PatrolEnemy4
+[12:07:26] [ENEMY] [PatrolEnemy4] Death animation component initialized
+[12:07:26] [ENEMY] [PatrolEnemy4] [Gunslinger] Enemy glow applied
+[12:07:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy1] Footprint scene loaded
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy1] Found EnemyModel for facing direction
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy1] BloodyFeetComponent ready on RpgEnemy1
+[12:07:26] [ENEMY] [RpgEnemy1] Death animation component initialized
+[12:07:26] [ENEMY] [RpgEnemy1] [Gunslinger] Enemy glow applied
+[12:07:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy2] Footprint scene loaded
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy2] Found EnemyModel for facing direction
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy2] BloodyFeetComponent ready on RpgEnemy2
+[12:07:26] [ENEMY] [RpgEnemy2] Death animation component initialized
+[12:07:26] [ENEMY] [RpgEnemy2] [Gunslinger] Enemy glow applied
+[12:07:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:26] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:07:26] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:07:26] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:07:26] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:07:26] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:07:26] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:07:26] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:07:26] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:07:26] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:07:26] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:07:26] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:07:26] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:07:26] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:07:26] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[12:07:26] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:07:26] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:07:26] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:07:26] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:07:26] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:07:26] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:07:26] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:07:26] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:07:26] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:07:26] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:07:26] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:07:26] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:07:26] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:07:26] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:07:26] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:07:26] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:07:26] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:07:26] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:07:26] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:07:26] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:07:26] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:07:26] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:07:26] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:07:26] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:07:26] [INFO] [Player.Jammer] JammerHUD initialized
+[12:07:26] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:07:26] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 2/4
+[12:07:26] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:07:26] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:07:26] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:07:26] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[12:07:26] [INFO] [GameManager] set_player() called with: <CharacterBody2D#344637577103> (class: CharacterBody2D)
+[12:07:26] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:07:26] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:07:26] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:07:26] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:07:26] [INFO] [ScoreManager] Level started with 12 enemies
+[12:07:26] [INFO] [TestTier] ReplayManager found as C# autoload - verified OK
+[12:07:26] [INFO] [ReplayManager] Replay data cleared
+[12:07:26] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:07:26] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:07:26] [INFO] [ReplayManager] Level: TestTier
+[12:07:26] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:07:26] [INFO] [ReplayManager] Enemies count: 12
+[12:07:26] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:07:26] [INFO] [ReplayManager]   Enemy 0: GuardEnemy1
+[12:07:26] [INFO] [ReplayManager]   Enemy 1: GuardEnemy2
+[12:07:26] [INFO] [ReplayManager]   Enemy 2: GuardEnemy3
+[12:07:26] [INFO] [ReplayManager]   Enemy 3: GuardEnemy4
+[12:07:26] [INFO] [ReplayManager]   Enemy 4: GuardEnemy5
+[12:07:26] [INFO] [ReplayManager]   Enemy 5: GuardEnemy6
+[12:07:26] [INFO] [ReplayManager]   Enemy 6: PatrolEnemy1
+[12:07:26] [INFO] [ReplayManager]   Enemy 7: PatrolEnemy2
+[12:07:26] [INFO] [ReplayManager]   Enemy 8: PatrolEnemy3
+[12:07:26] [INFO] [ReplayManager]   Enemy 9: PatrolEnemy4
+[12:07:26] [INFO] [ReplayManager]   Enemy 10: RpgEnemy1
+[12:07:26] [INFO] [ReplayManager]   Enemy 11: RpgEnemy2
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy1] Blood detector created and attached to GuardEnemy1
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy1] Snow surface detector created on GuardEnemy1
+[12:07:26] [INFO] [CinemaEffects] Found player node: Player
+[12:07:26] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:07:26] [INFO] [SoundPropagation] Registered listener: GuardEnemy1 (total: 1)
+[12:07:26] [ENEMY] [GuardEnemy1] Registered as sound listener
+[12:07:26] [ENEMY] [GuardEnemy1] Spawned at (2800, 600), hp: 1, behavior: GUARD
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy2] Blood detector created and attached to GuardEnemy2
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy2] Snow surface detector created on GuardEnemy2
+[12:07:26] [INFO] [SoundPropagation] Registered listener: GuardEnemy2 (total: 2)
+[12:07:26] [ENEMY] [GuardEnemy2] Registered as sound listener
+[12:07:26] [ENEMY] [GuardEnemy2] Spawned at (2800, 1000), hp: 1, behavior: GUARD
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy3] Blood detector created and attached to GuardEnemy3
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy3] Snow surface detector created on GuardEnemy3
+[12:07:26] [INFO] [SoundPropagation] Registered listener: GuardEnemy3 (total: 3)
+[12:07:26] [ENEMY] [GuardEnemy3] Registered as sound listener
+[12:07:26] [ENEMY] [GuardEnemy3] Spawned at (3400, 600), hp: 2, behavior: GUARD
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy4] Blood detector created and attached to GuardEnemy4
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy4] Snow surface detector created on GuardEnemy4
+[12:07:26] [INFO] [SoundPropagation] Registered listener: GuardEnemy4 (total: 4)
+[12:07:26] [ENEMY] [GuardEnemy4] Registered as sound listener
+[12:07:26] [ENEMY] [GuardEnemy4] Spawned at (3400, 1000), hp: 2, behavior: GUARD
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy5] Blood detector created and attached to GuardEnemy5
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy5] Snow surface detector created on GuardEnemy5
+[12:07:26] [INFO] [SoundPropagation] Registered listener: GuardEnemy5 (total: 5)
+[12:07:26] [ENEMY] [GuardEnemy5] Registered as sound listener
+[12:07:26] [ENEMY] [GuardEnemy5] Spawned at (3000, 2100), hp: 2, behavior: GUARD
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy6] Blood detector created and attached to GuardEnemy6
+[12:07:26] [INFO] [BloodyFeet:GuardEnemy6] Snow surface detector created on GuardEnemy6
+[12:07:26] [INFO] [SoundPropagation] Registered listener: GuardEnemy6 (total: 6)
+[12:07:26] [ENEMY] [GuardEnemy6] Registered as sound listener
+[12:07:26] [ENEMY] [GuardEnemy6] Spawned at (3000, 2400), hp: 1, behavior: GUARD
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy1] Blood detector created and attached to PatrolEnemy1
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy1] Snow surface detector created on PatrolEnemy1
+[12:07:26] [INFO] [SoundPropagation] Registered listener: PatrolEnemy1 (total: 7)
+[12:07:26] [ENEMY] [PatrolEnemy1] Registered as sound listener
+[12:07:26] [ENEMY] [PatrolEnemy1] Spawned at (2400, 800), hp: 1, behavior: PATROL
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy2] Blood detector created and attached to PatrolEnemy2
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy2] Snow surface detector created on PatrolEnemy2
+[12:07:26] [INFO] [SoundPropagation] Registered listener: PatrolEnemy2 (total: 8)
+[12:07:26] [ENEMY] [PatrolEnemy2] Registered as sound listener
+[12:07:26] [ENEMY] [PatrolEnemy2] Spawned at (2400, 2300), hp: 2, behavior: PATROL
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy3] Blood detector created and attached to PatrolEnemy3
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy3] Snow surface detector created on PatrolEnemy3
+[12:07:26] [INFO] [SoundPropagation] Registered listener: PatrolEnemy3 (total: 9)
+[12:07:26] [ENEMY] [PatrolEnemy3] Registered as sound listener
+[12:07:26] [ENEMY] [PatrolEnemy3] Spawned at (2800, 1544), hp: 2, behavior: PATROL
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy4] Blood detector created and attached to PatrolEnemy4
+[12:07:26] [INFO] [BloodyFeet:PatrolEnemy4] Snow surface detector created on PatrolEnemy4
+[12:07:26] [INFO] [SoundPropagation] Registered listener: PatrolEnemy4 (total: 10)
+[12:07:26] [ENEMY] [PatrolEnemy4] Registered as sound listener
+[12:07:26] [ENEMY] [PatrolEnemy4] Spawned at (3600, 1544), hp: 1, behavior: PATROL
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy1] Blood detector created and attached to RpgEnemy1
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy1] Snow surface detector created on RpgEnemy1
+[12:07:26] [INFO] [SoundPropagation] Registered listener: RpgEnemy1 (total: 11)
+[12:07:26] [ENEMY] [RpgEnemy1] Registered as sound listener
+[12:07:26] [ENEMY] [RpgEnemy1] Spawned at (3700, 1400), hp: 1, behavior: GUARD
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy2] Blood detector created and attached to RpgEnemy2
+[12:07:26] [INFO] [BloodyFeet:RpgEnemy2] Snow surface detector created on RpgEnemy2
+[12:07:26] [INFO] [SoundPropagation] Registered listener: RpgEnemy2 (total: 12)
+[12:07:26] [ENEMY] [RpgEnemy2] Registered as sound listener
+[12:07:26] [ENEMY] [RpgEnemy2] Spawned at (2000, 2200), hp: 1, behavior: GUARD
+[12:07:26] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:07:26] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:07:26] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 12) - skipping fallback
+[12:07:26] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=12
+[12:07:26] [ENEMY] [PatrolEnemy2] Patrol points snapped to navmesh (Issue #1216)
+[12:07:26] [ENEMY] [PatrolEnemy3] Patrol points snapped to navmesh (Issue #1216)
+[12:07:26] [ENEMY] [PatrolEnemy4] Patrol points snapped to navmesh (Issue #1216)
+[12:07:26] [ENEMY] [GuardEnemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:26] [ENEMY] [GuardEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:26] [ENEMY] [GuardEnemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:26] [ENEMY] [GuardEnemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:26] [ENEMY] [GuardEnemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:26] [ENEMY] [GuardEnemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:26] [ENEMY] [RpgEnemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:26] [ENEMY] [RpgEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:26] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:07:26] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:07:26] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:07:26] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:07:26] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:07:26] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:07:26] [INFO] [LastChance] Found player: Player
+[12:07:26] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:07:26] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:07:26] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:07:26] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:07:27] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=12
+[12:07:27] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:27] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[12:07:27] [INFO] [Player.Grenade] G pressed - starting grab animation
+[12:07:27] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[12:07:27] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[12:07:27] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[12:07:27] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:27] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (569.2529, 1740.3636)
+[12:07:27] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[12:07:27] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[12:07:27] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[12:07:27] [INFO] [DroneGrenade] Ready
+[12:07:27] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[12:07:27] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[12:07:27] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[12:07:27] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[12:07:27] [INFO] [Player.Grenade] Timer started, grenade created at (264, 1544)
+[12:07:27] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[12:07:27] [INFO] [Player.Grenade] Step 1 complete! Drag: (296.19427, -3.3394775)
+[12:07:27] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[12:07:27] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [ENEMY] [PatrolEnemy2] PATROL corner check: angle 180.0°
+[12:07:27] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -137.2°
+[12:07:27] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [ENEMY] [PatrolEnemy2] ROT_CHANGE: none -> P3:corner, state=IDLE, target=180.0°, current=-3.1°, player=(264,1544), corner_timer=0.30
+[12:07:27] [ENEMY] [PatrolEnemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-137.2°, current=-3.1°, player=(264,1544), corner_timer=0.30
+[12:07:27] [ENEMY] [PatrolEnemy4] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=3.1°, player=(264,1544), corner_timer=0.30
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:27] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[12:07:28] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-115.5°, player=(264,1544), corner_timer=-0.02
+[12:07:28] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -180.0°
+[12:07:28] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-8.1°, current=-62.6°, player=(264,1544), corner_timer=-0.02
+[12:07:28] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -97.9°
+[12:07:28] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=6.7°, player=(264,1544), corner_timer=-0.02
+[12:07:28] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:28] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-180.0°, current=-115.7°, player=(264,1544), corner_timer=0.30
+[12:07:28] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-97.9°, current=-59.4°, player=(264,1544), corner_timer=0.30
+[12:07:28] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=12.6°, player=(264,1544), corner_timer=0.30
+[12:07:28] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=12
+[12:07:28] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-180.0°, player=(264,1544), corner_timer=-0.02
+[12:07:28] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -180.0°
+[12:07:28] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=16.1°, current=-89.9°, player=(264,1544), corner_timer=-0.02
+[12:07:28] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -73.9°
+[12:07:28] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=0.0°, player=(264,1544), corner_timer=-0.02
+[12:07:28] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:28] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-180.0°, current=-177.1°, player=(264,1544), corner_timer=0.30
+[12:07:28] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-73.9°, current=-87.0°, player=(264,1544), corner_timer=0.30
+[12:07:28] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=2.9°, player=(264,1544), corner_timer=0.30
+[12:07:28] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=16.1°, current=-73.9°, player=(264,1544), corner_timer=-0.02
+[12:07:28] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -73.9°
+[12:07:28] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-73.9°, current=-71.0°, player=(264,1544), corner_timer=0.30
+[12:07:29] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-3.9°, current=-77.9°, player=(264,1544), corner_timer=-0.02
+[12:07:29] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -93.1°
+[12:07:29] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-93.1°, current=-75.9°, player=(264,1544), corner_timer=0.30
+[12:07:29] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=12
+[12:07:29] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=28.3°, current=-90.0°, player=(264,1544), corner_timer=-0.02
+[12:07:29] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -60.4°
+[12:07:29] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-60.4°, current=-84.1°, player=(264,1544), corner_timer=0.30
+[12:07:29] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=69.5°, current=-56.8°, player=(264,1544), corner_timer=-0.02
+[12:07:29] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 34.1°
+[12:07:29] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=34.1°, current=-50.8°, player=(264,1544), corner_timer=0.30
+[12:07:30] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=12
+[12:07:30] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=175.6°, player=(234,1552), corner_timer=-0.02
+[12:07:30] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:30] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-4.4°, player=(234,1552), corner_timer=-0.02
+[12:07:30] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:30] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=169.7°, player=(231,1555), corner_timer=0.30
+[12:07:30] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-10.3°, player=(231,1555), corner_timer=0.30
+[12:07:30] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=57.2°, player=(205,1573), corner_timer=-0.02
+[12:07:30] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:30] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-122.8°, player=(205,1573), corner_timer=-0.02
+[12:07:30] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:30] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=57.0°, player=(206,1573), corner_timer=0.30
+[12:07:30] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-123.0°, player=(206,1573), corner_timer=0.30
+[12:07:30] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=-5.2°, player=(266,1551), corner_timer=-0.02
+[12:07:30] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:30] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=175.4°, player=(266,1551), corner_timer=-0.02
+[12:07:30] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:30] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=-5.4°, player=(269,1550), corner_timer=0.30
+[12:07:30] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=175.2°, player=(269,1550), corner_timer=0.30
+[12:07:31] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=12
+[12:07:31] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=-0.7°, player=(283,1544), corner_timer=-0.02
+[12:07:31] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:31] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=180.0°, player=(283,1544), corner_timer=-0.02
+[12:07:31] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:31] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=2.2°, player=(283,1544), corner_timer=0.30
+[12:07:31] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-177.1°, player=(283,1544), corner_timer=0.30
+[12:07:31] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=-0.7°, player=(283,1544), corner_timer=-0.02
+[12:07:31] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:31] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-5.0°, current=31.0°, player=(283,1544), corner_timer=-0.02
+[12:07:31] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 92.7°
+[12:07:31] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=180.0°, player=(283,1544), corner_timer=-0.02
+[12:07:31] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:31] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=2.2°, player=(283,1544), corner_timer=0.30
+[12:07:31] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=92.7°, current=31.2°, player=(283,1544), corner_timer=0.30
+[12:07:31] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-177.1°, player=(283,1544), corner_timer=0.30
+[12:07:31] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-176.6°, current=95.8°, player=(227,1544), corner_timer=-0.02
+[12:07:31] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 93.1°
+[12:07:31] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=93.1°, current=101.7°, player=(222,1544), corner_timer=0.30
+[12:07:32] [INFO] [Player.Grenade.Simple] Throwing! Target: (666.0539, 1545.0447), Distance: 410,1, Speed: 496,0, Friction: 300,0
+[12:07:32] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,0015518299
+[12:07:32] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[12:07:32] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.99999875, 0.0015518292), speed=496,0, spawn=(255.96906, 1544.4083)
+[12:07:32] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.999999, 0.001552), Speed: 496.0 (clamped from 496.0, max: 850.0)
+[12:07:32] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[12:07:32] [INFO] [DroneGrenade] Camera attached to drone
+[12:07:32] [INFO] [DroneGrenade] Player control disabled
+[12:07:32] [INFO] [DroneGrenade] PILOTING phase started at (255.9691, 1544.408)
+[12:07:32] [INFO] [DroneGrenade] Drone launched at (255.9691, 1544.408)
+[12:07:32] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[12:07:32] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[12:07:32] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[12:07:32] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[12:07:32] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:32] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:32] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[12:07:32] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=12
+[12:07:32] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=162.2°, current=96.0°, player=(195,1544), corner_timer=-0.02
+[12:07:32] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 72.7°
+[12:07:32] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=72.7°, current=101.9°, player=(195,1544), corner_timer=0.30
+[12:07:32] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-170.2°, current=76.0°, player=(195,1544), corner_timer=-0.02
+[12:07:32] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 99.5°
+[12:07:32] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=99.5°, current=81.9°, player=(195,1544), corner_timer=0.30
+[12:07:32] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[12:07:32] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=99.0°, player=(195,1544), corner_timer=-0.02
+[12:07:32] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 93.0°
+[12:07:32] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=93.0°, current=101.4°, player=(195,1544), corner_timer=0.30
+[12:07:33] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=12
+[12:07:33] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.9°, current=93.5°, player=(195,1544), corner_timer=-0.02
+[12:07:33] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 85.4°
+[12:07:33] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=85.4°, current=93.3°, player=(195,1544), corner_timer=0.30
+[12:07:33] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-60.8°, current=-4.1°, player=(195,1544), corner_timer=-0.02
+[12:07:33] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -150.3°
+[12:07:33] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=176.4°, player=(195,1544), corner_timer=-0.02
+[12:07:33] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:33] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-150.3°, current=-10.0°, player=(195,1544), corner_timer=0.30
+[12:07:33] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=170.5°, player=(195,1544), corner_timer=0.30
+[12:07:33] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[12:07:33] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=147.5°, current=85.4°, player=(195,1544), corner_timer=-0.02
+[12:07:33] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 57.5°
+[12:07:33] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=57.5°, current=88.3°, player=(195,1544), corner_timer=0.30
+[12:07:33] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-88.6°, current=-6.4°, player=(195,1544), corner_timer=-0.02
+[12:07:33] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -178.6°
+[12:07:33] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=58.0°, player=(195,1544), corner_timer=-0.02
+[12:07:33] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:33] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-178.6°, current=-6.2°, player=(195,1544), corner_timer=0.30
+[12:07:33] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=57.8°, player=(195,1544), corner_timer=0.30
+[12:07:33] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=80.5°, current=57.7°, player=(195,1544), corner_timer=-0.02
+[12:07:33] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 88.5°
+[12:07:33] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=88.5°, current=63.6°, player=(195,1544), corner_timer=0.30
+[12:07:34] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-88.6°, current=-2.6°, player=(195,1544), corner_timer=-0.02
+[12:07:34] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -178.6°
+[12:07:34] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=-4.6°, player=(195,1544), corner_timer=-0.02
+[12:07:34] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:34] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-178.6°, current=-2.4°, player=(195,1544), corner_timer=0.30
+[12:07:34] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=-4.8°, player=(195,1544), corner_timer=0.30
+[12:07:34] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=12
+[12:07:34] [INFO] [GameManager] restart_scene() — starting scene reload
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy2 (remaining: 11)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy1 (remaining: 10)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy4 (remaining: 9)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy3 (remaining: 8)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy2 (remaining: 7)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy1 (remaining: 6)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy6 (remaining: 5)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy5 (remaining: 4)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy4 (remaining: 3)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy3 (remaining: 2)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy2 (remaining: 1)
+[12:07:34] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy1 (remaining: 0)
+[12:07:34] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:34] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy1] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy1] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy1] BloodyFeetComponent ready on GuardEnemy1
+[12:07:34] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:07:34] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:34] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:07:34] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:07:34] [INFO] [CinemaEffects] Scene changed to: TestTier
+[12:07:34] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:07:34] [INFO] [BlackMetalEffectsManager] Scene changed to: TestTier
+[12:07:34] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:07:34] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:34] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/TestTier.tscn
+[12:07:34] [ENEMY] [GuardEnemy1] Death animation component initialized
+[12:07:34] [ENEMY] [GuardEnemy1] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy2] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy2] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy2] BloodyFeetComponent ready on GuardEnemy2
+[12:07:34] [ENEMY] [GuardEnemy2] Death animation component initialized
+[12:07:34] [ENEMY] [GuardEnemy2] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy3] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy3] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy3] BloodyFeetComponent ready on GuardEnemy3
+[12:07:34] [ENEMY] [GuardEnemy3] Death animation component initialized
+[12:07:34] [ENEMY] [GuardEnemy3] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy4] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy4] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy4] BloodyFeetComponent ready on GuardEnemy4
+[12:07:34] [ENEMY] [GuardEnemy4] Death animation component initialized
+[12:07:34] [ENEMY] [GuardEnemy4] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy5] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy5] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy5] BloodyFeetComponent ready on GuardEnemy5
+[12:07:34] [ENEMY] [GuardEnemy5] Death animation component initialized
+[12:07:34] [ENEMY] [GuardEnemy5] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy6] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy6] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy6] BloodyFeetComponent ready on GuardEnemy6
+[12:07:34] [ENEMY] [GuardEnemy6] Death animation component initialized
+[12:07:34] [ENEMY] [GuardEnemy6] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy1] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy1] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy1] BloodyFeetComponent ready on PatrolEnemy1
+[12:07:34] [ENEMY] [PatrolEnemy1] Death animation component initialized
+[12:07:34] [ENEMY] [PatrolEnemy1] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy2] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy2] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy2] BloodyFeetComponent ready on PatrolEnemy2
+[12:07:34] [ENEMY] [PatrolEnemy2] Death animation component initialized
+[12:07:34] [ENEMY] [PatrolEnemy2] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy3] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy3] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy3] BloodyFeetComponent ready on PatrolEnemy3
+[12:07:34] [ENEMY] [PatrolEnemy3] Death animation component initialized
+[12:07:34] [ENEMY] [PatrolEnemy3] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy4] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy4] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy4] BloodyFeetComponent ready on PatrolEnemy4
+[12:07:34] [ENEMY] [PatrolEnemy4] Death animation component initialized
+[12:07:34] [ENEMY] [PatrolEnemy4] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy1] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy1] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy1] BloodyFeetComponent ready on RpgEnemy1
+[12:07:34] [ENEMY] [RpgEnemy1] Death animation component initialized
+[12:07:34] [ENEMY] [RpgEnemy1] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy2] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy2] Found EnemyModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy2] BloodyFeetComponent ready on RpgEnemy2
+[12:07:34] [ENEMY] [RpgEnemy2] Death animation component initialized
+[12:07:34] [ENEMY] [RpgEnemy2] [Gunslinger] Enemy glow applied
+[12:07:34] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:34] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:07:34] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:07:34] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:07:34] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:07:34] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:07:34] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:07:34] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:07:34] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:07:34] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:07:34] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:07:34] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:07:34] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:07:34] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:07:34] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[12:07:34] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:07:34] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:07:34] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:07:34] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:07:34] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:07:34] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:07:34] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:07:34] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:07:34] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:07:34] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:07:34] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:07:34] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:07:34] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:07:34] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:07:34] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:07:34] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:07:34] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:07:34] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:07:34] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:07:34] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:07:34] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:07:34] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:07:34] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:07:34] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:07:34] [INFO] [Player.Jammer] JammerHUD initialized
+[12:07:34] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:07:34] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[12:07:34] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:07:34] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:07:34] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:07:34] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[12:07:34] [INFO] [GameManager] set_player() called with: <CharacterBody2D#443639926385> (class: CharacterBody2D)
+[12:07:34] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:07:34] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:07:34] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:07:34] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:07:34] [INFO] [ScoreManager] Level started with 12 enemies
+[12:07:34] [INFO] [TestTier] ReplayManager found as C# autoload - verified OK
+[12:07:34] [INFO] [ReplayManager] Replay data cleared
+[12:07:34] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:07:34] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:07:34] [INFO] [ReplayManager] Level: TestTier
+[12:07:34] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:07:34] [INFO] [ReplayManager] Enemies count: 12
+[12:07:34] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:07:34] [INFO] [ReplayManager]   Enemy 0: GuardEnemy1
+[12:07:34] [INFO] [ReplayManager]   Enemy 1: GuardEnemy2
+[12:07:34] [INFO] [ReplayManager]   Enemy 2: GuardEnemy3
+[12:07:34] [INFO] [ReplayManager]   Enemy 3: GuardEnemy4
+[12:07:34] [INFO] [ReplayManager]   Enemy 4: GuardEnemy5
+[12:07:34] [INFO] [ReplayManager]   Enemy 5: GuardEnemy6
+[12:07:34] [INFO] [ReplayManager]   Enemy 6: PatrolEnemy1
+[12:07:34] [INFO] [ReplayManager]   Enemy 7: PatrolEnemy2
+[12:07:34] [INFO] [ReplayManager]   Enemy 8: PatrolEnemy3
+[12:07:34] [INFO] [ReplayManager]   Enemy 9: PatrolEnemy4
+[12:07:34] [INFO] [ReplayManager]   Enemy 10: RpgEnemy1
+[12:07:34] [INFO] [ReplayManager]   Enemy 11: RpgEnemy2
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy1] Blood detector created and attached to GuardEnemy1
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy1] Snow surface detector created on GuardEnemy1
+[12:07:34] [INFO] [CinemaEffects] Found player node: Player
+[12:07:34] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:07:34] [INFO] [SoundPropagation] Registered listener: GuardEnemy1 (total: 1)
+[12:07:34] [ENEMY] [GuardEnemy1] Registered as sound listener
+[12:07:34] [ENEMY] [GuardEnemy1] Spawned at (2800, 600), hp: 2, behavior: GUARD
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy2] Blood detector created and attached to GuardEnemy2
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy2] Snow surface detector created on GuardEnemy2
+[12:07:34] [INFO] [SoundPropagation] Registered listener: GuardEnemy2 (total: 2)
+[12:07:34] [ENEMY] [GuardEnemy2] Registered as sound listener
+[12:07:34] [ENEMY] [GuardEnemy2] Spawned at (2800, 1000), hp: 2, behavior: GUARD
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy3] Blood detector created and attached to GuardEnemy3
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy3] Snow surface detector created on GuardEnemy3
+[12:07:34] [INFO] [SoundPropagation] Registered listener: GuardEnemy3 (total: 3)
+[12:07:34] [ENEMY] [GuardEnemy3] Registered as sound listener
+[12:07:34] [ENEMY] [GuardEnemy3] Spawned at (3400, 600), hp: 2, behavior: GUARD
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy4] Blood detector created and attached to GuardEnemy4
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy4] Snow surface detector created on GuardEnemy4
+[12:07:34] [INFO] [SoundPropagation] Registered listener: GuardEnemy4 (total: 4)
+[12:07:34] [ENEMY] [GuardEnemy4] Registered as sound listener
+[12:07:34] [ENEMY] [GuardEnemy4] Spawned at (3400, 1000), hp: 2, behavior: GUARD
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy5] Blood detector created and attached to GuardEnemy5
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy5] Snow surface detector created on GuardEnemy5
+[12:07:34] [INFO] [SoundPropagation] Registered listener: GuardEnemy5 (total: 5)
+[12:07:34] [ENEMY] [GuardEnemy5] Registered as sound listener
+[12:07:34] [ENEMY] [GuardEnemy5] Spawned at (3000, 2100), hp: 2, behavior: GUARD
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy6] Blood detector created and attached to GuardEnemy6
+[12:07:34] [INFO] [BloodyFeet:GuardEnemy6] Snow surface detector created on GuardEnemy6
+[12:07:34] [INFO] [SoundPropagation] Registered listener: GuardEnemy6 (total: 6)
+[12:07:34] [ENEMY] [GuardEnemy6] Registered as sound listener
+[12:07:34] [ENEMY] [GuardEnemy6] Spawned at (3000, 2400), hp: 2, behavior: GUARD
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy1] Blood detector created and attached to PatrolEnemy1
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy1] Snow surface detector created on PatrolEnemy1
+[12:07:34] [INFO] [SoundPropagation] Registered listener: PatrolEnemy1 (total: 7)
+[12:07:34] [ENEMY] [PatrolEnemy1] Registered as sound listener
+[12:07:34] [ENEMY] [PatrolEnemy1] Spawned at (2400, 800), hp: 2, behavior: PATROL
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy2] Blood detector created and attached to PatrolEnemy2
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy2] Snow surface detector created on PatrolEnemy2
+[12:07:34] [INFO] [SoundPropagation] Registered listener: PatrolEnemy2 (total: 8)
+[12:07:34] [ENEMY] [PatrolEnemy2] Registered as sound listener
+[12:07:34] [ENEMY] [PatrolEnemy2] Spawned at (2400, 2300), hp: 1, behavior: PATROL
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy3] Blood detector created and attached to PatrolEnemy3
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy3] Snow surface detector created on PatrolEnemy3
+[12:07:34] [INFO] [SoundPropagation] Registered listener: PatrolEnemy3 (total: 9)
+[12:07:34] [ENEMY] [PatrolEnemy3] Registered as sound listener
+[12:07:34] [ENEMY] [PatrolEnemy3] Spawned at (2800, 1544), hp: 2, behavior: PATROL
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy4] Blood detector created and attached to PatrolEnemy4
+[12:07:34] [INFO] [BloodyFeet:PatrolEnemy4] Snow surface detector created on PatrolEnemy4
+[12:07:34] [INFO] [SoundPropagation] Registered listener: PatrolEnemy4 (total: 10)
+[12:07:34] [ENEMY] [PatrolEnemy4] Registered as sound listener
+[12:07:34] [ENEMY] [PatrolEnemy4] Spawned at (3600, 1544), hp: 1, behavior: PATROL
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy1] Blood detector created and attached to RpgEnemy1
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy1] Snow surface detector created on RpgEnemy1
+[12:07:34] [INFO] [SoundPropagation] Registered listener: RpgEnemy1 (total: 11)
+[12:07:34] [ENEMY] [RpgEnemy1] Registered as sound listener
+[12:07:34] [ENEMY] [RpgEnemy1] Spawned at (3700, 1400), hp: 1, behavior: GUARD
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy2] Blood detector created and attached to RpgEnemy2
+[12:07:34] [INFO] [BloodyFeet:RpgEnemy2] Snow surface detector created on RpgEnemy2
+[12:07:34] [INFO] [SoundPropagation] Registered listener: RpgEnemy2 (total: 12)
+[12:07:34] [ENEMY] [RpgEnemy2] Registered as sound listener
+[12:07:34] [ENEMY] [RpgEnemy2] Spawned at (2000, 2200), hp: 1, behavior: GUARD
+[12:07:34] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:07:34] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:07:34] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 12) - skipping fallback
+[12:07:34] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=12
+[12:07:34] [ENEMY] [PatrolEnemy1] Patrol points snapped to navmesh (Issue #1216)
+[12:07:34] [ENEMY] [PatrolEnemy2] Patrol points snapped to navmesh (Issue #1216)
+[12:07:34] [ENEMY] [PatrolEnemy3] Patrol points snapped to navmesh (Issue #1216)
+[12:07:34] [ENEMY] [PatrolEnemy4] Patrol points snapped to navmesh (Issue #1216)
+[12:07:34] [ENEMY] [GuardEnemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:34] [ENEMY] [GuardEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:34] [ENEMY] [GuardEnemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=270.0°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:34] [ENEMY] [GuardEnemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:34] [ENEMY] [GuardEnemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:34] [ENEMY] [GuardEnemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:34] [ENEMY] [RpgEnemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:34] [ENEMY] [RpgEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=315.0°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:34] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:07:34] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:07:34] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:07:34] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:07:34] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:07:34] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:07:34] [INFO] [LastChance] Found player: Player
+[12:07:34] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:07:34] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:07:34] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:07:34] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:07:35] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=12
+[12:07:35] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:35] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[12:07:35] [INFO] [Player.Grenade] G pressed - starting grab animation
+[12:07:35] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[12:07:35] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[12:07:35] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[12:07:35] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:35] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (408.41486, 1576.0593)
+[12:07:35] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[12:07:35] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[12:07:35] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[12:07:35] [INFO] [DroneGrenade] Ready
+[12:07:35] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[12:07:35] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[12:07:35] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[12:07:35] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[12:07:35] [INFO] [Player.Grenade] Timer started, grenade created at (264, 1544)
+[12:07:35] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[12:07:35] [INFO] [Player.Grenade] Step 1 complete! Drag: (264.33246, 14.026001)
+[12:07:35] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[12:07:35] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[12:07:35] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:35] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:35] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:35] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:35] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:35] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:35] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[12:07:35] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -0.0°
+[12:07:35] [ENEMY] [PatrolEnemy2] PATROL corner check: angle 180.0°
+[12:07:35] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -137.2°
+[12:07:35] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:35] [ENEMY] [PatrolEnemy1] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=3.1°, player=(264,1544), corner_timer=0.30
+[12:07:35] [ENEMY] [PatrolEnemy2] ROT_CHANGE: none -> P3:corner, state=IDLE, target=180.0°, current=-3.1°, player=(264,1544), corner_timer=0.30
+[12:07:35] [ENEMY] [PatrolEnemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-137.2°, current=-3.1°, player=(264,1544), corner_timer=0.30
+[12:07:35] [ENEMY] [PatrolEnemy4] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=3.1°, player=(264,1544), corner_timer=0.30
+[12:07:36] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=6.7°, player=(264,1544), corner_timer=-0.02
+[12:07:36] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -0.0°
+[12:07:36] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-115.5°, player=(264,1544), corner_timer=-0.02
+[12:07:36] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -180.0°
+[12:07:36] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-8.1°, current=-62.6°, player=(264,1544), corner_timer=-0.02
+[12:07:36] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -97.9°
+[12:07:36] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=6.7°, player=(264,1544), corner_timer=-0.02
+[12:07:36] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:36] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=12.6°, player=(264,1544), corner_timer=0.30
+[12:07:36] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-180.0°, current=-115.7°, player=(264,1544), corner_timer=0.30
+[12:07:36] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-97.9°, current=-59.4°, player=(264,1544), corner_timer=0.30
+[12:07:36] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=12.6°, player=(264,1544), corner_timer=0.30
+[12:07:36] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=12
+[12:07:36] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=-0.0°, player=(264,1544), corner_timer=-0.02
+[12:07:36] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -0.0°
+[12:07:36] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-180.0°, player=(264,1544), corner_timer=-0.02
+[12:07:36] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -180.0°
+[12:07:36] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=16.1°, current=-89.9°, player=(264,1544), corner_timer=-0.02
+[12:07:36] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -73.9°
+[12:07:36] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=0.0°, player=(264,1544), corner_timer=-0.02
+[12:07:36] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:36] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=2.9°, player=(264,1544), corner_timer=0.30
+[12:07:36] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-180.0°, current=-177.1°, player=(264,1544), corner_timer=0.30
+[12:07:36] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-73.9°, current=-87.0°, player=(264,1544), corner_timer=0.30
+[12:07:36] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=2.9°, player=(264,1544), corner_timer=0.30
+[12:07:36] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=16.1°, current=-73.9°, player=(264,1544), corner_timer=-0.02
+[12:07:36] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -73.9°
+[12:07:36] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-73.9°, current=-71.0°, player=(264,1544), corner_timer=0.30
+[12:07:36] [INFO] [Player.Grenade.Simple] Throwing! Target: (543.131, 1903.332), Distance: 395,0, Speed: 486,8, Friction: 300,0
+[12:07:36] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,91035944
+[12:07:36] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[12:07:36] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.6134619, 0.7897243), speed=486,8, spawn=(300.8077, 1591.3834)
+[12:07:37] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.613462, 0.789724), Speed: 486.8 (clamped from 486.8, max: 850.0)
+[12:07:37] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[12:07:37] [INFO] [DroneGrenade] Camera attached to drone
+[12:07:37] [INFO] [DroneGrenade] Player control disabled
+[12:07:37] [INFO] [DroneGrenade] PILOTING phase started at (300.8077, 1591.383)
+[12:07:37] [INFO] [DroneGrenade] Drone launched at (300.8077, 1591.383)
+[12:07:37] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[12:07:37] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[12:07:37] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[12:07:37] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[12:07:37] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:37] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:37] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[12:07:37] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-3.9°, current=-77.9°, player=(264,1544), corner_timer=-0.02
+[12:07:37] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -93.1°
+[12:07:37] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-93.1°, current=-75.9°, player=(264,1544), corner_timer=0.30
+[12:07:37] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=12
+[12:07:37] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=28.3°, current=-90.0°, player=(264,1544), corner_timer=-0.02
+[12:07:37] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -60.4°
+[12:07:37] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-60.4°, current=-84.1°, player=(264,1544), corner_timer=0.30
+[12:07:37] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[12:07:37] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=69.5°, current=-56.8°, player=(264,1544), corner_timer=-0.02
+[12:07:37] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 34.1°
+[12:07:37] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=34.1°, current=-50.8°, player=(264,1544), corner_timer=0.30
+[12:07:38] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=12
+[12:07:38] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-113.3°, current=3.6°, player=(264,1544), corner_timer=-0.02
+[12:07:38] [ENEMY] [PatrolEnemy1] PATROL corner check: angle 156.9°
+[12:07:38] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.4°, current=175.6°, player=(264,1544), corner_timer=-0.02
+[12:07:38] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:38] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-4.4°, player=(264,1544), corner_timer=-0.02
+[12:07:38] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:38] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=156.9°, current=3.8°, player=(264,1544), corner_timer=0.30
+[12:07:38] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=169.7°, player=(264,1544), corner_timer=0.30
+[12:07:38] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-10.3°, player=(264,1544), corner_timer=0.30
+[12:07:38] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[12:07:38] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-89.4°, current=116.3°, player=(264,1544), corner_timer=-0.02
+[12:07:38] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -179.4°
+[12:07:38] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=57.2°, player=(264,1544), corner_timer=-0.02
+[12:07:38] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:38] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-122.8°, player=(264,1544), corner_timer=-0.02
+[12:07:38] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:38] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-179.4°, current=122.2°, player=(264,1544), corner_timer=0.30
+[12:07:38] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=57.0°, player=(264,1544), corner_timer=0.30
+[12:07:38] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-123.0°, player=(264,1544), corner_timer=0.30
+[12:07:39] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-89.4°, current=-174.9°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -179.4°
+[12:07:39] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=-5.2°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:39] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=175.4°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:39] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-179.4°, current=-168.9°, player=(264,1544), corner_timer=0.30
+[12:07:39] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=-5.4°, player=(264,1544), corner_timer=0.30
+[12:07:39] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=175.2°, player=(264,1544), corner_timer=0.30
+[12:07:39] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=12
+[12:07:39] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-89.4°, current=-174.2°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -179.4°
+[12:07:39] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=-0.7°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:39] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=180.0°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:39] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-179.4°, current=-171.3°, player=(264,1544), corner_timer=0.30
+[12:07:39] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=2.2°, player=(264,1544), corner_timer=0.30
+[12:07:39] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-177.1°, player=(264,1544), corner_timer=0.30
+[12:07:39] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-89.4°, current=-179.4°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -179.4°
+[12:07:39] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=-0.7°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:39] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-5.0°, current=31.0°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 92.7°
+[12:07:39] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=180.0°, player=(264,1544), corner_timer=-0.02
+[12:07:39] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:39] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-179.4°, current=-176.6°, player=(264,1544), corner_timer=0.30
+[12:07:39] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=2.2°, player=(264,1544), corner_timer=0.30
+[12:07:39] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=92.7°, current=31.2°, player=(264,1544), corner_timer=0.30
+[12:07:39] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-177.1°, player=(264,1544), corner_timer=0.30
+[12:07:40] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-176.6°, current=95.8°, player=(264,1544), corner_timer=-0.02
+[12:07:40] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 93.1°
+[12:07:40] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=93.1°, current=101.7°, player=(264,1544), corner_timer=0.30
+[12:07:40] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=12
+[12:07:40] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=162.2°, current=96.0°, player=(264,1544), corner_timer=-0.02
+[12:07:40] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 72.7°
+[12:07:40] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=72.7°, current=101.9°, player=(264,1544), corner_timer=0.30
+[12:07:40] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-170.2°, current=76.0°, player=(264,1544), corner_timer=-0.02
+[12:07:40] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 99.5°
+[12:07:40] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=99.5°, current=81.9°, player=(264,1544), corner_timer=0.30
+[12:07:40] [INFO] [GrenadeTimer] Flashbang grenade landed at (1096.365, 1356.1493)
+[12:07:40] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(1096.365, 1356.149), source=NEUTRAL (DroneGrenade), range=112, listeners=12
+[12:07:40] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=12, self=0
+[12:07:40] [INFO] [GrenadeTimer] Emitted grenade landing sound at (1096.365, 1356.1493)
+[12:07:41] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=99.0°, player=(264,1544), corner_timer=-0.02
+[12:07:41] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 93.0°
+[12:07:41] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=93.0°, current=101.4°, player=(264,1544), corner_timer=0.30
+[12:07:41] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=12
+[12:07:41] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=178.9°, current=93.5°, player=(264,1544), corner_timer=-0.02
+[12:07:41] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 85.4°
+[12:07:41] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=85.4°, current=93.3°, player=(264,1544), corner_timer=0.30
+[12:07:41] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=116.8°, current=177.1°, player=(264,1544), corner_timer=-0.02
+[12:07:41] [ENEMY] [PatrolEnemy1] PATROL corner check: angle 24.8°
+[12:07:41] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-60.8°, current=-4.1°, player=(264,1544), corner_timer=-0.02
+[12:07:41] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -150.3°
+[12:07:41] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=176.4°, player=(264,1544), corner_timer=-0.02
+[12:07:41] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:41] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=24.8°, current=171.2°, player=(264,1544), corner_timer=0.30
+[12:07:41] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-150.3°, current=-10.0°, player=(264,1544), corner_timer=0.30
+[12:07:41] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=170.5°, player=(264,1544), corner_timer=0.30
+[12:07:41] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=147.5°, current=85.4°, player=(264,1544), corner_timer=-0.02
+[12:07:41] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 57.5°
+[12:07:41] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=57.5°, current=88.3°, player=(264,1544), corner_timer=0.30
+[12:07:41] [INFO] [GameManager] restart_scene() — starting scene reload
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy2 (remaining: 11)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy1 (remaining: 10)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy4 (remaining: 9)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy3 (remaining: 8)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy2 (remaining: 7)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy1 (remaining: 6)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy6 (remaining: 5)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy5 (remaining: 4)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy4 (remaining: 3)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy3 (remaining: 2)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy2 (remaining: 1)
+[12:07:41] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy1 (remaining: 0)
+[12:07:41] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:41] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:07:41] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:41] [INFO] [BloodyFeet:GuardEnemy1] Footprint scene loaded
+[12:07:41] [INFO] [BloodyFeet:GuardEnemy1] Found EnemyModel for facing direction
+[12:07:41] [INFO] [BloodyFeet:GuardEnemy1] BloodyFeetComponent ready on GuardEnemy1
+[12:07:41] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:07:41] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:41] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:07:41] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:07:41] [INFO] [CinemaEffects] Scene changed to: TestTier
+[12:07:41] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:07:41] [INFO] [BlackMetalEffectsManager] Scene changed to: TestTier
+[12:07:41] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:07:41] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:41] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/TestTier.tscn
+[12:07:42] [ENEMY] [GuardEnemy1] Death animation component initialized
+[12:07:42] [ENEMY] [GuardEnemy1] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy2] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy2] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy2] BloodyFeetComponent ready on GuardEnemy2
+[12:07:42] [ENEMY] [GuardEnemy2] Death animation component initialized
+[12:07:42] [ENEMY] [GuardEnemy2] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy3] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy3] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy3] BloodyFeetComponent ready on GuardEnemy3
+[12:07:42] [ENEMY] [GuardEnemy3] Death animation component initialized
+[12:07:42] [ENEMY] [GuardEnemy3] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy4] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy4] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy4] BloodyFeetComponent ready on GuardEnemy4
+[12:07:42] [ENEMY] [GuardEnemy4] Death animation component initialized
+[12:07:42] [ENEMY] [GuardEnemy4] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy5] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy5] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy5] BloodyFeetComponent ready on GuardEnemy5
+[12:07:42] [ENEMY] [GuardEnemy5] Death animation component initialized
+[12:07:42] [ENEMY] [GuardEnemy5] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy6] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy6] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy6] BloodyFeetComponent ready on GuardEnemy6
+[12:07:42] [ENEMY] [GuardEnemy6] Death animation component initialized
+[12:07:42] [ENEMY] [GuardEnemy6] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy1] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy1] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy1] BloodyFeetComponent ready on PatrolEnemy1
+[12:07:42] [ENEMY] [PatrolEnemy1] Death animation component initialized
+[12:07:42] [ENEMY] [PatrolEnemy1] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy2] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy2] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy2] BloodyFeetComponent ready on PatrolEnemy2
+[12:07:42] [ENEMY] [PatrolEnemy2] Death animation component initialized
+[12:07:42] [ENEMY] [PatrolEnemy2] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy3] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy3] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy3] BloodyFeetComponent ready on PatrolEnemy3
+[12:07:42] [ENEMY] [PatrolEnemy3] Death animation component initialized
+[12:07:42] [ENEMY] [PatrolEnemy3] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy4] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy4] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy4] BloodyFeetComponent ready on PatrolEnemy4
+[12:07:42] [ENEMY] [PatrolEnemy4] Death animation component initialized
+[12:07:42] [ENEMY] [PatrolEnemy4] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy1] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy1] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy1] BloodyFeetComponent ready on RpgEnemy1
+[12:07:42] [ENEMY] [RpgEnemy1] Death animation component initialized
+[12:07:42] [ENEMY] [RpgEnemy1] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy2] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy2] Found EnemyModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy2] BloodyFeetComponent ready on RpgEnemy2
+[12:07:42] [ENEMY] [RpgEnemy2] Death animation component initialized
+[12:07:42] [ENEMY] [RpgEnemy2] [Gunslinger] Enemy glow applied
+[12:07:42] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:42] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:07:42] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:07:42] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:07:42] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:07:42] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:07:42] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:07:42] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:07:42] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:07:42] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:07:42] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:07:42] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:07:42] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:07:42] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:07:42] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[12:07:42] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:07:42] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:07:42] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:07:42] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:07:42] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:07:42] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:07:42] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:07:42] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:07:42] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:07:42] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:07:42] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:07:42] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:07:42] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:07:42] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:07:42] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:07:42] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:07:42] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:07:42] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:07:42] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:07:42] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:07:42] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:07:42] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:07:42] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:07:42] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:07:42] [INFO] [Player.Jammer] JammerHUD initialized
+[12:07:42] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:07:42] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[12:07:42] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:07:42] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:07:42] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:07:42] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[12:07:42] [INFO] [GameManager] set_player() called with: <CharacterBody2D#530143254475> (class: CharacterBody2D)
+[12:07:42] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:07:42] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:07:42] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:07:42] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:07:42] [INFO] [ScoreManager] Level started with 12 enemies
+[12:07:42] [INFO] [TestTier] ReplayManager found as C# autoload - verified OK
+[12:07:42] [INFO] [ReplayManager] Replay data cleared
+[12:07:42] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:07:42] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:07:42] [INFO] [ReplayManager] Level: TestTier
+[12:07:42] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:07:42] [INFO] [ReplayManager] Enemies count: 12
+[12:07:42] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:07:42] [INFO] [ReplayManager]   Enemy 0: GuardEnemy1
+[12:07:42] [INFO] [ReplayManager]   Enemy 1: GuardEnemy2
+[12:07:42] [INFO] [ReplayManager]   Enemy 2: GuardEnemy3
+[12:07:42] [INFO] [ReplayManager]   Enemy 3: GuardEnemy4
+[12:07:42] [INFO] [ReplayManager]   Enemy 4: GuardEnemy5
+[12:07:42] [INFO] [ReplayManager]   Enemy 5: GuardEnemy6
+[12:07:42] [INFO] [ReplayManager]   Enemy 6: PatrolEnemy1
+[12:07:42] [INFO] [ReplayManager]   Enemy 7: PatrolEnemy2
+[12:07:42] [INFO] [ReplayManager]   Enemy 8: PatrolEnemy3
+[12:07:42] [INFO] [ReplayManager]   Enemy 9: PatrolEnemy4
+[12:07:42] [INFO] [ReplayManager]   Enemy 10: RpgEnemy1
+[12:07:42] [INFO] [ReplayManager]   Enemy 11: RpgEnemy2
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy1] Blood detector created and attached to GuardEnemy1
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy1] Snow surface detector created on GuardEnemy1
+[12:07:42] [INFO] [CinemaEffects] Found player node: Player
+[12:07:42] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:07:42] [INFO] [SoundPropagation] Registered listener: GuardEnemy1 (total: 1)
+[12:07:42] [ENEMY] [GuardEnemy1] Registered as sound listener
+[12:07:42] [ENEMY] [GuardEnemy1] Spawned at (2800, 600), hp: 1, behavior: GUARD
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy2] Blood detector created and attached to GuardEnemy2
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy2] Snow surface detector created on GuardEnemy2
+[12:07:42] [INFO] [SoundPropagation] Registered listener: GuardEnemy2 (total: 2)
+[12:07:42] [ENEMY] [GuardEnemy2] Registered as sound listener
+[12:07:42] [ENEMY] [GuardEnemy2] Spawned at (2800, 1000), hp: 2, behavior: GUARD
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy3] Blood detector created and attached to GuardEnemy3
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy3] Snow surface detector created on GuardEnemy3
+[12:07:42] [INFO] [SoundPropagation] Registered listener: GuardEnemy3 (total: 3)
+[12:07:42] [ENEMY] [GuardEnemy3] Registered as sound listener
+[12:07:42] [ENEMY] [GuardEnemy3] Spawned at (3400, 600), hp: 2, behavior: GUARD
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy4] Blood detector created and attached to GuardEnemy4
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy4] Snow surface detector created on GuardEnemy4
+[12:07:42] [INFO] [SoundPropagation] Registered listener: GuardEnemy4 (total: 4)
+[12:07:42] [ENEMY] [GuardEnemy4] Registered as sound listener
+[12:07:42] [ENEMY] [GuardEnemy4] Spawned at (3400, 1000), hp: 1, behavior: GUARD
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy5] Blood detector created and attached to GuardEnemy5
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy5] Snow surface detector created on GuardEnemy5
+[12:07:42] [INFO] [SoundPropagation] Registered listener: GuardEnemy5 (total: 5)
+[12:07:42] [ENEMY] [GuardEnemy5] Registered as sound listener
+[12:07:42] [ENEMY] [GuardEnemy5] Spawned at (3000, 2100), hp: 1, behavior: GUARD
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy6] Blood detector created and attached to GuardEnemy6
+[12:07:42] [INFO] [BloodyFeet:GuardEnemy6] Snow surface detector created on GuardEnemy6
+[12:07:42] [INFO] [SoundPropagation] Registered listener: GuardEnemy6 (total: 6)
+[12:07:42] [ENEMY] [GuardEnemy6] Registered as sound listener
+[12:07:42] [ENEMY] [GuardEnemy6] Spawned at (3000, 2400), hp: 1, behavior: GUARD
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy1] Blood detector created and attached to PatrolEnemy1
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy1] Snow surface detector created on PatrolEnemy1
+[12:07:42] [INFO] [SoundPropagation] Registered listener: PatrolEnemy1 (total: 7)
+[12:07:42] [ENEMY] [PatrolEnemy1] Registered as sound listener
+[12:07:42] [ENEMY] [PatrolEnemy1] Spawned at (2400, 800), hp: 2, behavior: PATROL
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy2] Blood detector created and attached to PatrolEnemy2
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy2] Snow surface detector created on PatrolEnemy2
+[12:07:42] [INFO] [SoundPropagation] Registered listener: PatrolEnemy2 (total: 8)
+[12:07:42] [ENEMY] [PatrolEnemy2] Registered as sound listener
+[12:07:42] [ENEMY] [PatrolEnemy2] Spawned at (2400, 2300), hp: 1, behavior: PATROL
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy3] Blood detector created and attached to PatrolEnemy3
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy3] Snow surface detector created on PatrolEnemy3
+[12:07:42] [INFO] [SoundPropagation] Registered listener: PatrolEnemy3 (total: 9)
+[12:07:42] [ENEMY] [PatrolEnemy3] Registered as sound listener
+[12:07:42] [ENEMY] [PatrolEnemy3] Spawned at (2800, 1544), hp: 1, behavior: PATROL
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy4] Blood detector created and attached to PatrolEnemy4
+[12:07:42] [INFO] [BloodyFeet:PatrolEnemy4] Snow surface detector created on PatrolEnemy4
+[12:07:42] [INFO] [SoundPropagation] Registered listener: PatrolEnemy4 (total: 10)
+[12:07:42] [ENEMY] [PatrolEnemy4] Registered as sound listener
+[12:07:42] [ENEMY] [PatrolEnemy4] Spawned at (3600, 1544), hp: 2, behavior: PATROL
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy1] Blood detector created and attached to RpgEnemy1
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy1] Snow surface detector created on RpgEnemy1
+[12:07:42] [INFO] [SoundPropagation] Registered listener: RpgEnemy1 (total: 11)
+[12:07:42] [ENEMY] [RpgEnemy1] Registered as sound listener
+[12:07:42] [ENEMY] [RpgEnemy1] Spawned at (3700, 1400), hp: 1, behavior: GUARD
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy2] Blood detector created and attached to RpgEnemy2
+[12:07:42] [INFO] [BloodyFeet:RpgEnemy2] Snow surface detector created on RpgEnemy2
+[12:07:42] [INFO] [SoundPropagation] Registered listener: RpgEnemy2 (total: 12)
+[12:07:42] [ENEMY] [RpgEnemy2] Registered as sound listener
+[12:07:42] [ENEMY] [RpgEnemy2] Spawned at (2000, 2200), hp: 1, behavior: GUARD
+[12:07:42] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:07:42] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:07:42] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 12) - skipping fallback
+[12:07:42] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=12
+[12:07:42] [ENEMY] [PatrolEnemy1] Patrol points snapped to navmesh (Issue #1216)
+[12:07:42] [ENEMY] [PatrolEnemy2] Patrol points snapped to navmesh (Issue #1216)
+[12:07:42] [ENEMY] [PatrolEnemy3] Patrol points snapped to navmesh (Issue #1216)
+[12:07:42] [ENEMY] [PatrolEnemy4] Patrol points snapped to navmesh (Issue #1216)
+[12:07:42] [ENEMY] [GuardEnemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:42] [ENEMY] [GuardEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:42] [ENEMY] [GuardEnemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:42] [ENEMY] [GuardEnemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:42] [ENEMY] [GuardEnemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:42] [ENEMY] [GuardEnemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:42] [ENEMY] [RpgEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:42] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:07:42] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:07:42] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:07:42] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:07:42] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:07:42] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:07:42] [INFO] [LastChance] Found player: Player
+[12:07:42] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:07:42] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:07:42] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:07:42] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:07:43] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=12
+[12:07:43] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:43] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[12:07:43] [INFO] [Player.Grenade] G pressed - starting grab animation
+[12:07:43] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[12:07:43] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[12:07:43] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[12:07:43] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:43] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (444.81482, 1718.3228)
+[12:07:43] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[12:07:43] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[12:07:43] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[12:07:43] [INFO] [DroneGrenade] Ready
+[12:07:43] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[12:07:43] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[12:07:43] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[12:07:43] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[12:07:43] [INFO] [Player.Grenade] Timer started, grenade created at (264, 1544)
+[12:07:43] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[12:07:43] [INFO] [Player.Grenade] Step 1 complete! Drag: (431.79504, 8.014893)
+[12:07:43] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[12:07:43] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:43] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[12:07:43] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -0.0°
+[12:07:43] [ENEMY] [PatrolEnemy2] PATROL corner check: angle 180.0°
+[12:07:43] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -137.2°
+[12:07:43] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:43] [ENEMY] [PatrolEnemy1] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=3.1°, player=(264,1544), corner_timer=0.30
+[12:07:43] [ENEMY] [PatrolEnemy2] ROT_CHANGE: none -> P3:corner, state=IDLE, target=180.0°, current=-3.1°, player=(264,1544), corner_timer=0.30
+[12:07:43] [ENEMY] [PatrolEnemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-137.2°, current=-3.1°, player=(264,1544), corner_timer=0.30
+[12:07:43] [ENEMY] [PatrolEnemy4] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=3.1°, player=(264,1544), corner_timer=0.30
+[12:07:44] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=6.7°, player=(264,1544), corner_timer=-0.02
+[12:07:44] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -0.0°
+[12:07:44] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-115.5°, player=(264,1544), corner_timer=-0.02
+[12:07:44] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -180.0°
+[12:07:44] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-8.1°, current=-62.6°, player=(264,1544), corner_timer=-0.02
+[12:07:44] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -97.9°
+[12:07:44] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=6.7°, player=(264,1544), corner_timer=-0.02
+[12:07:44] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:44] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=12.6°, player=(264,1544), corner_timer=0.30
+[12:07:44] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-180.0°, current=-115.7°, player=(264,1544), corner_timer=0.30
+[12:07:44] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-97.9°, current=-59.4°, player=(264,1544), corner_timer=0.30
+[12:07:44] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=12.6°, player=(264,1544), corner_timer=0.30
+[12:07:44] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=12
+[12:07:44] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=-0.0°, player=(264,1544), corner_timer=-0.02
+[12:07:44] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -0.0°
+[12:07:44] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-180.0°, player=(264,1544), corner_timer=-0.02
+[12:07:44] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -180.0°
+[12:07:44] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=16.1°, current=-89.9°, player=(264,1544), corner_timer=-0.02
+[12:07:44] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -73.9°
+[12:07:44] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=0.0°, player=(264,1544), corner_timer=-0.02
+[12:07:44] [ENEMY] [PatrolEnemy4] PATROL corner check: angle -0.0°
+[12:07:44] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=2.9°, player=(264,1544), corner_timer=0.30
+[12:07:44] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-180.0°, current=-177.1°, player=(264,1544), corner_timer=0.30
+[12:07:44] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-73.9°, current=-87.0°, player=(264,1544), corner_timer=0.30
+[12:07:44] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=2.9°, player=(264,1544), corner_timer=0.30
+[12:07:44] [INFO] [Player.Grenade.Simple] Throwing! Target: (898.5376, 1568.0446), Distance: 575,0, Speed: 587,4, Friction: 300,0
+[12:07:44] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,037874915
+[12:07:44] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[12:07:44] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.9992828, 0.03786586), speed=587,4, spawn=(323.95697, 1546.272)
+[12:07:44] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.999283, 0.037866), Speed: 587.4 (clamped from 587.4, max: 850.0)
+[12:07:44] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[12:07:44] [INFO] [DroneGrenade] Camera attached to drone
+[12:07:44] [INFO] [DroneGrenade] Player control disabled
+[12:07:44] [INFO] [DroneGrenade] PILOTING phase started at (323.957, 1546.272)
+[12:07:44] [INFO] [DroneGrenade] Drone launched at (323.957, 1546.272)
+[12:07:44] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[12:07:44] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[12:07:44] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[12:07:44] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[12:07:44] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:44] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:44] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[12:07:44] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=16.1°, current=-73.9°, player=(264,1544), corner_timer=-0.02
+[12:07:44] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -73.9°
+[12:07:44] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-73.9°, current=-71.0°, player=(264,1544), corner_timer=0.30
+[12:07:45] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-3.9°, current=-77.9°, player=(264,1544), corner_timer=-0.02
+[12:07:45] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -93.1°
+[12:07:45] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-93.1°, current=-75.9°, player=(264,1544), corner_timer=0.30
+[12:07:45] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=12
+[12:07:45] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[12:07:45] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=28.3°, current=-90.0°, player=(264,1544), corner_timer=-0.02
+[12:07:45] [ENEMY] [PatrolEnemy3] PATROL corner check: angle -60.4°
+[12:07:45] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-60.4°, current=-84.1°, player=(264,1544), corner_timer=0.30
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=69.5°, current=-56.8°, player=(264,1544), corner_timer=-0.02
+[12:07:45] [ENEMY] [PatrolEnemy3] PATROL corner check: angle 34.1°
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [ENEMY] [PatrolEnemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=34.1°, current=-50.8°, player=(264,1544), corner_timer=0.30
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:45] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:46] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:46] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:46] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:46] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:46] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[12:07:46] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:46] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=12
+[12:07:46] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:46] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:46] [INFO] [GrenadeTimer] Flashbang grenade landed at (474.07086, 1546.272)
+[12:07:46] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(474.0709, 1546.272), source=NEUTRAL (DroneGrenade), range=112, listeners=12
+[12:07:46] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=12, self=0
+[12:07:46] [INFO] [GrenadeTimer] Emitted grenade landing sound at (474.07086, 1546.272)
+[12:07:46] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-113.3°, current=3.6°, player=(264,1544), corner_timer=-0.02
+[12:07:46] [ENEMY] [PatrolEnemy1] PATROL corner check: angle 156.9°
+[12:07:46] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.4°, current=175.6°, player=(264,1544), corner_timer=-0.02
+[12:07:46] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:46] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-4.4°, player=(264,1544), corner_timer=-0.02
+[12:07:46] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:46] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=156.9°, current=3.8°, player=(264,1544), corner_timer=0.30
+[12:07:46] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=169.7°, player=(264,1544), corner_timer=0.30
+[12:07:46] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-10.3°, player=(264,1544), corner_timer=0.30
+[12:07:46] [INFO] [GrenadeBase] Collision detected with SpawnCover (type: StaticBody2D)
+[12:07:46] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-89.4°, current=116.3°, player=(264,1544), corner_timer=-0.02
+[12:07:46] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -179.4°
+[12:07:46] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=57.2°, player=(264,1544), corner_timer=-0.02
+[12:07:46] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:46] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=-122.8°, player=(264,1544), corner_timer=-0.02
+[12:07:46] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:46] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-179.4°, current=122.2°, player=(264,1544), corner_timer=0.30
+[12:07:46] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=57.0°, player=(264,1544), corner_timer=0.30
+[12:07:46] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-123.0°, player=(264,1544), corner_timer=0.30
+[12:07:46] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-89.4°, current=-174.9°, player=(264,1544), corner_timer=-0.02
+[12:07:46] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -179.4°
+[12:07:46] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=-5.2°, player=(264,1544), corner_timer=-0.02
+[12:07:46] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:46] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=175.4°, player=(264,1544), corner_timer=-0.02
+[12:07:46] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:46] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-179.4°, current=-168.9°, player=(264,1544), corner_timer=0.30
+[12:07:46] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=-5.4°, player=(264,1544), corner_timer=0.30
+[12:07:46] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=175.2°, player=(264,1544), corner_timer=0.30
+[12:07:47] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=12
+[12:07:47] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-89.4°, current=-174.2°, player=(264,1544), corner_timer=-0.02
+[12:07:47] [ENEMY] [PatrolEnemy1] PATROL corner check: angle -179.4°
+[12:07:47] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=89.3°, current=-0.7°, player=(264,1544), corner_timer=-0.02
+[12:07:47] [ENEMY] [PatrolEnemy2] PATROL corner check: angle -0.7°
+[12:07:47] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-90.0°, current=180.0°, player=(264,1544), corner_timer=-0.02
+[12:07:47] [ENEMY] [PatrolEnemy4] PATROL corner check: angle 180.0°
+[12:07:47] [ENEMY] [PatrolEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-179.4°, current=-171.3°, player=(264,1544), corner_timer=0.30
+[12:07:47] [ENEMY] [PatrolEnemy2] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.7°, current=2.2°, player=(264,1544), corner_timer=0.30
+[12:07:47] [ENEMY] [PatrolEnemy4] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=180.0°, current=-177.1°, player=(264,1544), corner_timer=0.30
+[12:07:47] [INFO] [GameManager] restart_scene() — starting scene reload
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy2 (remaining: 11)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy1 (remaining: 10)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy4 (remaining: 9)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy3 (remaining: 8)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy2 (remaining: 7)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy1 (remaining: 6)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy6 (remaining: 5)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy5 (remaining: 4)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy4 (remaining: 3)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy3 (remaining: 2)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy2 (remaining: 1)
+[12:07:47] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy1 (remaining: 0)
+[12:07:47] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:47] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy1] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy1] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy1] BloodyFeetComponent ready on GuardEnemy1
+[12:07:47] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:07:47] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:47] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:07:47] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:07:47] [INFO] [CinemaEffects] Scene changed to: TestTier
+[12:07:47] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:07:47] [INFO] [BlackMetalEffectsManager] Scene changed to: TestTier
+[12:07:47] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:07:47] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:47] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/TestTier.tscn
+[12:07:47] [ENEMY] [GuardEnemy1] Death animation component initialized
+[12:07:47] [ENEMY] [GuardEnemy1] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy2] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy2] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy2] BloodyFeetComponent ready on GuardEnemy2
+[12:07:47] [ENEMY] [GuardEnemy2] Death animation component initialized
+[12:07:47] [ENEMY] [GuardEnemy2] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy3] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy3] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy3] BloodyFeetComponent ready on GuardEnemy3
+[12:07:47] [ENEMY] [GuardEnemy3] Death animation component initialized
+[12:07:47] [ENEMY] [GuardEnemy3] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy4] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy4] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy4] BloodyFeetComponent ready on GuardEnemy4
+[12:07:47] [ENEMY] [GuardEnemy4] Death animation component initialized
+[12:07:47] [ENEMY] [GuardEnemy4] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy5] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy5] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy5] BloodyFeetComponent ready on GuardEnemy5
+[12:07:47] [ENEMY] [GuardEnemy5] Death animation component initialized
+[12:07:47] [ENEMY] [GuardEnemy5] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy6] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy6] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy6] BloodyFeetComponent ready on GuardEnemy6
+[12:07:47] [ENEMY] [GuardEnemy6] Death animation component initialized
+[12:07:47] [ENEMY] [GuardEnemy6] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy1] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy1] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy1] BloodyFeetComponent ready on PatrolEnemy1
+[12:07:47] [ENEMY] [PatrolEnemy1] Death animation component initialized
+[12:07:47] [ENEMY] [PatrolEnemy1] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy2] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy2] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy2] BloodyFeetComponent ready on PatrolEnemy2
+[12:07:47] [ENEMY] [PatrolEnemy2] Death animation component initialized
+[12:07:47] [ENEMY] [PatrolEnemy2] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy3] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy3] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy3] BloodyFeetComponent ready on PatrolEnemy3
+[12:07:47] [ENEMY] [PatrolEnemy3] Death animation component initialized
+[12:07:47] [ENEMY] [PatrolEnemy3] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy4] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy4] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy4] BloodyFeetComponent ready on PatrolEnemy4
+[12:07:47] [ENEMY] [PatrolEnemy4] Death animation component initialized
+[12:07:47] [ENEMY] [PatrolEnemy4] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy1] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy1] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy1] BloodyFeetComponent ready on RpgEnemy1
+[12:07:47] [ENEMY] [RpgEnemy1] Death animation component initialized
+[12:07:47] [ENEMY] [RpgEnemy1] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy2] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy2] Found EnemyModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy2] BloodyFeetComponent ready on RpgEnemy2
+[12:07:47] [ENEMY] [RpgEnemy2] Death animation component initialized
+[12:07:47] [ENEMY] [RpgEnemy2] [Gunslinger] Enemy glow applied
+[12:07:47] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:47] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:07:47] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:07:47] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:07:47] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:07:47] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:07:47] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:07:47] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:07:47] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:07:47] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:07:47] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:07:47] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:07:47] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:07:47] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:07:47] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[12:07:47] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:07:47] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:07:47] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:07:47] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:07:47] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:07:47] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:07:47] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:07:47] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:07:47] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:07:47] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:07:47] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:07:47] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:07:47] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:07:47] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:07:47] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:07:47] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:07:47] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:07:47] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:07:47] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:07:47] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:07:47] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:07:47] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:07:47] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:07:47] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:07:47] [INFO] [Player.Jammer] JammerHUD initialized
+[12:07:47] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:07:47] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[12:07:47] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:07:47] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:07:47] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:07:47] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[12:07:47] [INFO] [GameManager] set_player() called with: <CharacterBody2D#609935691702> (class: CharacterBody2D)
+[12:07:47] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:07:47] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:07:47] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:07:47] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:07:47] [INFO] [ScoreManager] Level started with 12 enemies
+[12:07:47] [INFO] [TestTier] ReplayManager found as C# autoload - verified OK
+[12:07:47] [INFO] [ReplayManager] Replay data cleared
+[12:07:47] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:07:47] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:07:47] [INFO] [ReplayManager] Level: TestTier
+[12:07:47] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:07:47] [INFO] [ReplayManager] Enemies count: 12
+[12:07:47] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:07:47] [INFO] [ReplayManager]   Enemy 0: GuardEnemy1
+[12:07:47] [INFO] [ReplayManager]   Enemy 1: GuardEnemy2
+[12:07:47] [INFO] [ReplayManager]   Enemy 2: GuardEnemy3
+[12:07:47] [INFO] [ReplayManager]   Enemy 3: GuardEnemy4
+[12:07:47] [INFO] [ReplayManager]   Enemy 4: GuardEnemy5
+[12:07:47] [INFO] [ReplayManager]   Enemy 5: GuardEnemy6
+[12:07:47] [INFO] [ReplayManager]   Enemy 6: PatrolEnemy1
+[12:07:47] [INFO] [ReplayManager]   Enemy 7: PatrolEnemy2
+[12:07:47] [INFO] [ReplayManager]   Enemy 8: PatrolEnemy3
+[12:07:47] [INFO] [ReplayManager]   Enemy 9: PatrolEnemy4
+[12:07:47] [INFO] [ReplayManager]   Enemy 10: RpgEnemy1
+[12:07:47] [INFO] [ReplayManager]   Enemy 11: RpgEnemy2
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy1] Blood detector created and attached to GuardEnemy1
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy1] Snow surface detector created on GuardEnemy1
+[12:07:47] [INFO] [CinemaEffects] Found player node: Player
+[12:07:47] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:07:47] [INFO] [SoundPropagation] Registered listener: GuardEnemy1 (total: 1)
+[12:07:47] [ENEMY] [GuardEnemy1] Registered as sound listener
+[12:07:47] [ENEMY] [GuardEnemy1] Spawned at (2800, 600), hp: 1, behavior: GUARD
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy2] Blood detector created and attached to GuardEnemy2
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy2] Snow surface detector created on GuardEnemy2
+[12:07:47] [INFO] [SoundPropagation] Registered listener: GuardEnemy2 (total: 2)
+[12:07:47] [ENEMY] [GuardEnemy2] Registered as sound listener
+[12:07:47] [ENEMY] [GuardEnemy2] Spawned at (2800, 1000), hp: 1, behavior: GUARD
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy3] Blood detector created and attached to GuardEnemy3
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy3] Snow surface detector created on GuardEnemy3
+[12:07:47] [INFO] [SoundPropagation] Registered listener: GuardEnemy3 (total: 3)
+[12:07:47] [ENEMY] [GuardEnemy3] Registered as sound listener
+[12:07:47] [ENEMY] [GuardEnemy3] Spawned at (3400, 600), hp: 2, behavior: GUARD
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy4] Blood detector created and attached to GuardEnemy4
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy4] Snow surface detector created on GuardEnemy4
+[12:07:47] [INFO] [SoundPropagation] Registered listener: GuardEnemy4 (total: 4)
+[12:07:47] [ENEMY] [GuardEnemy4] Registered as sound listener
+[12:07:47] [ENEMY] [GuardEnemy4] Spawned at (3400, 1000), hp: 1, behavior: GUARD
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy5] Blood detector created and attached to GuardEnemy5
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy5] Snow surface detector created on GuardEnemy5
+[12:07:47] [INFO] [SoundPropagation] Registered listener: GuardEnemy5 (total: 5)
+[12:07:47] [ENEMY] [GuardEnemy5] Registered as sound listener
+[12:07:47] [ENEMY] [GuardEnemy5] Spawned at (3000, 2100), hp: 1, behavior: GUARD
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy6] Blood detector created and attached to GuardEnemy6
+[12:07:47] [INFO] [BloodyFeet:GuardEnemy6] Snow surface detector created on GuardEnemy6
+[12:07:47] [INFO] [SoundPropagation] Registered listener: GuardEnemy6 (total: 6)
+[12:07:47] [ENEMY] [GuardEnemy6] Registered as sound listener
+[12:07:47] [ENEMY] [GuardEnemy6] Spawned at (3000, 2400), hp: 2, behavior: GUARD
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy1] Blood detector created and attached to PatrolEnemy1
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy1] Snow surface detector created on PatrolEnemy1
+[12:07:47] [INFO] [SoundPropagation] Registered listener: PatrolEnemy1 (total: 7)
+[12:07:47] [ENEMY] [PatrolEnemy1] Registered as sound listener
+[12:07:47] [ENEMY] [PatrolEnemy1] Spawned at (2400, 800), hp: 2, behavior: PATROL
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy2] Blood detector created and attached to PatrolEnemy2
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy2] Snow surface detector created on PatrolEnemy2
+[12:07:47] [INFO] [SoundPropagation] Registered listener: PatrolEnemy2 (total: 8)
+[12:07:47] [ENEMY] [PatrolEnemy2] Registered as sound listener
+[12:07:47] [ENEMY] [PatrolEnemy2] Spawned at (2400, 2300), hp: 1, behavior: PATROL
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy3] Blood detector created and attached to PatrolEnemy3
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy3] Snow surface detector created on PatrolEnemy3
+[12:07:47] [INFO] [SoundPropagation] Registered listener: PatrolEnemy3 (total: 9)
+[12:07:47] [ENEMY] [PatrolEnemy3] Registered as sound listener
+[12:07:47] [ENEMY] [PatrolEnemy3] Spawned at (2800, 1544), hp: 1, behavior: PATROL
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy4] Blood detector created and attached to PatrolEnemy4
+[12:07:47] [INFO] [BloodyFeet:PatrolEnemy4] Snow surface detector created on PatrolEnemy4
+[12:07:47] [INFO] [SoundPropagation] Registered listener: PatrolEnemy4 (total: 10)
+[12:07:47] [ENEMY] [PatrolEnemy4] Registered as sound listener
+[12:07:47] [ENEMY] [PatrolEnemy4] Spawned at (3600, 1544), hp: 2, behavior: PATROL
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy1] Blood detector created and attached to RpgEnemy1
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy1] Snow surface detector created on RpgEnemy1
+[12:07:47] [INFO] [SoundPropagation] Registered listener: RpgEnemy1 (total: 11)
+[12:07:47] [ENEMY] [RpgEnemy1] Registered as sound listener
+[12:07:47] [ENEMY] [RpgEnemy1] Spawned at (3700, 1400), hp: 1, behavior: GUARD
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy2] Blood detector created and attached to RpgEnemy2
+[12:07:47] [INFO] [BloodyFeet:RpgEnemy2] Snow surface detector created on RpgEnemy2
+[12:07:47] [INFO] [SoundPropagation] Registered listener: RpgEnemy2 (total: 12)
+[12:07:47] [ENEMY] [RpgEnemy2] Registered as sound listener
+[12:07:47] [ENEMY] [RpgEnemy2] Spawned at (2000, 2200), hp: 1, behavior: GUARD
+[12:07:47] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:07:47] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:07:47] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 12) - skipping fallback
+[12:07:47] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=12
+[12:07:47] [ENEMY] [PatrolEnemy1] Patrol points snapped to navmesh (Issue #1216)
+[12:07:47] [ENEMY] [PatrolEnemy2] Patrol points snapped to navmesh (Issue #1216)
+[12:07:47] [ENEMY] [PatrolEnemy3] Patrol points snapped to navmesh (Issue #1216)
+[12:07:47] [ENEMY] [PatrolEnemy4] Patrol points snapped to navmesh (Issue #1216)
+[12:07:47] [ENEMY] [GuardEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:47] [ENEMY] [GuardEnemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:47] [ENEMY] [GuardEnemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:47] [ENEMY] [GuardEnemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:47] [ENEMY] [GuardEnemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:47] [ENEMY] [RpgEnemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(264,1544), corner_timer=0.00
+[12:07:47] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:07:47] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:07:47] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:07:47] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:07:47] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:07:47] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:07:47] [INFO] [LastChance] Found player: Player
+[12:07:47] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:07:47] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:07:47] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:07:47] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:07:48] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=12
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy2 (remaining: 11)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: RpgEnemy1 (remaining: 10)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy4 (remaining: 9)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy3 (remaining: 8)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy2 (remaining: 7)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: PatrolEnemy1 (remaining: 6)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy6 (remaining: 5)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy5 (remaining: 4)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy4 (remaining: 3)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy3 (remaining: 2)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy2 (remaining: 1)
+[12:07:48] [INFO] [SoundPropagation] Unregistered listener: GuardEnemy1 (remaining: 0)
+[12:07:48] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:48] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:07:48] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:07:48] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:48] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:07:48] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:07:48] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[12:07:48] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:07:48] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[12:07:48] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:07:48] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:48] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[12:07:48] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:48] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:07:48] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:07:48] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:07:48] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:07:48] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[12:07:48] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:07:48] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:07:48] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:07:48] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:07:48] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:07:48] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:07:48] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:07:48] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:07:48] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[12:07:48] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:07:48] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:07:48] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:07:48] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:07:48] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:07:48] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:07:48] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:07:48] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:07:48] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:07:48] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:07:48] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:07:48] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:07:48] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:07:48] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:07:48] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:07:48] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:07:48] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:07:48] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:07:48] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:07:48] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:07:48] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:07:48] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:07:48] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:07:48] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:07:48] [INFO] [Player.Jammer] JammerHUD initialized
+[12:07:48] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:07:48] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 2/4
+[12:07:48] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:07:48] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:07:48] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:07:48] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[12:07:48] [INFO] [GameManager] set_player() called with: <CharacterBody2D#660518999416> (class: CharacterBody2D)
+[12:07:48] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:07:48] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:07:48] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:07:48] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:07:48] [INFO] [CinemaEffects] Found player node: Player
+[12:07:48] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:07:48] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:07:48] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:07:48] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:07:48] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:07:48] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:07:48] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:07:48] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:07:48] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:07:48] [INFO] [LastChance] Found player: Player
+[12:07:48] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:07:48] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:07:48] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:07:48] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:07:49] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:49] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[12:07:49] [INFO] [Player.Grenade] G pressed - starting grab animation
+[12:07:49] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[12:07:49] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[12:07:49] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[12:07:49] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:49] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (624.39905, 481.55276)
+[12:07:49] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[12:07:49] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[12:07:49] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[12:07:49] [INFO] [DroneGrenade] Ready
+[12:07:49] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[12:07:49] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[12:07:49] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[12:07:49] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[12:07:49] [INFO] [Player.Grenade] Timer started, grenade created at (150, 360)
+[12:07:49] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[12:07:49] [INFO] [Player.Grenade] Step 1 complete! Drag: (177.44745, -8.762817)
+[12:07:49] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[12:07:49] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[12:07:49] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:49] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:49] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:49] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:49] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:49] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:49] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[12:07:49] [INFO] [ReplayManager] Recording frame 120 (2,1s): player_valid=False, enemies=12
+[12:07:49] [INFO] [Player.Grenade.Simple] Throwing! Target: (853.7669, 393.49536), Distance: 644,6, Speed: 621,9, Friction: 300,0
+[12:07:49] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,04755851
+[12:07:49] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[12:07:49] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.9988693, 0.047540583), speed=621,9, spawn=(209.93216, 362.85245)
+[12:07:49] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.998869, 0.047541), Speed: 621.9 (clamped from 621.9, max: 850.0)
+[12:07:49] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[12:07:49] [INFO] [DroneGrenade] Camera attached to drone
+[12:07:49] [INFO] [DroneGrenade] Player control disabled
+[12:07:49] [INFO] [DroneGrenade] PILOTING phase started at (209.9322, 362.8524)
+[12:07:49] [INFO] [DroneGrenade] Drone launched at (209.9322, 362.8524)
+[12:07:49] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[12:07:49] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[12:07:49] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[12:07:49] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[12:07:49] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:49] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:49] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[12:07:50] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[12:07:50] [INFO] [ReplayManager] Recording frame 180 (3,1s): player_valid=False, enemies=12
+[12:07:51] [INFO] [ReplayManager] Recording frame 240 (4,1s): player_valid=False, enemies=12
+[12:07:52] [INFO] [ReplayManager] Recording frame 300 (5,1s): player_valid=False, enemies=12
+[12:07:53] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[12:07:53] [INFO] [ReplayManager] Recording frame 360 (6,1s): player_valid=False, enemies=12
+[12:07:54] [INFO] [GrenadeTimer] Flashbang grenade landed at (412.21207, 362.85245)
+[12:07:54] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(412.2121, 362.8524), source=NEUTRAL (DroneGrenade), range=112, listeners=0
+[12:07:54] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[12:07:54] [INFO] [GrenadeTimer] Emitted grenade landing sound at (412.21207, 362.85245)
+[12:07:54] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:07:54] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:07:54] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:07:54] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:07:54] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:07:54] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:07:54] [INFO] [ReplayManager] Recording frame 420 (7,1s): player_valid=False, enemies=12
+[12:07:55] [INFO] [ReplayManager] Recording frame 480 (8,1s): player_valid=False, enemies=12
+[12:07:56] [INFO] [ReplayManager] Recording frame 540 (9,1s): player_valid=False, enemies=12
+[12:07:56] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:56] [INFO] [PersistManager] Last level saved: res://scenes/levels/LabyrinthLevel.tscn
+[12:07:56] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/LabyrinthLevel.tscn
+[12:07:57] [INFO] [SceneLoader] Background load started successfully
+[12:07:57] [INFO] [SceneLoader] Background load complete: res://scenes/levels/LabyrinthLevel.tscn
+[12:07:57] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:57] [INFO] [SceneLoader] Scene changed successfully
+[12:07:57] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:07:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:57] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[12:07:57] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[12:07:57] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[12:07:57] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:07:57] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:07:57] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:07:57] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:07:57] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[12:07:57] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:07:57] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[12:07:57] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:07:57] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:07:57] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/LabyrinthLevel.tscn
+[12:07:57] [ENEMY] [Enemy1] Death animation component initialized
+[12:07:57] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[12:07:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:57] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[12:07:57] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[12:07:57] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[12:07:57] [ENEMY] [Enemy2] Death animation component initialized
+[12:07:57] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[12:07:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:57] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[12:07:57] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[12:07:57] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[12:07:57] [ENEMY] [Enemy3] Death animation component initialized
+[12:07:57] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[12:07:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:57] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[12:07:57] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[12:07:57] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[12:07:57] [ENEMY] [Enemy4] Death animation component initialized
+[12:07:57] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[12:07:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:57] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[12:07:57] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[12:07:57] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[12:07:57] [ENEMY] [Enemy5] Death animation component initialized
+[12:07:57] [ENEMY] [Enemy5] [Gunslinger] Enemy glow applied
+[12:07:57] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:07:57] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:07:57] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:07:57] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:07:57] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:07:57] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:07:57] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:07:57] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:07:57] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:07:57] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:07:57] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:07:57] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:07:57] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:07:57] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:07:57] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[12:07:57] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:07:57] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:07:57] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:07:57] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:07:57] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:07:57] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:07:57] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:07:57] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:07:57] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:07:57] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:07:57] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:07:57] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:07:57] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:07:57] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:07:57] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:07:57] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:07:57] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:07:57] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:07:57] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:07:57] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:07:57] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:07:57] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:07:57] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:07:57] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:07:57] [INFO] [Player.Jammer] JammerHUD initialized
+[12:07:57] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:07:57] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 3/4
+[12:07:57] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:07:57] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[12:07:57] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[12:07:57] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[12:07:57] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[12:07:57] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[12:07:57] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[12:07:57] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[12:07:57] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[12:07:57] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[12:07:57] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/210
+[12:07:57] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[12:07:57] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/210
+[12:07:57] [INFO] [GameManager] set_player() called with: <CharacterBody2D#707696529922> (class: CharacterBody2D)
+[12:07:57] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:07:57] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:07:57] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:07:57] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:07:57] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[12:07:57] [INFO] [ScoreManager] Level started with 5 enemies
+[12:07:57] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[12:07:57] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[12:07:57] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[12:07:57] [INFO] [ReplayManager] Replay data cleared
+[12:07:57] [INFO] [LabyrinthLevel] Previous replay data cleared
+[12:07:57] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:07:57] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:07:57] [INFO] [ReplayManager] Level: LabyrinthLevel
+[12:07:57] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:07:57] [INFO] [ReplayManager] Enemies count: 5
+[12:07:57] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:07:57] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[12:07:57] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[12:07:57] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[12:07:57] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[12:07:57] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[12:07:57] [INFO] [LabyrinthLevel] Replay recording started successfully
+[12:07:57] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[12:07:57] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[12:07:57] [INFO] [CinemaEffects] Found player node: Player
+[12:07:57] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:07:57] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[12:07:57] [ENEMY] [Enemy1] Registered as sound listener
+[12:07:57] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[12:07:57] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[12:07:57] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[12:07:57] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[12:07:57] [ENEMY] [Enemy2] Registered as sound listener
+[12:07:57] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[12:07:57] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[12:07:57] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[12:07:57] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[12:07:57] [ENEMY] [Enemy3] Registered as sound listener
+[12:07:57] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[12:07:57] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[12:07:57] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[12:07:57] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[12:07:57] [ENEMY] [Enemy4] Registered as sound listener
+[12:07:57] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[12:07:57] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[12:07:57] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[12:07:57] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[12:07:57] [ENEMY] [Enemy5] Registered as sound listener
+[12:07:57] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 1, behavior: GUARD
+[12:07:57] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:07:57] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:07:57] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[12:07:58] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[12:07:58] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:07:58] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:07:58] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:07:58] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:07:58] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:07:58] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:07:58] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:07:58] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:07:58] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:07:58] [INFO] [LastChance] Found player: Player
+[12:07:58] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:07:58] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:07:58] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:07:58] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:07:58] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:58] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[12:07:58] [INFO] [Player.Grenade] G pressed - starting grab animation
+[12:07:58] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:07:58] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (262.55182, 759.4265)
+[12:07:58] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[12:07:58] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[12:07:58] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[12:07:58] [INFO] [DroneGrenade] Ready
+[12:07:58] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[12:07:58] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[12:07:58] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[12:07:58] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[12:07:58] [INFO] [Player.Grenade] Timer started, grenade created at (150, 1000)
+[12:07:58] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[12:07:58] [INFO] [Player.Grenade] Step 1 complete! Drag: (212.16025, -8.520752)
+[12:07:58] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[12:07:58] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:07:58] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[12:07:58] [INFO] [Player.Grenade.Simple] Throwing! Target: (297.6317, 680.42993), Distance: 292,0, Speed: 418,6, Friction: 300,0
+[12:07:58] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,138033
+[12:07:58] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[12:07:58] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.41938093, -0.90781033), speed=418,6, spawn=(175.16286, 945.5314)
+[12:07:58] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.419381, -0.90781), Speed: 418.6 (clamped from 418.6, max: 850.0)
+[12:07:58] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[12:07:58] [INFO] [DroneGrenade] Camera attached to drone
+[12:07:58] [INFO] [DroneGrenade] Player control disabled
+[12:07:58] [INFO] [DroneGrenade] PILOTING phase started at (175.1629, 945.5314)
+[12:07:58] [INFO] [DroneGrenade] Drone launched at (175.1629, 945.5314)
+[12:07:58] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[12:07:58] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[12:07:58] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:58] [INFO] [Player.Grenade] State reset to IDLE
+[12:07:58] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[12:07:58] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[12:07:59] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[12:07:59] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=-0.0°, player=(150,1000), corner_timer=0.30
+[12:07:59] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-54.4°, player=(150,1000), corner_timer=-0.02
+[12:07:59] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[12:07:59] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(150,1000), corner_timer=0.30
+[12:07:59] [INFO] [GrenadeTimer] Flashbang grenade landed at (175.16286, 842.00195)
+[12:07:59] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(175.1629, 842.002), source=NEUTRAL (DroneGrenade), range=112, listeners=5
+[12:07:59] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0
+[12:07:59] [INFO] [GrenadeTimer] Emitted grenade landing sound at (175.16286, 842.00195)
+[12:07:59] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[12:08:00] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[12:08:00] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[12:08:00] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[12:08:00] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[12:08:00] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[12:08:01] [INFO] [GameManager] restart_scene() — starting scene reload
+[12:08:01] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[12:08:01] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[12:08:01] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[12:08:01] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[12:08:01] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[12:08:01] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:08:01] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:08:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:08:01] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[12:08:01] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[12:08:01] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[12:08:01] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:08:01] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:08:01] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:08:01] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:08:01] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[12:08:01] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:08:01] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[12:08:01] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:08:01] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:08:01] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/LabyrinthLevel.tscn
+[12:08:01] [ENEMY] [Enemy1] Death animation component initialized
+[12:08:01] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[12:08:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:08:01] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[12:08:01] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[12:08:01] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[12:08:01] [ENEMY] [Enemy2] Death animation component initialized
+[12:08:01] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[12:08:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:08:01] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[12:08:01] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[12:08:01] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[12:08:01] [ENEMY] [Enemy3] Death animation component initialized
+[12:08:01] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[12:08:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:08:01] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[12:08:01] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[12:08:01] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[12:08:01] [ENEMY] [Enemy4] Death animation component initialized
+[12:08:01] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[12:08:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:08:01] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[12:08:01] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[12:08:01] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[12:08:01] [ENEMY] [Enemy5] Death animation component initialized
+[12:08:01] [ENEMY] [Enemy5] [Gunslinger] Enemy glow applied
+[12:08:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:08:01] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:08:01] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:08:01] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:08:01] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:08:01] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:08:01] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:08:01] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:08:01] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:08:01] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:08:01] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:08:01] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:08:01] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:08:01] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:08:01] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[12:08:01] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:08:01] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:08:01] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:08:01] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:08:01] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:08:01] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:08:01] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:08:01] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:08:01] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:08:01] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:08:01] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:08:01] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:08:01] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:08:01] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:08:01] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:08:01] [INFO] [Player.ItemVisual] Visual applied for item type: 0
+[12:08:01] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:08:01] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:08:01] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:08:01] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:08:01] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[12:08:01] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:08:01] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:08:01] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:08:01] [INFO] [Player.Jammer] JammerHUD initialized
+[12:08:01] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:08:01] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 4/4
+[12:08:01] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:08:01] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[12:08:01] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[12:08:01] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[12:08:01] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[12:08:01] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[12:08:01] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[12:08:01] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[12:08:01] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[12:08:01] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[12:08:01] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/210
+[12:08:01] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[12:08:01] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/210
+[12:08:01] [INFO] [GameManager] set_player() called with: <CharacterBody2D#746804218266> (class: CharacterBody2D)
+[12:08:01] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:08:01] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:08:01] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:08:01] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:08:01] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[12:08:01] [INFO] [ScoreManager] Level started with 5 enemies
+[12:08:01] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[12:08:02] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[12:08:02] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[12:08:02] [INFO] [ReplayManager] Replay data cleared
+[12:08:02] [INFO] [LabyrinthLevel] Previous replay data cleared
+[12:08:02] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:08:02] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:08:02] [INFO] [ReplayManager] Level: LabyrinthLevel
+[12:08:02] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:08:02] [INFO] [ReplayManager] Enemies count: 5
+[12:08:02] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:08:02] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[12:08:02] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[12:08:02] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[12:08:02] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[12:08:02] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[12:08:02] [INFO] [LabyrinthLevel] Replay recording started successfully
+[12:08:02] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[12:08:02] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[12:08:02] [INFO] [CinemaEffects] Found player node: Player
+[12:08:02] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:08:02] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[12:08:02] [ENEMY] [Enemy1] Registered as sound listener
+[12:08:02] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[12:08:02] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[12:08:02] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[12:08:02] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[12:08:02] [ENEMY] [Enemy2] Registered as sound listener
+[12:08:02] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[12:08:02] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[12:08:02] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[12:08:02] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[12:08:02] [ENEMY] [Enemy3] Registered as sound listener
+[12:08:02] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[12:08:02] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[12:08:02] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[12:08:02] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[12:08:02] [ENEMY] [Enemy4] Registered as sound listener
+[12:08:02] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[12:08:02] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[12:08:02] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[12:08:02] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[12:08:02] [ENEMY] [Enemy5] Registered as sound listener
+[12:08:02] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 2, behavior: GUARD
+[12:08:02] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:08:02] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:08:02] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[12:08:02] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[12:08:02] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:08:02] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:08:02] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=315.0°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:08:02] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:08:02] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:08:02] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:08:02] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:08:02] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:08:02] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:08:02] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:08:02] [INFO] [LastChance] Found player: Player
+[12:08:02] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:08:02] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:08:02] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:08:02] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:08:02] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:08:02] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[12:08:02] [INFO] [Player.Grenade] G pressed - starting grab animation
+[12:08:02] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:08:02] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (160.20029, 792.661)
+[12:08:03] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[12:08:03] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[12:08:03] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[12:08:03] [INFO] [DroneGrenade] Ready
+[12:08:03] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[12:08:03] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[12:08:03] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[12:08:03] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[12:08:03] [INFO] [Player.Grenade] Timer started, grenade created at (150, 1000)
+[12:08:03] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[12:08:03] [INFO] [Player.Grenade] Step 1 complete! Drag: (133.98822, 18.630676)
+[12:08:03] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[12:08:03] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[12:08:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:08:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:08:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:08:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:08:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:08:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:08:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:08:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:08:03] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[12:08:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:08:03] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[12:08:03] [WARN] [FPS] Drop detected: 21 fps (threshold: 30)
+[12:08:03] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[12:08:03] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[12:08:04] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-54.4°, player=(150,1000), corner_timer=-0.02
+[12:08:04] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[12:08:04] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(150,1000), corner_timer=0.30
+[12:08:04] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[12:08:04] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[12:08:04] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[12:08:04] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[12:08:04] [INFO] [Player.Grenade.Simple] Throwing! Target: (407.41483, 412.00778), Distance: 581,9, Speed: 590,9, Friction: 300,0
+[12:08:04] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,1581458
+[12:08:04] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[12:08:04] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.40103886, -0.9160611), speed=590,9, spawn=(174.06233, 945.0363)
+[12:08:04] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.401039, -0.916061), Speed: 590.9 (clamped from 590.9, max: 850.0)
+[12:08:04] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[12:08:04] [INFO] [DroneGrenade] Camera attached to drone
+[12:08:04] [INFO] [DroneGrenade] Player control disabled
+[12:08:04] [INFO] [DroneGrenade] PILOTING phase started at (174.0623, 945.0363)
+[12:08:04] [INFO] [DroneGrenade] Drone launched at (174.0623, 945.0363)
+[12:08:04] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[12:08:04] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[12:08:04] [INFO] [Player.Grenade] State reset to IDLE
+[12:08:04] [INFO] [Player.Grenade] State reset to IDLE
+[12:08:04] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[12:08:05] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[12:08:06] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[12:08:06] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-85.8°, player=(150,1000), corner_timer=-0.02
+[12:08:06] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[12:08:06] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-85.6°, player=(150,1000), corner_timer=0.30
+[12:08:06] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[12:08:06] [INFO] ------------------------------------------------------------
+[12:08:06] [INFO] GAME LOG ENDED: 2026-04-20T12:08:06
+[12:08:06] [INFO] ============================================================

--- a/docs/case-studies/issue-1896/game_log_20260420_123426.txt
+++ b/docs/case-studies/issue-1896/game_log_20260420_123426.txt
@@ -1,0 +1,934 @@
+[12:34:26] [INFO] ============================================================
+[12:34:26] [INFO] GAME LOG STARTED
+[12:34:26] [INFO] ============================================================
+[12:34:26] [INFO] Timestamp: 2026-04-20T12:34:26
+[12:34:26] [INFO] Log file: I:/Загрузки/godot exe/дрон/game_log_20260420_123426.txt
+[12:34:26] [INFO] Executable: I:/Загрузки/godot exe/дрон/Godot-Top-Down-Template.exe
+[12:34:26] [INFO] OS: Windows
+[12:34:26] [INFO] Debug build: false
+[12:34:26] [INFO] Engine version: 4.3-stable (official)
+[12:34:26] [INFO] Project: Godot Top-Down Template
+[12:34:26] [INFO] Build info: not available (build_info.cfg not found)
+[12:34:26] [INFO] ------------------------------------------------------------
+[12:34:26] [INFO] [GameManager] GameManager ready
+[12:34:26] [INFO] [ScoreManager] ScoreManager ready
+[12:34:26] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:34:26] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[12:34:26] [INFO] [DifficultyManager] Loaded difficulty: Power Fantasy (value: 3)
+[12:34:26] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[12:34:26] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[12:34:26] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[12:34:26] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[12:34:26] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[12:34:26] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:34:26] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[12:34:26] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[12:34:26] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[12:34:26] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[12:34:26] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[12:34:26] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[12:34:26] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[12:34:26] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:34:26] [INFO] [LastChance] Last chance shader loaded successfully
+[12:34:26] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[12:34:26] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[12:34:26] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[12:34:26] [INFO] [LastChance]   Sepia intensity: 0.70
+[12:34:26] [INFO] [LastChance]   Brightness: 0.60
+[12:34:26] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[12:34:26] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[12:34:26] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[12:34:26] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[12:34:26] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DroneGrenade.tscn
+[12:34:26] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: false, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: false, FPS drop logging: true, All weapons unlocked: true, All maps unlocked: true, Global stuck max time: 20.0s, Nav mesh visible: false, Search path visible: false, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false, Enemy path visible: false, Cover raycast visible: false, Tactical group: false, Cover infinite rays: true, Cover sector rays: true, Roguelike unlocked: false
+[12:34:26] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[12:34:26] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.50, music: 1.00
+[12:34:26] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true, revolver_aim_assist: true, unlock_notifications: true, combo_font_size: 140
+[12:34:26] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[12:34:26] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[12:34:26] [INFO] [CinemaEffects] Created effects layer at layer 99
+[12:34:26] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[12:34:26] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[12:34:26] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[12:34:26] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[12:34:26] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[12:34:26] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[12:34:26] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[12:34:26] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[12:34:26] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[12:34:26] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[12:34:26] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[12:34:26] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[12:34:26] [INFO] [GrenadeTimerHelper] Autoload ready
+[12:34:26] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:34:26] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[12:34:26] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[12:34:26] [INFO] [PowerFantasy]   Kill effect duration: 600ms
+[12:34:26] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[12:34:26] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[12:34:26] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[12:34:26] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[12:34:26] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[12:34:26] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[12:34:26] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[12:34:26] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[12:34:26] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[12:34:26] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[12:34:26] [INFO] [ProgressManager] ProgressManager ready, loaded 6 entries
+[12:34:26] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[12:34:26] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:34:26] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[12:34:26] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[12:34:26] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[12:34:26] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[12:34:26] [INFO] [SceneLoader] SceneLoader initialized
+[12:34:26] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[12:34:26] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[12:34:26] [INFO] [PersistManager] Restored unlocked weapon: mini_uzi
+[12:34:26] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[12:34:26] [INFO] [PersistManager] Restored kills_without_laser_sight: 75
+[12:34:26] [INFO] [PersistManager] Restored shots_fired_special_weapons: 0
+[12:34:26] [INFO] [PersistManager] Restored total_deaths: 1
+[12:34:26] [INFO] [PersistManager] Restored no_damage_levels_completed: 1
+[12:34:26] [INFO] [PersistManager] Restored levels_completed_rank_a_or_higher: 6
+[12:34:26] [INFO] [PersistManager] Restored kills_through_wall: 0
+[12:34:26] [INFO] [PersistManager] Restored levels_completed_with_silenced_pistol: 0
+[12:34:26] [INFO] [GameManager] Weapon selected: ak_gl
+[12:34:26] [INFO] [PersistManager] Restored selected weapon: ak_gl
+[12:34:26] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[12:34:26] [INFO] [PersistManager] Restored unlocked grenade type: 1
+[12:34:26] [INFO] [PersistManager] Restored unlocked grenade type: 4
+[12:34:26] [INFO] [GrenadeManager] Grenade type changed from Flashbang to Drone
+[12:34:26] [INFO] [PersistManager] Restored selected grenade type: 4
+[12:34:26] [INFO] [PersistManager] Restored unlocked active item type: 0
+[12:34:26] [INFO] [PersistManager] Restored unlocked active item type: 1
+[12:34:26] [INFO] [PersistManager] Restored unlocked active item type: 4
+[12:34:26] [INFO] [PersistManager] Restored unlocked active item type: 11
+[12:34:26] [INFO] [PersistManager] Restored unlocked active item type: 12
+[12:34:26] [INFO] [PersistManager] Restored unlocked active item type: 16
+[12:34:26] [INFO] [PersistManager] Restored unlocked active item type: 17
+[12:34:26] [INFO] [ActiveItemManager] Active item changed from None to Experimental Sample
+[12:34:26] [INFO] [PersistManager] Restored selected active item type: 18
+[12:34:26] [INFO] [PersistManager] Loudspeaker progress restored: level 1, levels_completed=0
+[12:34:26] [INFO] [PersistManager] State loaded successfully
+[12:34:26] [INFO] [PersistManager] PersistManager ready
+[12:34:26] [INFO] [UnlockManager] UnlockManager ready
+[12:34:26] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["makarov_pm", "silenced_pistol", "ak_gl", "sniper", "revolver", "shotgun"]
+[12:34:26] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, warm_lights: true, ai: true
+[12:34:26] [INFO] [LocalizationSettings] Loaded 2 translation(s)
+[12:34:26] [INFO] [LocalizationSettings] LocalizationSettings initialized — locale: en
+[12:34:26] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_condition
+[12:34:26] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_kill_condition
+[12:34:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:26] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[12:34:26] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[12:34:26] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[12:34:26] [ENEMY] [Enemy1] Death animation component initialized
+[12:34:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:26] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[12:34:26] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[12:34:26] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[12:34:26] [ENEMY] [Enemy2] Death animation component initialized
+[12:34:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:26] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[12:34:26] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[12:34:26] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[12:34:26] [ENEMY] [Enemy3] Death animation component initialized
+[12:34:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:26] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[12:34:26] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[12:34:26] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[12:34:26] [ENEMY] [Enemy4] Death animation component initialized
+[12:34:26] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:26] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[12:34:26] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[12:34:26] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[12:34:26] [ENEMY] [Enemy5] Death animation component initialized
+[12:34:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:27] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:34:27] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:34:27] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:34:27] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:34:27] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:34:27] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:34:27] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:34:27] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:34:27] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:34:27] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:34:27] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:34:27] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:34:27] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:34:27] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[12:34:27] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:34:27] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:34:27] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:34:27] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:34:27] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:34:27] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:34:27] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:34:27] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:34:27] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:34:27] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:34:27] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:34:27] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:34:27] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:34:27] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:34:27] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:34:27] [INFO] [Player.ItemVisual] Visual applied for item type: 18
+[12:34:27] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:34:27] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:34:27] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:34:27] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:34:27] [INFO] [Player.ExperimentalSample] Equipped, charges this run: 1
+[12:34:27] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:34:27] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:34:27] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:34:27] [INFO] [Player.Jammer] JammerHUD initialized
+[12:34:27] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:34:27] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 10/10
+[12:34:27] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:34:27] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[12:34:27] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[12:34:27] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[12:34:27] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[12:34:27] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[12:34:27] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[12:34:27] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[12:34:27] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[12:34:27] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[12:34:27] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[12:34:27] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/150
+[12:34:27] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[12:34:27] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/150
+[12:34:27] [INFO] [GameManager] set_player() called with: <CharacterBody2D#86922757902> (class: CharacterBody2D)
+[12:34:27] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:34:27] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:34:27] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:34:27] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:34:27] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[12:34:27] [INFO] [ScoreManager] Level started with 5 enemies
+[12:34:27] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[12:34:27] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[12:34:27] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[12:34:27] [INFO] [ReplayManager] Replay data cleared
+[12:34:27] [INFO] [LabyrinthLevel] Previous replay data cleared
+[12:34:27] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:34:27] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:34:27] [INFO] [ReplayManager] Level: LabyrinthLevel
+[12:34:27] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:34:27] [INFO] [ReplayManager] Enemies count: 5
+[12:34:27] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:34:27] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[12:34:27] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[12:34:27] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[12:34:27] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[12:34:27] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[12:34:27] [INFO] [LabyrinthLevel] Replay recording started successfully
+[12:34:27] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[12:34:27] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[12:34:27] [INFO] [CinemaEffects] Found player node: Player
+[12:34:27] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:34:27] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/SewerLevel.tscn
+[12:34:27] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/SewerLevel.tscn
+[12:34:27] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[12:34:27] [INFO] [UnlockManager] Restored saved unlock for weapon: mini_uzi
+[12:34:27] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[12:34:27] [INFO] [UnlockManager] Skipped restore for weapon 'ak_gl' (condition not met — treating as corrupt save)
+[12:34:27] [INFO] [UnlockManager] Restored saved unlock for grenade type: 1
+[12:34:27] [INFO] [UnlockManager] Restored saved unlock for grenade type: 4
+[12:34:27] [INFO] [UnlockManager] Restored saved unlock for active item type: 1
+[12:34:27] [INFO] [UnlockManager] Restored saved unlock for active item type: 16
+[12:34:27] [INFO] [UnlockManager] Restored saved unlock for active item type: 12
+[12:34:27] [INFO] [UnlockManager] Restored saved unlock for active item type: 4
+[12:34:27] [INFO] [UnlockManager] Restored saved unlock for active item type: 17
+[12:34:27] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[12:34:27] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[12:34:27] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[12:34:27] [ENEMY] [Enemy1] Registered as sound listener
+[12:34:27] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[12:34:27] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[12:34:27] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[12:34:27] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[12:34:27] [ENEMY] [Enemy2] Registered as sound listener
+[12:34:27] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 2, behavior: GUARD
+[12:34:27] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[12:34:27] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[12:34:27] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[12:34:27] [ENEMY] [Enemy3] Registered as sound listener
+[12:34:27] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[12:34:27] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[12:34:27] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[12:34:27] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[12:34:27] [ENEMY] [Enemy4] Registered as sound listener
+[12:34:27] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[12:34:27] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[12:34:27] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[12:34:27] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[12:34:27] [ENEMY] [Enemy5] Registered as sound listener
+[12:34:27] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 2, behavior: GUARD
+[12:34:27] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:34:27] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:34:27] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:34:27] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:34:27] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:34:27] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[12:34:27] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:34:27] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:34:27] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:34:27] [INFO] [PenultimateHit] Shader warmup complete in 1233 ms
+[12:34:27] [INFO] [LastChance] Shader warmup complete in 1232 ms
+[12:34:27] [INFO] [CinemaEffects] Cinema shader warmup complete in 1110 ms
+[12:34:27] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1102 ms
+[12:34:27] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[12:34:27] [INFO] [FlashbangPlayer] Shader warmup complete in 1099 ms
+[12:34:27] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:34:27] [INFO] [SceneLoader] ERROR: Invalid resource (falling back to sync): res://scenes/levels/SewerLevel.tscn
+[12:34:27] [INFO] [SceneLoader] Using synchronous load fallback
+[12:34:28] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[12:34:28] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[12:34:28] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[12:34:28] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[12:34:28] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[12:34:28] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:34:28] [INFO] [SceneLoader] Sync fallback scene changed successfully: res://scenes/levels/SewerLevel.tscn
+[12:34:28] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:Corridor1Guard] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:Corridor1Guard] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:Corridor1Guard] BloodyFeetComponent ready on Corridor1Guard
+[12:34:28] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:34:28] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:34:28] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:34:28] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:34:28] [INFO] [CinemaEffects] Scene changed to: SewerLevel
+[12:34:28] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:34:28] [INFO] [BlackMetalEffectsManager] Scene changed to: SewerLevel
+[12:34:28] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:34:28] [INFO] [PersistManager] Startup navigation complete — arrived at: res://scenes/levels/SewerLevel.tscn
+[12:34:28] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:34:28] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/SewerLevel.tscn
+[12:34:28] [INFO] [EnemyShield] SWAT riot shield visual created with collision area (top-down view)
+[12:34:28] [INFO] [EnemyShield] Setup complete (shield_hp=20, stun=1.0s)
+[12:34:28] [ENEMY] [Corridor1Guard] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:Room1Guard] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:Room1Guard] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:Room1Guard] BloodyFeetComponent ready on Room1Guard
+[12:34:28] [INFO] [EnemyShield] SWAT riot shield visual created with collision area (top-down view)
+[12:34:28] [INFO] [EnemyShield] Setup complete (shield_hp=20, stun=1.0s)
+[12:34:28] [ENEMY] [Room1Guard] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:Corridor2Guard] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:Corridor2Guard] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:Corridor2Guard] BloodyFeetComponent ready on Corridor2Guard
+[12:34:28] [ENEMY] [Corridor2Guard] Death animation component initialized
+[12:34:28] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:Room2Guard] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:Room2Guard] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:Room2Guard] BloodyFeetComponent ready on Room2Guard
+[12:34:28] [ENEMY] [Room2Guard] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:Corridor3Guard] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:Corridor3Guard] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:Corridor3Guard] BloodyFeetComponent ready on Corridor3Guard
+[12:34:28] [ENEMY] [Corridor3Guard] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:Room3Guard] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:Room3Guard] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:Room3Guard] BloodyFeetComponent ready on Room3Guard
+[12:34:28] [ENEMY] [Room3Guard] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:ForkGuardUp] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:ForkGuardUp] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:ForkGuardUp] BloodyFeetComponent ready on ForkGuardUp
+[12:34:28] [ENEMY] [ForkGuardUp] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:ForkGuardRight] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:ForkGuardRight] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:ForkGuardRight] BloodyFeetComponent ready on ForkGuardRight
+[12:34:28] [ENEMY] [ForkGuardRight] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:RoomAGuard] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:RoomAGuard] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:RoomAGuard] BloodyFeetComponent ready on RoomAGuard
+[12:34:28] [ENEMY] [RoomAGuard] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:RoomBGuard] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:RoomBGuard] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:RoomBGuard] BloodyFeetComponent ready on RoomBGuard
+[12:34:28] [ENEMY] [RoomBGuard] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:ExitRoomMachineGunner] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:ExitRoomMachineGunner] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:ExitRoomMachineGunner] BloodyFeetComponent ready on ExitRoomMachineGunner
+[12:34:28] [ENEMY] [ExitRoomMachineGunner] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:TopRoomGuard] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:TopRoomGuard] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:TopRoomGuard] BloodyFeetComponent ready on TopRoomGuard
+[12:34:28] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[12:34:28] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[12:34:28] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[12:34:28] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[12:34:28] [ENEMY] [TopRoomGuard] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:TopRoomGrenadier] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:TopRoomGrenadier] Found EnemyModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:TopRoomGrenadier] BloodyFeetComponent ready on TopRoomGrenadier
+[12:34:28] [ENEMY] [TopRoomGrenadier] Death animation component initialized
+[12:34:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:28] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:34:28] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:34:28] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:34:28] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:34:28] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[12:34:28] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:34:28] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:34:28] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:34:28] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:34:28] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:34:28] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:34:28] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:34:28] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:34:28] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[12:34:28] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:34:28] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:34:28] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:34:28] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:34:28] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:34:28] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:34:28] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:34:28] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:34:28] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:34:28] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:34:28] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:34:28] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:34:28] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:34:28] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:34:28] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:34:28] [INFO] [Player.ItemVisual] Visual applied for item type: 18
+[12:34:28] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:34:28] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:34:28] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:34:28] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:34:28] [INFO] [Player.ExperimentalSample] Equipped, charges this run: 4
+[12:34:28] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:34:28] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:34:28] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:34:28] [INFO] [Player.Jammer] JammerHUD initialized
+[12:34:28] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:34:28] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 10/10
+[12:34:28] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:34:28] [INFO] [SewerLevel] Enemy tracking complete: 13 enemies registered
+[12:34:28] [INFO] [GameManager] set_player() called with: <CharacterBody2D#157051522952> (class: CharacterBody2D)
+[12:34:28] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:34:28] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:34:28] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:34:28] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:34:28] [INFO] [ScoreManager] Level started with 13 enemies
+[12:34:28] [INFO] [SewerLevel] ReplayManager found as C# autoload
+[12:34:28] [INFO] [SewerLevel] Starting replay recording - Player: Player, Enemies count: 13
+[12:34:28] [INFO] [ReplayManager] Replay data cleared
+[12:34:28] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[12:34:28] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[12:34:28] [INFO] [ReplayManager] Level: SewerLevel
+[12:34:28] [INFO] [ReplayManager] Player: Player (valid: True)
+[12:34:28] [INFO] [ReplayManager] Enemies count: 13
+[12:34:28] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[12:34:28] [INFO] [ReplayManager]   Enemy 0: Corridor1Guard
+[12:34:28] [INFO] [ReplayManager]   Enemy 1: Room1Guard
+[12:34:28] [INFO] [ReplayManager]   Enemy 2: Corridor2Guard
+[12:34:28] [INFO] [ReplayManager]   Enemy 3: Room2Guard
+[12:34:28] [INFO] [ReplayManager]   Enemy 4: Corridor3Guard
+[12:34:28] [INFO] [ReplayManager]   Enemy 5: Room3Guard
+[12:34:28] [INFO] [ReplayManager]   Enemy 6: ForkGuardUp
+[12:34:28] [INFO] [ReplayManager]   Enemy 7: ForkGuardRight
+[12:34:28] [INFO] [ReplayManager]   Enemy 8: RoomAGuard
+[12:34:28] [INFO] [ReplayManager]   Enemy 9: RoomBGuard
+[12:34:28] [INFO] [ReplayManager]   Enemy 10: ExitRoomMachineGunner
+[12:34:28] [INFO] [ReplayManager]   Enemy 11: TopRoomGuard
+[12:34:28] [INFO] [ReplayManager]   Enemy 12: TopRoomGrenadier
+[12:34:28] [INFO] [SewerLevel] Replay recording started successfully
+[12:34:28] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:34:28] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:34:28] [INFO] [BloodyFeet:Corridor1Guard] Blood detector created and attached to Corridor1Guard
+[12:34:28] [INFO] [BloodyFeet:Corridor1Guard] Snow surface detector created on Corridor1Guard
+[12:34:28] [INFO] [CinemaEffects] Found player node: Player
+[12:34:28] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:34:28] [INFO] [SoundPropagation] Registered listener: Corridor1Guard (total: 1)
+[12:34:28] [ENEMY] [Corridor1Guard] Registered as sound listener
+[12:34:28] [ENEMY] [Corridor1Guard] Spawned at (200, 2750), hp: 2, behavior: PATROL
+[12:34:28] [INFO] [BloodyFeet:Room1Guard] Blood detector created and attached to Room1Guard
+[12:34:28] [INFO] [BloodyFeet:Room1Guard] Snow surface detector created on Room1Guard
+[12:34:28] [INFO] [SoundPropagation] Registered listener: Room1Guard (total: 2)
+[12:34:28] [ENEMY] [Room1Guard] Registered as sound listener
+[12:34:28] [ENEMY] [Room1Guard] Spawned at (200, 2600), hp: 2, behavior: GUARD
+[12:34:28] [INFO] [BloodyFeet:Corridor2Guard] Blood detector created and attached to Corridor2Guard
+[12:34:28] [INFO] [BloodyFeet:Corridor2Guard] Snow surface detector created on Corridor2Guard
+[12:34:28] [INFO] [SoundPropagation] Registered listener: Corridor2Guard (total: 3)
+[12:34:28] [ENEMY] [Corridor2Guard] Registered as sound listener
+[12:34:28] [ENEMY] [Corridor2Guard] Spawned at (200, 2500), hp: 2, behavior: GUARD
+[12:34:28] [INFO] [BloodyFeet:Room2Guard] Blood detector created and attached to Room2Guard
+[12:34:28] [INFO] [BloodyFeet:Room2Guard] Snow surface detector created on Room2Guard
+[12:34:28] [INFO] [SoundPropagation] Registered listener: Room2Guard (total: 4)
+[12:34:28] [ENEMY] [Room2Guard] Registered as sound listener
+[12:34:28] [ENEMY] [Room2Guard] Spawned at (390, 2300), hp: 4, behavior: GUARD
+[12:34:28] [INFO] [BloodyFeet:Corridor3Guard] Blood detector created and attached to Corridor3Guard
+[12:34:28] [INFO] [BloodyFeet:Corridor3Guard] Snow surface detector created on Corridor3Guard
+[12:34:28] [INFO] [SoundPropagation] Registered listener: Corridor3Guard (total: 5)
+[12:34:28] [ENEMY] [Corridor3Guard] Registered as sound listener
+[12:34:28] [ENEMY] [Corridor3Guard] Spawned at (200, 1700), hp: 4, behavior: GUARD
+[12:34:28] [INFO] [BloodyFeet:Room3Guard] Blood detector created and attached to Room3Guard
+[12:34:28] [INFO] [BloodyFeet:Room3Guard] Snow surface detector created on Room3Guard
+[12:34:28] [INFO] [SoundPropagation] Registered listener: Room3Guard (total: 6)
+[12:34:28] [ENEMY] [Room3Guard] Registered as sound listener
+[12:34:28] [ENEMY] [Room3Guard] Spawned at (390, 1900), hp: 4, behavior: PATROL
+[12:34:28] [INFO] [BloodyFeet:ForkGuardUp] Blood detector created and attached to ForkGuardUp
+[12:34:28] [INFO] [BloodyFeet:ForkGuardUp] Snow surface detector created on ForkGuardUp
+[12:34:28] [INFO] [SoundPropagation] Registered listener: ForkGuardUp (total: 7)
+[12:34:28] [ENEMY] [ForkGuardUp] Registered as sound listener
+[12:34:28] [ENEMY] [ForkGuardUp] Spawned at (200, 1000), hp: 3, behavior: GUARD
+[12:34:28] [INFO] [BloodyFeet:ForkGuardRight] Blood detector created and attached to ForkGuardRight
+[12:34:28] [INFO] [BloodyFeet:ForkGuardRight] Snow surface detector created on ForkGuardRight
+[12:34:28] [INFO] [SoundPropagation] Registered listener: ForkGuardRight (total: 8)
+[12:34:28] [ENEMY] [ForkGuardRight] Registered as sound listener
+[12:34:28] [ENEMY] [ForkGuardRight] Spawned at (800, 1450), hp: 4, behavior: GUARD
+[12:34:28] [INFO] [BloodyFeet:RoomAGuard] Blood detector created and attached to RoomAGuard
+[12:34:28] [INFO] [BloodyFeet:RoomAGuard] Snow surface detector created on RoomAGuard
+[12:34:28] [INFO] [SoundPropagation] Registered listener: RoomAGuard (total: 9)
+[12:34:28] [ENEMY] [RoomAGuard] Registered as sound listener
+[12:34:28] [ENEMY] [RoomAGuard] Spawned at (1187, 1794), hp: 4, behavior: GUARD
+[12:34:28] [INFO] [BloodyFeet:RoomBGuard] Blood detector created and attached to RoomBGuard
+[12:34:28] [INFO] [BloodyFeet:RoomBGuard] Snow surface detector created on RoomBGuard
+[12:34:28] [INFO] [SoundPropagation] Registered listener: RoomBGuard (total: 10)
+[12:34:28] [ENEMY] [RoomBGuard] Registered as sound listener
+[12:34:28] [ENEMY] [RoomBGuard] Spawned at (1850, 1731), hp: 4, behavior: GUARD
+[12:34:28] [INFO] [BloodyFeet:ExitRoomMachineGunner] Blood detector created and attached to ExitRoomMachineGunner
+[12:34:28] [INFO] [BloodyFeet:ExitRoomMachineGunner] Snow surface detector created on ExitRoomMachineGunner
+[12:34:28] [INFO] [SoundPropagation] Registered listener: ExitRoomMachineGunner (total: 11)
+[12:34:28] [ENEMY] [ExitRoomMachineGunner] Registered as sound listener
+[12:34:28] [ENEMY] [ExitRoomMachineGunner] Spawned at (2000, 1450), hp: 3, behavior: GUARD
+[12:34:28] [INFO] [BloodyFeet:TopRoomGuard] Blood detector created and attached to TopRoomGuard
+[12:34:28] [INFO] [BloodyFeet:TopRoomGuard] Snow surface detector created on TopRoomGuard
+[12:34:28] [INFO] [SoundPropagation] Registered listener: TopRoomGuard (total: 12)
+[12:34:28] [ENEMY] [TopRoomGuard] Registered as sound listener
+[12:34:28] [ENEMY] [TopRoomGuard] Spawned at (200, 280), hp: 4, behavior: PATROL
+[12:34:28] [INFO] [BloodyFeet:TopRoomGrenadier] Blood detector created and attached to TopRoomGrenadier
+[12:34:28] [INFO] [BloodyFeet:TopRoomGrenadier] Snow surface detector created on TopRoomGrenadier
+[12:34:28] [INFO] [SoundPropagation] Registered listener: TopRoomGrenadier (total: 13)
+[12:34:28] [ENEMY] [TopRoomGrenadier] Registered as sound listener
+[12:34:28] [ENEMY] [TopRoomGrenadier] Spawned at (400, 280), hp: 2, behavior: PATROL
+[12:34:28] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:34:28] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:34:28] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 13) - skipping fallback
+[12:34:28] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=13
+[12:34:28] [ENEMY] [Corridor1Guard] SHIELD_TRACK: updated facing to 90.0° (interval=1.5s)
+[12:34:28] [ENEMY] [Corridor1Guard] Patrol points snapped to navmesh (Issue #1216)
+[12:34:28] [ENEMY] [Room1Guard] SHIELD_TRACK: updated facing to 90.0° (interval=1.5s)
+[12:34:28] [ENEMY] [Room3Guard] Patrol points snapped to navmesh (Issue #1216)
+[12:34:28] [ENEMY] [TopRoomGuard] Patrol points snapped to navmesh (Issue #1216)
+[12:34:28] [ENEMY] [TopRoomGrenadier] Patrol points snapped to navmesh (Issue #1216)
+[12:34:28] [ENEMY] [Room1Guard] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [Corridor2Guard] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=112.5°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [Room2Guard] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [Corridor3Guard] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=112.5°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [ForkGuardUp] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [ForkGuardRight] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [RoomAGuard] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [RoomBGuard] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [ExitRoomMachineGunner] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:34:28] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:34:28] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:34:28] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:34:28] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:34:28] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:34:28] [INFO] [LastChance] Found player: Player
+[12:34:28] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:34:28] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:34:28] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:34:28] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:34:28] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 1978 ms
+[12:34:28] [ENEMY] [Corridor2Guard] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=89.6°, current=43.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [Corridor2Guard] State: IDLE -> COMBAT
+[12:34:28] [ENEMY] [Corridor2Guard] Found cover at (245.1931, 2435.229) (distance: 81.3, player at (200, 3050))
+[12:34:28] [ENEMY] [Corridor3Guard] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=89.8°, current=54.4°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [Corridor3Guard] State: IDLE -> COMBAT
+[12:34:28] [ENEMY] [Corridor3Guard] Found cover at (247.6992, 1635.048) (distance: 83.0, player at (200, 3050))
+[12:34:28] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[12:34:28] [INFO] [GrenadeBase] Grenade created at (192.1131, 2525.862) (frozen)
+[12:34:28] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[12:34:28] [INFO] [GrenadeBase] LEGACY throw_grenade() called! Direction: (-0.010306, 0.999947), Speed: 1048.4 (unfrozen)
+[12:34:28] [INFO] [GrenadeBase] NOTE: Using DRAG-BASED system. If velocity-based is expected, ensure grenade has throw_grenade_velocity_based() method.
+[12:34:28] [INFO] [GasMaskGrenade] Chemical grenade thrown at (200, 3050) (remaining: 3)
+[12:34:28] [INFO] [GrenadeBase] Collision detected with Corridor2Guard (type: CharacterBody2D)
+[12:34:28] [ENEMY] [Corridor2Guard] GRENADE DANGER: Entering EVADING_GRENADE state from COMBAT
+[12:34:28] [ENEMY] [Corridor2Guard] EVADING_GRENADE started: escaping to (199.5189, 1849.434)
+[12:34:28] [INFO] [GrenadeBase] Collision detected with Room1Guard (type: CharacterBody2D)
+[12:34:28] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(191.6332, 2569.115), source=NEUTRAL (ChemicalGasGrenade), range=112, listeners=13
+[12:34:28] [ENEMY] [Room1Guard] Heard GRENADE_LANDING at (191.6332, 2569.115), intensity=1.00
+[12:34:28] [ENEMY] [Room1Guard] EVADING_GRENADE (from sound): escaping from (191.6332, 2569.115)
+[12:34:28] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=11, self=0
+[12:34:28] [INFO] [GrenadeBase] Grenade landed at (191.6332, 2569.115)
+[12:34:28] [INFO] [ChemicalGasGrenade] Landed at (191.6332, 2569.115) — detonating on contact
+[12:34:28] [INFO] [ChemicalGasGrenade] Gas released at (191.6332, 2569.115)!
+[12:34:28] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(191.6332, 2569.115), source=NEUTRAL (ChemicalGasGrenade), range=1469, listeners=13
+[12:34:28] [ENEMY] [Corridor1Guard] Heard EXPLOSION at (191.6332, 2569.115), intensity=0.08, distance=181
+[12:34:28] [ENEMY] [Room2Guard] Heard EXPLOSION at (191.6332, 2569.115), intensity=0.02, distance=334
+[12:34:28] [ENEMY] [Room3Guard] Heard EXPLOSION at (191.6332, 2569.115), intensity=0.01, distance=698
+[12:34:28] [ENEMY] [ForkGuardRight] Heard EXPLOSION at (191.6332, 2569.115), intensity=0.00, distance=1274
+[12:34:28] [ENEMY] [RoomAGuard] Heard EXPLOSION at (191.6332, 2569.115), intensity=0.00, distance=1262
+[12:34:28] [INFO] [SoundPropagation] Sound result: notified=8, out_of_range=5, self=0
+[12:34:28] [INFO] [ChemicalGasGrenade] Spawning cloud with 5.62s grow-in matching sound
+[12:34:28] [INFO] [ChemicalCloud] _ready() at (191.6332, 2569.115)
+[12:34:28] [INFO] [ChemicalCloud] Particle system created
+[12:34:28] [INFO] [ChemicalCloud] Cloud spawned at (191.6332, 2569.115), radius=600, duration=20s
+[12:34:28] [INFO] [ChemicalGasGrenade] Chemical cloud spawned at (191.6332, 2569.115) (radius=600, duration=20s, grow_in=5.62s)
+[12:34:28] [INFO] [GrenadeBase] Collision detected with Corridor2Guard (type: CharacterBody2D)
+[12:34:28] [ENEMY] [Corridor1Guard] ROT_CHANGE: none -> P2:shield_delayed, state=COMBAT, target=90.0°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [Corridor1Guard] Found cover at (136, 2760.097) (distance: 64.8, player at (200, 3050))
+[12:34:28] [ENEMY] [Corridor2Guard] EVADING_GRENADE: Escaped to safe distance
+[12:34:28] [ENEMY] [Corridor2Guard] State: EVADING_GRENADE -> COMBAT
+[12:34:28] [ENEMY] [Room2Guard] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=104.2°, current=-71.6°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [Room2Guard] Found cover at (264, 2292.947) (distance: 126.2, player at (200, 3050))
+[12:34:28] [ENEMY] [Room3Guard] ROT_CHANGE: none -> P2:combat_state, state=COMBAT, target=99.4°, current=0.0°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [Room3Guard] Found cover at (148.5922, 2000.156) (distance: 261.4, player at (200, 3050))
+[12:34:28] [ENEMY] [ForkGuardRight] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=110.6°, current=-71.6°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [ForkGuardRight] Found cover at (240.7219, 1635.035) (distance: 589.1, player at (200, 3050))
+[12:34:28] [ENEMY] [RoomAGuard] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=128.2°, current=-71.6°, player=(200,3050), corner_timer=0.00
+[12:34:28] [ENEMY] [RoomAGuard] Found cover at (264, 1897.387) (distance: 928.8, player at (200, 3050))
+[12:34:28] [INFO] [ChemicalCloud] Moving original enemy from (200, 2752.667) to (130.3678, 2755.713) (offset=(-69.60556, 3.603544))
+[12:34:28] [INFO] [IllusionEffect] Spawned at (200, 2752.667), offset=(69.60556, -3.603544), duration=20s
+[12:34:28] [INFO] [IllusionEffect] Spawned at (265.9982, 2735.805), offset=(135.4667, -20.99248), duration=20s
+[12:34:28] [INFO] [ChemicalCloud] Moving original enemy from (201.0931, 2607.925) to (133.7016, 2567.938) (offset=(-67.70924, -39.44652))
+[12:34:28] [INFO] [IllusionEffect] Spawned at (201.0931, 2607.925), offset=(67.70924, 39.44652), duration=20s
+[12:34:28] [INFO] [IllusionEffect] Spawned at (266.308, 2604.413), offset=(132.8939, 35.41339), duration=20s
+[12:34:28] [INFO] [IllusionEffect] Spawned at (202.7059, 2696.565), offset=(70.03107, 128.0711), duration=20s
+[12:34:28] [INFO] [IllusionEffect] Spawned at (151.2083, 2651.439), offset=(18.17413, 83.35866), duration=20s
+[12:34:28] [INFO] [IllusionEffect] Spawned at (256.6886, 2504.884), offset=(122.4787, -64.03632), duration=20s
+[12:34:28] [INFO] [ChemicalCloud] Moving original enemy from (192.5193, 2525.861) to (259.4342, 2536.909) (offset=(66.99329, -10.56218))
+[12:34:28] [INFO] [IllusionEffect] Spawned at (192.5193, 2525.861), offset=(-66.99329, 10.56218), duration=20s
+[12:34:28] [INFO] [IllusionEffect] Spawned at (94.75287, 2459.095), offset=(-180.7991, -22.06081), duration=20s
+[12:34:28] [INFO] [IllusionEffect] Spawned at (463.1674, 2300.32), offset=(78.31293, -2.548916), duration=20s
+[12:34:28] [INFO] [ChemicalCloud] Per-cloud cap reached (10), stopping initial batch
+[12:34:28] [INFO] [ChemicalCloud] Spawned 10 illusion copies for 13 enemies (total: 10/10)
+[12:34:28] [ENEMY] [Room1Guard] ROT_CHANGE: P5:idle_scan -> P4:shield_delayed, state=EVADING_GRENADE, target=90.0°, current=-10.3°, player=(200,3050), corner_timer=0.00
+[12:34:29] [WARN] [FPS] Drop detected: 1 fps (threshold: 30)
+[12:34:29] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=13
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: TopRoomGrenadier (remaining: 12)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: TopRoomGuard (remaining: 11)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: ExitRoomMachineGunner (remaining: 10)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: RoomBGuard (remaining: 9)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: RoomAGuard (remaining: 8)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: ForkGuardRight (remaining: 7)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: ForkGuardUp (remaining: 6)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: Room3Guard (remaining: 5)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: Corridor3Guard (remaining: 4)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: Room2Guard (remaining: 3)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: Corridor2Guard (remaining: 2)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: Room1Guard (remaining: 1)
+[12:34:30] [INFO] [SoundPropagation] Unregistered listener: Corridor1Guard (remaining: 0)
+[12:34:30] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:34:30] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:34:30] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:34:30] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:34:30] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:34:30] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:34:30] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[12:34:30] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:34:30] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[12:34:30] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:34:30] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:34:30] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[12:34:30] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:30] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:34:30] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:34:30] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:34:30] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:34:30] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[12:34:30] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:34:30] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:34:30] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:34:30] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:34:30] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:34:30] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:34:30] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:34:30] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:34:30] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[12:34:30] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:34:30] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:34:30] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:34:30] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:34:30] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:34:30] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:34:30] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:34:30] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:34:30] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:34:30] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:34:30] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:34:30] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:34:30] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:34:30] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:34:30] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:34:30] [INFO] [Player.ItemVisual] Visual applied for item type: 18
+[12:34:30] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:34:30] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:34:30] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:34:30] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:34:30] [INFO] [Player.ExperimentalSample] Equipped, charges this run: 2
+[12:34:30] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:34:30] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:34:30] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:34:30] [INFO] [Player.Jammer] JammerHUD initialized
+[12:34:30] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:34:30] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 10/10
+[12:34:30] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:34:30] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:34:30] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:34:30] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[12:34:30] [INFO] [GameManager] set_player() called with: <CharacterBody2D#292829533259> (class: CharacterBody2D)
+[12:34:30] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:34:30] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:34:30] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:34:30] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:34:30] [INFO] [CinemaEffects] Found player node: Player
+[12:34:30] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:34:30] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:34:30] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:34:30] [INFO] [ReplayManager] Recording frame 120 (2,1s): player_valid=False, enemies=13
+[12:34:30] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:34:30] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:34:30] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:34:30] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:34:30] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:34:30] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:34:30] [INFO] [LastChance] Found player: Player
+[12:34:30] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:34:30] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:34:30] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:34:30] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:34:31] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:34:31] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[12:34:31] [INFO] [Player.Grenade] G pressed - starting grab animation
+[12:34:31] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[12:34:31] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[12:34:31] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[12:34:31] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:34:31] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (546.4132, 454.9876)
+[12:34:31] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[12:34:31] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[12:34:31] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[12:34:31] [INFO] [DroneGrenade] Ready
+[12:34:31] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[12:34:31] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[12:34:31] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[12:34:31] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[12:34:31] [INFO] [Player.Grenade] Timer started, grenade created at (150, 360)
+[12:34:31] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[12:34:31] [INFO] [Player.Grenade] Step 1 complete! Drag: (418.84875, -36.197266)
+[12:34:31] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[12:34:31] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [ReplayManager] Recording frame 180 (3,1s): player_valid=False, enemies=13
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:31] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[12:34:32] [INFO] [ReplayManager] Recording frame 240 (4,1s): player_valid=False, enemies=13
+[12:34:32] [INFO] [Player.Grenade.Simple] Throwing! Target: (790.8414, 257.69128), Distance: 589,0, Speed: 594,5, Friction: 300,0
+[12:34:32] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,15831153
+[12:34:32] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[12:34:32] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.9874949, -0.15765108), speed=594,5, spawn=(209.2497, 350.54092)
+[12:34:32] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.987495, -0.157651), Speed: 594.5 (clamped from 594.5, max: 850.0)
+[12:34:32] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[12:34:32] [INFO] [DroneGrenade] Camera attached to drone
+[12:34:32] [INFO] [DroneGrenade] Player control disabled
+[12:34:32] [INFO] [DroneGrenade] PILOTING phase started at (209.2497, 350.5409)
+[12:34:32] [INFO] [DroneGrenade] Drone launched at (209.2497, 350.5409)
+[12:34:32] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[12:34:32] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[12:34:32] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[12:34:32] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[12:34:32] [INFO] [Player.Grenade] State reset to IDLE
+[12:34:32] [INFO] [Player.Grenade] State reset to IDLE
+[12:34:32] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[12:34:33] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[12:34:33] [INFO] [ReplayManager] Recording frame 300 (5,1s): player_valid=False, enemies=13
+[12:34:34] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [ReplayManager] Recording frame 360 (6,1s): player_valid=False, enemies=13
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:34] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:35] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:35] [INFO] [GrenadeTimer] Flashbang grenade landed at (476.07086, 350.54092)
+[12:34:35] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(476.0709, 350.5409), source=NEUTRAL (DroneGrenade), range=112, listeners=0
+[12:34:35] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[12:34:35] [INFO] [GrenadeTimer] Emitted grenade landing sound at (476.07086, 350.54092)
+[12:34:35] [INFO] [GrenadeBase] Collision detected with Obstacle3 (type: StaticBody2D)
+[12:34:35] [INFO] [ReplayManager] Recording frame 420 (7,1s): player_valid=False, enemies=13
+[12:34:36] [INFO] [GameManager] restart_scene() — starting scene reload
+[12:34:36] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:34:36] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[12:34:36] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[12:34:36] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[12:34:36] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[12:34:36] [INFO] [LastChance] Resetting all effects (scene change detected)
+[12:34:36] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[12:34:36] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[12:34:36] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[12:34:36] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[12:34:36] [INFO] [PersistManager] State saved to user://game_state.cfg
+[12:34:36] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[12:34:36] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[12:34:36] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[12:34:36] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[12:34:36] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[12:34:36] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[12:34:36] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[12:34:36] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[12:34:36] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[12:34:36] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[12:34:36] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[12:34:36] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[12:34:36] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[12:34:36] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[12:34:36] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[12:34:36] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[12:34:36] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[12:34:36] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[12:34:36] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[12:34:36] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[12:34:36] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[12:34:36] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[12:34:36] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[12:34:36] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[12:34:36] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[12:34:36] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[12:34:36] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[12:34:36] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[12:34:36] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[12:34:36] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[12:34:36] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[12:34:36] [INFO] [Player.ItemVisual] Visual applied for item type: 18
+[12:34:36] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[12:34:36] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[12:34:36] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[12:34:36] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[12:34:36] [INFO] [Player.ExperimentalSample] Equipped, charges this run: 4
+[12:34:36] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[12:34:36] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[12:34:36] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[12:34:36] [INFO] [Player.Jammer] JammerHUD initialized
+[12:34:36] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[12:34:36] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 10/10
+[12:34:36] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[12:34:36] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[12:34:36] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[12:34:36] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[12:34:36] [INFO] [GameManager] set_player() called with: <CharacterBody2D#313381619338> (class: CharacterBody2D)
+[12:34:36] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[12:34:36] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[12:34:36] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[12:34:36] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[12:34:36] [INFO] [CinemaEffects] Found player node: Player
+[12:34:36] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[12:34:36] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[12:34:36] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[12:34:36] [INFO] [Player] Detecting weapon pose (frame 3)...
+[12:34:36] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[12:34:36] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[12:34:36] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[12:34:36] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[12:34:36] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[12:34:36] [INFO] [LastChance] Found player: Player
+[12:34:36] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[12:34:36] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[12:34:36] [INFO] [LastChance] Connected to player Died signal (C#)
+[12:34:36] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[12:34:36] [INFO] [ReplayManager] Recording frame 480 (8,1s): player_valid=False, enemies=13
+[12:34:36] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:34:36] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[12:34:36] [INFO] [Player.Grenade] G pressed - starting grab animation
+[12:34:36] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[12:34:36] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[12:34:36] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[12:34:37] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[12:34:37] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (656.64233, 334.79156)
+[12:34:37] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[12:34:37] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[12:34:37] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[12:34:37] [INFO] [DroneGrenade] Ready
+[12:34:37] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[12:34:37] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[12:34:37] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[12:34:37] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[12:34:37] [INFO] [Player.Grenade] Timer started, grenade created at (150, 360)
+[12:34:37] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[12:34:37] [INFO] [Player.Grenade] Step 1 complete! Drag: (65.32324, 0.0602417)
+[12:34:37] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[12:34:37] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[12:34:37] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[12:34:37] [INFO] [ReplayManager] Recording frame 540 (9,1s): player_valid=False, enemies=13
+[12:34:38] [INFO] [ReplayManager] Recording frame 600 (10,1s): player_valid=False, enemies=13
+[12:34:38] [INFO] [Player.Grenade.Simple] Throwing! Target: (1308.5927, 63.999817), Distance: 1150,0, Speed: 830,7, Friction: 300,0
+[12:34:38] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,29245085
+[12:34:38] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[12:34:38] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.9575402, -0.2882999), speed=830,7, spawn=(207.45241, 395.53534)
+[12:34:38] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.95754, -0.2883), Speed: 830.7 (clamped from 830.7, max: 850.0)
+[12:34:38] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[12:34:38] [INFO] [DroneGrenade] Camera attached to drone
+[12:34:38] [INFO] [DroneGrenade] Player control disabled
+[12:34:38] [INFO] [DroneGrenade] PILOTING phase started at (207.4524, 395.5353)
+[12:34:38] [INFO] [DroneGrenade] Drone launched at (207.4524, 395.5353)
+[12:34:38] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[12:34:38] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[12:34:38] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[12:34:38] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[12:34:38] [INFO] [Player.Grenade] State reset to IDLE
+[12:34:38] [INFO] [Player.Grenade] State reset to IDLE
+[12:34:38] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[12:34:39] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[12:34:39] [INFO] [ReplayManager] Recording frame 660 (11,1s): player_valid=False, enemies=13
+[12:34:40] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[12:34:40] [INFO] [ReplayManager] Recording frame 720 (12,1s): player_valid=False, enemies=13
+[12:34:41] [INFO] [ReplayManager] Recording frame 780 (13,1s): player_valid=False, enemies=13
+[12:34:42] [INFO] [ReplayManager] Recording frame 840 (14,1s): player_valid=False, enemies=13
+[12:34:42] [INFO] [GrenadeTimer] Flashbang grenade landed at (944.82574, 217.51872)
+[12:34:42] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(944.8257, 217.5187), source=NEUTRAL (DroneGrenade), range=112, listeners=0
+[12:34:42] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[12:34:42] [INFO] [GrenadeTimer] Emitted grenade landing sound at (944.82574, 217.51872)
+[12:34:43] [INFO] [ReplayManager] Recording frame 900 (15,1s): player_valid=False, enemies=13
+[12:34:44] [INFO] ------------------------------------------------------------
+[12:34:44] [INFO] GAME LOG ENDED: 2026-04-20T12:34:44
+[12:34:44] [INFO] ============================================================

--- a/scripts/characters/player.gd
+++ b/scripts/characters/player.gd
@@ -1930,6 +1930,10 @@ func _throw_simple_grenade() -> void:
 	# Unfreeze and throw the grenade
 	_active_grenade.freeze = false
 
+	# Issue #1896: pass the mouse cursor world position so DroneGrenade can fly there first.
+	if _active_grenade.has_method("set_aim_point"):
+		_active_grenade.set_aim_point(target_pos)
+
 	# Use the simple throw method for direct speed control
 	# This bypasses velocity-to-throw multipliers for accurate cursor-based aiming
 	if _active_grenade.has_method("throw_grenade_simple"):
@@ -2090,6 +2094,10 @@ func _throw_grenade(drag_end: Vector2) -> void:
 
 	# Raycast from player to intended spawn position to check for walls
 	var spawn_position := _get_safe_grenade_spawn_position(global_position, intended_spawn_position, throw_direction)
+
+	# Issue #1896: pass the mouse cursor world position so DroneGrenade can fly there first.
+	if _active_grenade.has_method("set_aim_point"):
+		_active_grenade.set_aim_point(drag_end)
 
 	# Use direction-based throwing (FIX for issue #313)
 	# Priority: throw_grenade_with_direction > throw_grenade_velocity_based > throw_grenade > direct physics

--- a/scripts/projectiles/drone_grenade.gd
+++ b/scripts/projectiles/drone_grenade.gd
@@ -19,8 +19,8 @@ const ROTOR_RADIUS: float = 4.0
 ##
 ## After the explosion control returns to the player automatically.
 
-## Speed of the player-controlled drone (pixels/second).
-@export var drone_speed: float = 400.0
+## Speed of the player-controlled drone (pixels/second). 50% faster than original (400 → 600).
+@export var drone_speed: float = 600.0
 
 ## Explosion radius matching RPG charge (pixels). 50% larger than standard (150 → 225).
 @export var explosion_radius: float = 225.0
@@ -34,6 +34,17 @@ const DRIFT_FACTOR: float = 0.82
 
 ## Delay (seconds) before enemies start targeting this drone (Issue #1667).
 const ENEMY_TARGETING_DELAY: float = 1.5
+
+## Speed of the ballistic throw phase (pixels/second). Issue #1896.
+const THROW_PHASE_SPEED: float = 900.0
+
+## Drone state machine for Issue #1896: throw-then-pilot mechanic.
+enum DroneState {
+	IDLE,        ## Not yet launched.
+	THROWING,    ## Flying ballistically toward aim target; player has no control.
+	PILOTING,    ## Player is piloting the drone.
+	EXPLODED,    ## Drone has exploded.
+}
 
 ## Whether the drone has been launched (player is now piloting).
 var _drone_launched: bool = false
@@ -58,6 +69,15 @@ var _enemy_targeting_timer: float = 0.0
 
 ## Whether enemies are currently targeting this drone (Issue #1667).
 var _enemy_targeting_active: bool = false
+
+## Current drone state machine state (Issue #1896).
+var _drone_state: DroneState = DroneState.IDLE
+
+## World position the drone is being thrown toward (Issue #1896).
+var _throw_target: Vector2 = Vector2.ZERO
+
+## The aim point passed at throw time (mouse cursor world position). Issue #1896.
+var _aim_point: Vector2 = Vector2.ZERO
 
 ## Visual: drone body polygon drawn procedurally.
 var _drone_visual: Node2D = null
@@ -118,15 +138,19 @@ func throw_grenade(direction: Vector2, drag_distance: float) -> void:
 	_launch_drone()
 
 
-## Launch the drone: stop physics movement, transfer control.
+## Set the aim point for the throw phase. Call before any throw_grenade* method.
+## Issue #1896: the drone flies to this world position before player control activates.
+func set_aim_point(world_pos: Vector2) -> void:
+	_aim_point = world_pos
+
+
+## Launch the drone: enter THROWING phase and fly ballistically to aim point.
+## Issue #1896: player control only activates after the drone reaches the aim point.
 func _launch_drone() -> void:
 	if _drone_launched:
 		return
 	_drone_launched = true
 	_drone_alive = true
-
-	# Stop physics movement — the drone is now under direct player control.
-	linear_velocity = Vector2.ZERO
 
 	# Issue #1667: enemies can shoot this drone; add it to a discoverable group.
 	add_to_group("player_drones")
@@ -136,10 +160,32 @@ func _launch_drone() -> void:
 	_enemy_targeting_active = false
 
 	_find_player_and_camera()
+
+	# Issue #1896: if an aim point was provided, enter THROWING phase.
+	# Otherwise fall back to immediate PILOTING (legacy behavior).
+	if _aim_point != Vector2.ZERO:
+		_drone_state = DroneState.THROWING
+		_throw_target = _aim_point
+		# Fly toward the aim point at throw speed; let physics carry it.
+		var throw_dir := global_position.direction_to(_throw_target)
+		linear_velocity = throw_dir * THROW_PHASE_SPEED
+		rotation = throw_dir.angle()
+		FileLogger.info("[DroneGrenade] THROWING phase started toward %s" % str(_throw_target))
+	else:
+		_start_piloting()
+
+	FileLogger.info("[DroneGrenade] Drone launched at %s" % str(global_position))
+
+
+## Activate player piloting mode (camera attach + disable player input).
+func _start_piloting() -> void:
+	_drone_state = DroneState.PILOTING
+	# Stop ballistic movement; the player takes over.
+	linear_velocity = Vector2.ZERO
+	_current_move_dir = Vector2.ZERO
 	_attach_camera_to_drone()
 	_disable_player_control()
-
-	FileLogger.info("[DroneGrenade] Drone launched at %s — player now piloting" % str(global_position))
+	FileLogger.info("[DroneGrenade] PILOTING phase started at %s" % str(global_position))
 
 
 ## Find the player node and its Camera2D.
@@ -218,7 +264,7 @@ func _restore_player_control() -> void:
 	FileLogger.info("[DroneGrenade] Player control restored")
 
 
-## Override _physics_process to pilot the drone via player input.
+## Override _physics_process to handle THROWING and PILOTING phases.
 func _physics_process(delta: float) -> void:
 	if _has_exploded:
 		return
@@ -238,6 +284,15 @@ func _physics_process(delta: float) -> void:
 		if _enemy_targeting_timer <= 0.0:
 			_enemy_targeting_active = true
 			FileLogger.info("[DroneGrenade] Enemy targeting now active (delay elapsed)")
+
+	# Issue #1896: THROWING phase — fly ballistically toward target.
+	if _drone_state == DroneState.THROWING:
+		_update_throwing_phase()
+		return
+
+	# PILOTING phase — player controls the drone.
+	if _drone_state != DroneState.PILOTING:
+		return
 
 	# Read WASD / arrow key input.
 	var input_dir := Vector2.ZERO
@@ -272,20 +327,34 @@ func _physics_process(delta: float) -> void:
 		linear_velocity = _current_move_dir * drone_speed
 
 
-## Override body collision to explode when hitting an enemy.
+## Issue #1896: update THROWING phase — transition to PILOTING when target reached.
+func _update_throwing_phase() -> void:
+	var dist_to_target := global_position.distance_to(_throw_target)
+	# Transition to piloting when the drone reaches (or overshoots) the aim point.
+	if dist_to_target <= THROW_PHASE_SPEED * get_physics_process_delta_time() * 2.0 or dist_to_target <= 16.0:
+		FileLogger.info("[DroneGrenade] Throw target reached — switching to PILOTING")
+		_start_piloting()
+
+
+## Override body collision to explode on contact.
+## Issue #1896: during THROWING phase any collision (enemy OR obstacle) triggers explosion.
+## During PILOTING phase only enemies trigger explosion (walls block movement but don't explode).
 func _on_body_entered(body: Node) -> void:
 	super._on_body_entered(body)
 
 	if not _drone_alive or _has_exploded:
 		return
 
-	# Explode on contact with an enemy.
-	if body.is_in_group("enemies") or body is CharacterBody2D:
-		# Only trigger on enemies (not walls/obstacles for drone — drone flies over them
-		# conceptually, but walls block movement via physics).
-		if body.is_in_group("enemies"):
-			FileLogger.info("[DroneGrenade] Crashed into enemy '%s' — exploding!" % body.name)
-			_explode()
+	if _drone_state == DroneState.THROWING:
+		# During the throw, colliding with anything explodes the drone.
+		FileLogger.info("[DroneGrenade] Throw collision with '%s' — exploding!" % body.name)
+		_explode()
+		return
+
+	# PILOTING phase: only explode on enemy contact.
+	if body.is_in_group("enemies"):
+		FileLogger.info("[DroneGrenade] Crashed into enemy '%s' — exploding!" % body.name)
+		_explode()
 
 
 ## Called when a bullet hits the drone.
@@ -307,6 +376,7 @@ func is_targetable_by_enemies() -> bool:
 func _on_explode() -> void:
 	_drone_alive = false
 	_enemy_targeting_active = false
+	_drone_state = DroneState.EXPLODED
 	# Issue #1667: leave the targeting group so enemies stop shooting at debris.
 	if is_in_group("player_drones"):
 		remove_from_group("player_drones")

--- a/tests/unit/test_drone_grenade.gd
+++ b/tests/unit/test_drone_grenade.gd
@@ -1,5 +1,5 @@
 extends GutTest
-## Unit tests for DroneGrenade (Issue #1667).
+## Unit tests for DroneGrenade (Issues #1667, #1896).
 ##
 ## Tests:
 ## 1. Drift / inertia movement: DRIFT_FACTOR blends input_dir into banked direction.
@@ -7,20 +7,27 @@ extends GutTest
 ## 3. Enemy targeting: drone IS targetable once delay elapses.
 ## 4. is_targetable_by_enemies() returns false after explosion.
 ## 5. Drift constants are sane.
+## 6. (Issue #1896) Drone speed is 600 (50% faster).
+## 7. (Issue #1896) Throw phase: player control inactive during THROWING.
+## 8. (Issue #1896) Throw phase: transitions to PILOTING when target reached.
+## 9. (Issue #1896) Throw phase: early collision explodes instead of piloting.
 
 
 # ============================================================================
-# Mock drone grenade for movement and targeting logic tests
+# Mock drone grenade for movement, targeting, and throw-phase logic tests
 # ============================================================================
 
 
 class MockDroneGrenade:
-	## Mirrors the drift and enemy-targeting logic from drone_grenade.gd.
+	## Mirrors the drift, enemy-targeting, and throw-phase logic from drone_grenade.gd.
 
 	const DRIFT_FACTOR: float = 0.82
 	const ENEMY_TARGETING_DELAY: float = 1.5
+	const THROW_PHASE_SPEED: float = 900.0
 
-	var drone_speed: float = 400.0
+	enum DroneState { IDLE, THROWING, PILOTING, EXPLODED }
+
+	var drone_speed: float = 600.0
 
 	var _drone_launched: bool = false
 	var _drone_alive: bool = false
@@ -28,11 +35,20 @@ class MockDroneGrenade:
 
 	var _current_move_dir: Vector2 = Vector2.ZERO
 	var _linear_velocity: Vector2 = Vector2.ZERO
+	var _position: Vector2 = Vector2.ZERO
 
 	var _enemy_targeting_timer: float = 0.0
 	var _enemy_targeting_active: bool = false
 
-	## Launch the drone (simulates _launch_drone).
+	var _drone_state: DroneState = DroneState.IDLE
+	var _throw_target: Vector2 = Vector2.ZERO
+	var _aim_point: Vector2 = Vector2.ZERO
+
+	## Set the aim point (world position of mouse cursor at throw time). Issue #1896.
+	func set_aim_point(world_pos: Vector2) -> void:
+		_aim_point = world_pos
+
+	## Launch the drone (simulates _launch_drone). Issue #1896: enters THROWING if aim point set.
 	func launch() -> void:
 		if _drone_launched:
 			return
@@ -40,6 +56,20 @@ class MockDroneGrenade:
 		_drone_alive = true
 		_enemy_targeting_timer = ENEMY_TARGETING_DELAY
 		_enemy_targeting_active = false
+
+		if _aim_point != Vector2.ZERO:
+			_drone_state = DroneState.THROWING
+			_throw_target = _aim_point
+			var throw_dir := _position.direction_to(_throw_target)
+			_linear_velocity = throw_dir * THROW_PHASE_SPEED
+		else:
+			_start_piloting()
+
+	## Activate PILOTING phase.
+	func _start_piloting() -> void:
+		_drone_state = DroneState.PILOTING
+		_linear_velocity = Vector2.ZERO
+		_current_move_dir = Vector2.ZERO
 
 	## Simulate one physics tick (mirrors _physics_process).
 	func process(delta: float, input_dir: Vector2) -> void:
@@ -52,7 +82,18 @@ class MockDroneGrenade:
 			if _enemy_targeting_timer <= 0.0:
 				_enemy_targeting_active = true
 
-		# Drift / inertia movement.
+		# THROWING phase: advance position toward target, transition when close.
+		if _drone_state == DroneState.THROWING:
+			_position += _linear_velocity * delta
+			var dist := _position.distance_to(_throw_target)
+			if dist <= THROW_PHASE_SPEED * delta * 2.0 or dist <= 16.0:
+				_start_piloting()
+			return
+
+		# PILOTING phase: apply drift movement from input.
+		if _drone_state != DroneState.PILOTING:
+			return
+
 		if input_dir != Vector2.ZERO:
 			if _current_move_dir == Vector2.ZERO:
 				_current_move_dir = input_dir
@@ -65,6 +106,13 @@ class MockDroneGrenade:
 				_current_move_dir = Vector2.ZERO
 			_linear_velocity = _current_move_dir * drone_speed
 
+	## Simulate a collision during the throw (triggers explosion). Issue #1896.
+	func on_throw_collision() -> void:
+		if not _drone_alive or _has_exploded:
+			return
+		if _drone_state == DroneState.THROWING:
+			explode()
+
 	## Returns true when enemies should aim at this drone.
 	func is_targetable_by_enemies() -> bool:
 		return _drone_alive and not _has_exploded and _enemy_targeting_active
@@ -76,6 +124,7 @@ class MockDroneGrenade:
 		_drone_alive = false
 		_has_exploded = true
 		_enemy_targeting_active = false
+		_drone_state = DroneState.EXPLODED
 
 
 # ============================================================================
@@ -129,6 +178,11 @@ func test_drift_majority_of_old_direction_preserved() -> void:
 	# With DRIFT_FACTOR=0.82 the rightward component dominates over the 0.18 upward blend.
 	assert_gt(abs(drone._current_move_dir.x), abs(drone._current_move_dir.y),
 		"After one frame of 90° change, old direction should still dominate")
+
+
+func test_drone_speed_is_600() -> void:
+	assert_almost_eq(MockDroneGrenade.new().drone_speed, 600.0, 0.001,
+		"drone_speed should be 600 (50% faster than original 400) — Issue #1896")
 
 
 func test_drift_velocity_equals_drone_speed_when_moving() -> void:
@@ -259,3 +313,109 @@ func test_targeting_timer_not_active_after_explode() -> void:
 	drone.explode()
 	assert_false(drone._enemy_targeting_active,
 		"_enemy_targeting_active must be cleared when drone explodes")
+
+
+# ============================================================================
+# Throw Phase Tests (Issue #1896)
+# ============================================================================
+
+
+func test_throw_phase_speed_constant() -> void:
+	assert_almost_eq(MockDroneGrenade.THROW_PHASE_SPEED, 900.0, 0.001,
+		"THROW_PHASE_SPEED should be 900.0 px/s")
+
+
+func test_no_aim_point_enters_piloting_immediately() -> void:
+	var drone := MockDroneGrenade.new()
+	# No set_aim_point — legacy behavior.
+	drone.launch()
+	assert_eq(drone._drone_state, MockDroneGrenade.DroneState.PILOTING,
+		"Without aim point, drone should enter PILOTING immediately")
+
+
+func test_with_aim_point_enters_throwing_phase() -> void:
+	var drone := MockDroneGrenade.new()
+	drone.set_aim_point(Vector2(200.0, 0.0))
+	drone.launch()
+	assert_eq(drone._drone_state, MockDroneGrenade.DroneState.THROWING,
+		"With aim point set, drone should start in THROWING phase (Issue #1896)")
+
+
+func test_throw_phase_velocity_toward_target() -> void:
+	var drone := MockDroneGrenade.new()
+	drone.set_aim_point(Vector2(500.0, 0.0))
+	drone.launch()
+	# Linear velocity should point right toward the target.
+	assert_gt(drone._linear_velocity.x, 0.0,
+		"Throw velocity X should be positive toward rightward target")
+	assert_almost_eq(drone._linear_velocity.y, 0.0, 1.0,
+		"Throw velocity Y should be near zero for rightward target")
+	assert_almost_eq(drone._linear_velocity.length(), MockDroneGrenade.THROW_PHASE_SPEED, 1.0,
+		"Throw velocity magnitude should equal THROW_PHASE_SPEED")
+
+
+func test_throw_phase_no_player_input_active() -> void:
+	var drone := MockDroneGrenade.new()
+	drone.set_aim_point(Vector2(200.0, 0.0))
+	drone.launch()
+	# Simulate a few frames; state should remain THROWING (far from target).
+	for _i in range(3):
+		drone.process(0.016, Vector2.RIGHT)  # player pushes keys but drone ignores them
+	assert_eq(drone._drone_state, MockDroneGrenade.DroneState.THROWING,
+		"Player input must not affect state while drone is in THROWING phase")
+	# Velocity should still reflect ballistic throw (not drone_speed).
+	assert_almost_eq(drone._linear_velocity.length(), MockDroneGrenade.THROW_PHASE_SPEED, 1.0,
+		"Velocity during THROWING should be throw speed, not pilot speed")
+
+
+func test_throw_phase_transitions_to_piloting_on_arrival() -> void:
+	var drone := MockDroneGrenade.new()
+	# Place target very close so it is reached quickly.
+	drone.set_aim_point(Vector2(8.0, 0.0))
+	drone.launch()
+	# One tick should be enough to reach the target (8px away, tolerance 16px).
+	drone.process(0.016, Vector2.ZERO)
+	assert_eq(drone._drone_state, MockDroneGrenade.DroneState.PILOTING,
+		"Drone should transition from THROWING to PILOTING after reaching the target (Issue #1896)")
+
+
+func test_throw_phase_piloting_uses_drone_speed() -> void:
+	var drone := MockDroneGrenade.new()
+	drone.set_aim_point(Vector2(8.0, 0.0))
+	drone.launch()
+	# Arrive at target.
+	drone.process(0.016, Vector2.ZERO)
+	assert_eq(drone._drone_state, MockDroneGrenade.DroneState.PILOTING,
+		"Pre-condition: should be in PILOTING")
+	# Now apply input and check speed.
+	drone.process(0.016, Vector2.RIGHT)
+	assert_almost_eq(drone._linear_velocity.length(), drone.drone_speed, 0.5,
+		"After transition to PILOTING, velocity magnitude should equal drone_speed")
+
+
+func test_throw_phase_collision_explodes_drone() -> void:
+	var drone := MockDroneGrenade.new()
+	drone.set_aim_point(Vector2(500.0, 0.0))
+	drone.launch()
+	assert_eq(drone._drone_state, MockDroneGrenade.DroneState.THROWING,
+		"Pre-condition: drone is THROWING")
+	# Simulate hitting a wall during the throw.
+	drone.on_throw_collision()
+	assert_true(drone._has_exploded,
+		"Collision during THROWING phase must explode the drone (Issue #1896)")
+	assert_false(drone._drone_alive,
+		"Drone must not be alive after throw-phase collision explosion")
+	assert_eq(drone._drone_state, MockDroneGrenade.DroneState.EXPLODED,
+		"State must be EXPLODED after throw-phase collision")
+
+
+func test_throw_phase_collision_never_enters_piloting() -> void:
+	var drone := MockDroneGrenade.new()
+	drone.set_aim_point(Vector2(500.0, 0.0))
+	drone.launch()
+	drone.on_throw_collision()
+	# Simulate further ticks — state must stay EXPLODED.
+	for _i in range(5):
+		drone.process(0.016, Vector2.ZERO)
+	assert_eq(drone._drone_state, MockDroneGrenade.DroneState.EXPLODED,
+		"After throw-phase explosion the drone must never transition to PILOTING")

--- a/tests/unit/test_drone_grenade.gd
+++ b/tests/unit/test_drone_grenade.gd
@@ -419,3 +419,87 @@ func test_throw_phase_collision_never_enters_piloting() -> void:
 		drone.process(0.016, Vector2.ZERO)
 	assert_eq(drone._drone_state, MockDroneGrenade.DroneState.EXPLODED,
 		"After throw-phase explosion the drone must never transition to PILOTING")
+
+
+# ============================================================================
+# C# Player Interop Regression Tests (Issue #1896)
+# ============================================================================
+
+
+func _read_csharp_player_grenade_source() -> String:
+	var file := FileAccess.open("res://Scripts/Characters/Player.Grenade.cs", FileAccess.READ)
+	assert_not_null(file, "Player.Grenade.cs must be readable for C# interop regression tests")
+	if file == null:
+		return ""
+	return file.get_as_text()
+
+
+func _extract_csharp_method(source: String, signature: String) -> String:
+	var method_start := source.find(signature)
+	assert_gt(method_start, -1, "Expected C# method signature to exist: %s" % signature)
+	if method_start == -1:
+		return ""
+
+	var brace_start := source.find("{", method_start)
+	assert_gt(brace_start, -1, "Expected method body to start after signature: %s" % signature)
+	if brace_start == -1:
+		return ""
+
+	var depth := 0
+	for i in range(brace_start, source.length()):
+		var ch := source.substr(i, 1)
+		if ch == "{":
+			depth += 1
+		elif ch == "}":
+			depth -= 1
+			if depth == 0:
+				return source.substr(brace_start, i - brace_start + 1)
+
+	fail_test("Expected method body to close for signature: %s" % signature)
+	return ""
+
+
+func test_csharp_simple_throw_sets_drone_aim_before_unfreeze() -> void:
+	var source := _read_csharp_player_grenade_source()
+	var method := _extract_csharp_method(source, "private void ThrowSimpleGrenade()")
+
+	var aim_idx := method.find("PassDroneThrowAimPoint(targetPos);")
+	var unfreeze_idx := method.find("_activeGrenade.Freeze = false;")
+	var throw_call_idx := method.find("_activeGrenade.Call(\"throw_grenade_simple\"")
+
+	assert_gt(aim_idx, -1,
+		"C# simple throw must pass the cursor target to DroneGrenade.set_aim_point before launch")
+	assert_gt(unfreeze_idx, -1, "C# simple throw must still unfreeze the grenade")
+	assert_gt(throw_call_idx, -1, "C# simple throw must still call the GDScript throw hook")
+	assert_lt(aim_idx, unfreeze_idx,
+		"C# simple throw must set the drone aim point before unfreezing to avoid fallback launch")
+	assert_lt(aim_idx, throw_call_idx,
+		"C# simple throw must set the drone aim point before calling throw_grenade_simple")
+
+
+func test_csharp_velocity_throw_sets_drone_aim_before_unfreeze() -> void:
+	var source := _read_csharp_player_grenade_source()
+	var method := _extract_csharp_method(source, "private void ThrowGrenade(Vector2 dragEnd)")
+
+	var aim_idx := method.find("PassDroneThrowAimPoint(dragEnd);")
+	var unfreeze_idx := method.find("_activeGrenade.Freeze = false;")
+	var throw_call_idx := method.find("_activeGrenade.Call(\"throw_grenade_with_direction\"")
+
+	assert_gt(aim_idx, -1,
+		"C# velocity throw must pass dragEnd to DroneGrenade.set_aim_point before launch")
+	assert_gt(unfreeze_idx, -1, "C# velocity throw must still unfreeze the grenade")
+	assert_gt(throw_call_idx, -1, "C# velocity throw must still call the GDScript throw hook")
+	assert_lt(aim_idx, unfreeze_idx,
+		"C# velocity throw must set the drone aim point before unfreezing to avoid fallback launch")
+	assert_lt(aim_idx, throw_call_idx,
+		"C# velocity throw must set the drone aim point before calling throw_grenade_with_direction")
+
+
+func test_csharp_drone_aim_helper_calls_snake_case_gdscript_method() -> void:
+	var source := _read_csharp_player_grenade_source()
+	var method := _extract_csharp_method(source, "private void PassDroneThrowAimPoint(Vector2 aimPoint)")
+
+	assert_true(method.contains("_activeGrenade.HasMethod(\"set_aim_point\")"),
+		"C# interop must look for DroneGrenade's snake_case GDScript method")
+	assert_true(method.contains("_activeGrenade.Call(\"set_aim_point\", aimPoint)"),
+		"C# interop must call DroneGrenade.set_aim_point with the world-space aim point")


### PR DESCRIPTION
## Summary

Resolves #1896.

- Increased drone grenade flight speed from 400 to 600.
- Added the requested throw-before-pilot state flow: the drone first flies toward the throw aim point, then enters player-controlled piloting only after reaching that point.
- Added throw-phase collision behavior so the drone explodes immediately if it hits something before reaching the aim point.
- Follow-up fix from owner retest logs: the tested runtime path was `Scripts/Characters/Player.Grenade.cs`, not only `scripts/characters/player.gd`. The C# throw paths now pass `set_aim_point` before unfreezing or calling the GDScript throw hooks.
- Preserved the owner-provided retest logs and expanded the investigation in `docs/case-studies/issue-1896/`.

## Root Cause From Latest Retest

The second retest log contained this runtime fingerprint:

```text
[Player.Grenade.Simple] C# set velocity directly
[DroneGrenade] PILOTING phase started
```

That line comes from `Scripts/Characters/Player.Grenade.cs`. The first follow-up fix had only wired `set_aim_point()` in the GDScript player path, so the exported/tested C# path still launched the drone with `_aim_point == Vector2.ZERO` and immediately fell back to `PILOTING`.

The C# path now calls `PassDroneThrowAimPoint(targetPos)` / `PassDroneThrowAimPoint(dragEnd)` before `_activeGrenade.Freeze = false` and before the `throw_grenade_*` GDScript calls.

## Evidence Preserved

- `docs/case-studies/issue-1896/game_log_20260420_120715.txt`
- `docs/case-studies/issue-1896/game_log_20260420_123426.txt`
- `docs/case-studies/issue-1896/case-study.md`

## Tests

- `dotnet build GodotTopDownTemplate.sln --configuration Debug` - passed, 0 warnings, 0 errors.
- Focused GUT run before final cleanup: `res://tests/unit/test_drone_grenade.gd` - 32/32 passed.
- Added regression tests that assert both C# throw paths set the drone aim point before unfreezing and before invoking the GDScript throw hooks.

## Expected Runtime Signature

A successful throw should now log the C# aim handoff, then the drone throw phase, then piloting only after the throw target is reached:

```text
[Player.Grenade] Drone aim point set to (...)
[DroneGrenade] THROWING phase started toward (...)
[DroneGrenade] Throw target reached — switching to PILOTING
[DroneGrenade] PILOTING phase started at (...)
```
