### PR TITLE
fix: suppress startup-available unlock toasts permanently per session

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T08:49:16.706Z for PR creation at branch issue-1907-aaab8f45ea8b for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1907

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T08:49:16.706Z for PR creation at branch issue-1907-aaab8f45ea8b for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1907

--- a/docs/case-studies/issue-1907/analysis.md
+++ b/docs/case-studies/issue-1907/analysis.md
@@ -1,0 +1,73 @@
+# Issue #1907: Fix Unlock Toast Shown on Every Game Restart
+
+## Problem Statement
+
+When the armory has items available to unlock (conditions met, but not yet permanently unlocked by the player), toast notifications appear during combat on **every game restart**, not just once when the item first becomes available.
+
+## Log Evidence
+
+From `game_log_20260420_114551.txt`:
+
+```
+[11:45:52] [UnlockNotificationManager] Suppressed 5 already-available startup unlock notification(s)
+...
+[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: weapon:mini_uzi
+[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: grenade:4
+[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: active_item:12
+[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: active_item:16
+[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: active_item:17
+[11:46:09] [UnlockManager] Kill condition met — items now available to unlock in armory
+```
+
+At 11:45:52, 5 already-available items were correctly suppressed. But at 11:46:09 (when a kill triggered `kills_without_laser_sight_updated`), all 5 suppressed items fired their toast notifications anyway.
+
+## Timeline of Events
+
+1. **Startup** (`_ready` → `_seed_announced_available_unlocks`): 5 items that already have conditions met are detected and added to `_startup_suppressed_available_keys`. This is correct — they should not show a toast since they were available before this session.
+
+2. **First kill** → `items_unlocked_by_kill_condition` signal fires → `_queue_new_available_unlocks` runs.
+
+3. **Bug**: In `_queue_new_available_unlocks`, for each entry collected:
+   - The check `if _announced_available_keys.get(key, false)` passes (they were never announced).
+   - `_announced_available_keys[key] = true` is set.
+   - `_startup_suppressed_available_keys.erase(key)` removes the suppression.
+   - `show_unlock_notification(...)` fires the toast.
+
+4. On the **next game restart**: `_announced_available_keys` is reset to `{}` (in-memory only). `_startup_suppressed_available_keys` is also reset. The same 5 items are suppressed at startup again, then re-announced on the first kill again.
+
+## Root Cause
+
+`_announced_available_keys` is not persisted across sessions. On every new session:
+- Startup suppression correctly captures already-available items.
+- But the first live signal removes the suppression and shows the toast, defeating the purpose.
+
+The design intent of `_startup_suppressed_available_keys` was to suppress items at startup (correct), but allow them to be shown "once" when a live signal triggers (wrong: this re-shows on every session since memory is wiped on restart).
+
+## Fix
+
+In `_queue_new_available_unlocks`, items in `_startup_suppressed_available_keys` should be **permanently skipped for the current session** — not erased and re-announced. The suppression at startup means "this was already available before the player started playing today, don't bother them again this session."
+
+```gdscript
+# Before (buggy):
+_announced_available_keys[key] = true
+if _startup_suppressed_available_keys.erase(key):
+    _log("Announcing previously startup-available unlock after live condition signal: %s" % key)
+show_unlock_notification(entry["name"], entry["kind"])
+
+# After (fixed):
+if _startup_suppressed_available_keys.has(key):
+    continue
+_announced_available_keys[key] = true
+show_unlock_notification(entry["name"], entry["kind"])
+```
+
+## Correct Behavior After Fix
+
+- Items available at startup: never shown in current session (startup suppression is permanent).
+- Items whose condition becomes newly met during a session (new kill or level completion): shown once via toast.
+- On next restart: items already available are again suppressed and not shown.
+
+## Files Changed
+
+- `scripts/autoload/unlock_notification_manager.gd`: fixed `_queue_new_available_unlocks`
+- `tests/unit/test_unlock_notification_manager.gd`: replaced test validating old behavior with test validating correct behavior

--- a/scripts/autoload/unlock_notification_manager.gd
+++ b/scripts/autoload/unlock_notification_manager.gd
@@ -397,9 +397,9 @@ func _queue_new_available_unlocks() -> void:
 		var key: String = entry["key"]
 		if _announced_available_keys.get(key, false):
 			continue
+		if _startup_suppressed_available_keys.has(key):
+			continue
 		_announced_available_keys[key] = true
-		if _startup_suppressed_available_keys.erase(key):
-			_log("Announcing previously startup-available unlock after live condition signal: %s" % key)
 		show_unlock_notification(entry["name"], entry["kind"])
 
 

--- a/tests/unit/test_unlock_notification_manager.gd
+++ b/tests/unit/test_unlock_notification_manager.gd
@@ -336,14 +336,23 @@ func test_collects_only_locked_items_with_met_conditions() -> void:
 	assert_false("active_item:8" in keys, "Already unlocked active items should not be announced")
 
 
-func test_startup_suppressed_unlock_can_announce_after_live_signal() -> void:
+func test_startup_suppressed_unlock_is_not_reshown_on_live_signal() -> void:
+	## Issue #1907: items that were already available at game startup should not
+	## show a toast on every new game session when a kill/condition signal fires.
 	var script: GDScript = load(NOTIFICATION_MANAGER_SCRIPT)
 	assert_not_null(script, "UnlockNotificationManager script should load")
 	var manager: Node = autofree(script.new())
 
+	# Simulate a startup-available item (condition met, not yet unlocked)
 	manager._startup_suppressed_available_keys["active_item:9"] = true
 	manager._announced_available_keys.clear()
 
+	# Simulate a live condition signal firing (e.g., a kill increments a stat)
+	# _queue_new_available_unlocks scans entries — active_item:9 condition is met
+	# (MockUnlockManager returns true for item type 9, MockActiveItemManager has it locked)
+	var startup_notification_count: int = manager._pending_notifications.size()
+	# Call the internal method directly to simulate the signal handler
+	# We reproduce the logic of _queue_new_available_unlocks with mocked managers
 	var unlock_manager: Node = autofree(MockUnlockManager.new())
 	var game_manager: Node = autofree(MockGameManager.new())
 	var grenade_manager: Node = autofree(MockGrenadeManager.new())
@@ -356,13 +365,14 @@ func test_startup_suppressed_unlock_can_announce_after_live_signal() -> void:
 		var key: String = entry["key"]
 		if manager._announced_available_keys.get(key, false):
 			continue
+		if manager._startup_suppressed_available_keys.has(key):
+			continue
 		manager._announced_available_keys[key] = true
-		manager._startup_suppressed_available_keys.erase(key)
 		manager.show_unlock_notification(entry["name"], entry["kind"])
 
-	assert_true(manager._announced_available_keys.get("active_item:9", false),
-		"Live stat signals should announce an item even if it was available during startup seeding")
-	assert_false(manager._startup_suppressed_available_keys.has("active_item:9"),
-		"Startup suppression should be consumed once a live signal announces the unlock")
-	assert_true(manager._pending_notifications.size() > 0,
-		"A notification should be queued for the live condition signal")
+	assert_false(manager._announced_available_keys.get("active_item:9", false),
+		"Startup-available item should not be added to announced keys — it stays suppressed this session")
+	assert_true(manager._startup_suppressed_available_keys.has("active_item:9"),
+		"Startup suppression should remain in place so repeated signals never show the toast")
+	assert_eq(manager._pending_notifications.size(), startup_notification_count,
+		"No new notification should be queued for an item that was already available at startup")


### PR DESCRIPTION
## Problem

Items already available to unlock at startup (conditions met, not yet permanently unlocked) showed toast notifications during combat on every game restart. At startup they were correctly suppressed, but the first kill that fired a stat-update signal would erase the suppression and re-announce all of them.

Root cause: `_announced_available_keys` is in-memory only. On each new session it resets to `{}`, so the "already announced" guard never triggered. The first live signal would call `_startup_suppressed_available_keys.erase(key)` + `show_unlock_notification(...)` for every startup-suppressed item.

**Log evidence** (`game_log_20260420_114551.txt`):
```
[11:45:52] [UnlockNotificationManager] Suppressed 5 already-available startup unlock notification(s)
...
[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: weapon:mini_uzi
[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: grenade:4
[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: active_item:12
[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: active_item:16
[11:46:09] [UnlockNotificationManager] Announcing previously startup-available unlock after live condition signal: active_item:17
```

## Fix

In `_queue_new_available_unlocks`, items present in `_startup_suppressed_available_keys` are now **skipped without erasure** instead of being erased and announced. The startup suppression is treated as a permanent per-session block.

```gdscript
# Before (buggy):
_announced_available_keys[key] = true
if _startup_suppressed_available_keys.erase(key):
    _log("Announcing previously startup-available unlock ...")
show_unlock_notification(entry["name"], entry["kind"])

# After (fixed):
if _startup_suppressed_available_keys.has(key):
    continue
_announced_available_keys[key] = true
show_unlock_notification(entry["name"], entry["kind"])
```

## Behavior

- **Items available at startup**: never shown in current session (permanent suppression).
- **Items newly unlocked during a session**: shown once as usual.
- **Next restart**: items are again suppressed at startup and not shown.

## Test

Replaced `test_startup_suppressed_unlock_can_announce_after_live_signal` (which validated the buggy behavior) with `test_startup_suppressed_unlock_is_not_reshown_on_live_signal` that asserts the fix:
- Suppressed items remain in `_startup_suppressed_available_keys` after a signal.
- No notification is queued for already-startup-available items.

## Case Study

See `docs/case-studies/issue-1907/analysis.md` for full root cause analysis and `docs/case-studies/issue-1907/game_log_20260420_114551.txt` for the original log.

Fixes #1907