### PR TITLE
fix(#1909): ensure enemies get snow blood footprints on winter forest level

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T08:53:38.435Z for PR creation at branch issue-1909-cc9ee3d06d85 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1909

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T08:53:38.435Z for PR creation at branch issue-1909-cc9ee3d06d85 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1909

--- a/scripts/components/bloody_feet_component.gd
+++ b/scripts/components/bloody_feet_component.gd
@@ -523,7 +523,10 @@ func _spawn_footprint() -> void:
 	# On snow levels, SnowyFeetComponent handles all footprint rendering (both normal
 	# white and red blood-snow prints). This component only tracks the blood level so
 	# SnowyFeetComponent can read it via has_bloody_feet() and _blood_color (Issue #1627).
-	if on_snow:
+	# Also defer to SnowyFeetComponent if one exists as a sibling — this covers the case
+	# where on_snow wasn't set before the first blood contact (Issue #1909: enemies).
+	var has_snowy_feet: bool = _parent_body != null and _parent_body.get_node_or_null("SnowyFeetComponent") != null
+	if on_snow or has_snowy_feet:
 		if debug_logging:
 			_log_info("On snow — SnowyFeetComponent handles prints (blood steps remaining: %d)" % _blood_level)
 		return

--- a/scripts/components/snowy_feet_component.gd
+++ b/scripts/components/snowy_feet_component.gd
@@ -245,8 +245,9 @@ func _arm_blood_snow_steps_from_bloody_feet_if_needed() -> void:
 		_connect_bloody_feet()
 	if _bloody_feet == null:
 		return
-	if _bloody_feet.get("on_snow") == null or not _bloody_feet.on_snow:
-		return
+	# SnowyFeetComponent is only attached to characters on snow levels (via _add_snowy_feet),
+	# so skip the on_snow guard — it may not be set yet if setup races with blood contact
+	# (Issue #1909: enemies received regular boot prints because on_snow wasn't set in time).
 	if not _bloody_feet.has_method("has_bloody_feet") or not _bloody_feet.has_bloody_feet():
 		return
 

--- a/scripts/levels/winter_forest_level.gd
+++ b/scripts/levels/winter_forest_level.gd
@@ -1511,16 +1511,18 @@ func _create_snow_area() -> void:
 ## Adds a SnowyFeetComponent to a CharacterBody2D and configures any existing
 ## BloodyFeetComponent on the same character for faster snow-blood fading.
 func _add_snowy_feet(character: CharacterBody2D, snowy_feet_script: GDScript) -> void:
+	# BloodyFeetComponent: set on_snow BEFORE adding SnowyFeetComponent so the flag
+	# is already true when SnowyFeetComponent._ready() connects to blood_contact.
+	# This ensures enemies (Issue #1909) receive snow blood prints, not regular boot prints.
+	var bloody_feet: Node = character.get_node_or_null("BloodyFeetComponent")
+	if bloody_feet and bloody_feet.get("on_snow") != null:
+		bloody_feet.on_snow = true
+
 	# SnowyFeetComponent: leave snow tracks.
 	var snowy_feet := Node.new()
 	snowy_feet.name = "SnowyFeetComponent"
 	snowy_feet.set_script(snowy_feet_script)
 	character.add_child(snowy_feet)
-
-	# BloodyFeetComponent: enable faster fading on snow (Issue #1627).
-	var bloody_feet: Node = character.get_node_or_null("BloodyFeetComponent")
-	if bloody_feet and bloody_feet.get("on_snow") != null:
-		bloody_feet.on_snow = true
 
 
 func _log_to_file(message: String) -> void:

--- a/tests/unit/test_bloody_feet_component.gd
+++ b/tests/unit/test_bloody_feet_component.gd
@@ -375,3 +375,25 @@ func test_consume_snow_blood_step_drains_after_snowy_feet_render() -> void:
 
 	assert_eq(_component.get_blood_level(), 4,
 		"SnowyFeetComponent should explicitly consume one blood step after rendering a red snow print")
+
+
+## Test that _spawn_footprint skips boot prints when a SnowyFeetComponent sibling exists,
+## even if on_snow was not set (Issue #1909: enemies on snow left regular boot prints).
+## BloodyFeetComponent must not drain blood — only SnowyFeetComponent does via consume_snow_blood_step.
+func test_spawn_footprint_defers_to_snowy_feet_component_when_sibling_exists() -> void:
+	_component.on_snow = false  # on_snow not yet set (simulates setup race for enemies)
+	_component.snow_blood_steps_count = 5
+	_component.blood_steps_count = 12
+
+	var snowy_feet_stub := Node.new()
+	snowy_feet_stub.name = "SnowyFeetComponent"
+	_character.add_child(snowy_feet_stub)
+	await wait_frames(1)
+
+	_component.set_blood_level(12)
+	_component._spawn_footprint()
+
+	assert_eq(_component.get_blood_level(), 12,
+		"BloodyFeetComponent must not drain blood when SnowyFeetComponent sibling exists — SnowyFeetComponent owns snow-level spawning (Issue #1909)")
+
+	snowy_feet_stub.queue_free()

--- a/tests/unit/test_snowy_feet_component.gd
+++ b/tests/unit/test_snowy_feet_component.gd
@@ -626,6 +626,52 @@ func test_red_snow_footprints_consume_bloody_feet_after_rendering() -> void:
 		"Second rendered red snow print should consume exactly one more snow blood step")
 
 
+## Regression test for Issue #1909: enemies received regular boot prints instead of
+## snow blood prints because on_snow was not set on BloodyFeetComponent before blood contact.
+## The signal path (_on_blood_contact) must arm the counter regardless of on_snow.
+func test_enemy_gets_snow_blood_prints_via_signal_even_when_on_snow_not_yet_set() -> void:
+	var comp := MockSnowyFeetComponentWithBloodCheck.new()
+	comp.is_on_snow = true
+	comp.snow_blood_steps_count = 5
+	var bloody := MockBloodyFeet.new()
+	bloody._blood_level = 5
+	bloody.snow_blood_steps_count = 5
+	# Simulate enemy: on_snow was not yet set (mimics race between _add_snowy_feet and
+	# blood contact before on_snow = true is applied to BloodyFeetComponent).
+	comp._bloody_feet = bloody
+	comp.ready(Vector2.ZERO)
+
+	# Arm via signal (primary path) — this is what BloodyFeetComponent.blood_contact emits.
+	comp.on_blood_contact()
+
+	comp.process(Vector2(comp.step_distance, 0.0))
+	assert_eq(comp.spawned_footprints.size(), 1, "One footprint should be spawned")
+	assert_true(comp.spawned_footprints[0].get("is_blood", false),
+		"Enemy must get snow blood print (not regular boot print) — Issue #1909")
+
+
+## Regression test for Issue #1909: fallback path (_arm_blood_snow_steps_from_bloody_feet_if_needed)
+## must NOT require on_snow=true since SnowyFeetComponent is only ever added to snow-level characters.
+func test_fallback_arms_snow_prints_even_when_on_snow_false_on_bloody_feet() -> void:
+	## This simulates the case where the signal was missed (race) AND on_snow is still false.
+	## The fallback should still arm the counter because SnowyFeetComponent exists = snow level.
+	var comp := MockSnowyFeetComponentWithBloodCheck.new()
+	comp.is_on_snow = true
+	comp.snow_blood_steps_count = 5
+	var bloody := MockBloodyFeet.new()
+	bloody._blood_level = 5
+	bloody.snow_blood_steps_count = 5
+	comp._bloody_feet = bloody
+	comp.ready(Vector2.ZERO)
+
+	# Do NOT fire on_blood_contact() — simulate missed signal.
+	# Verify the fallback arms prints even without on_snow guard.
+	comp.process(Vector2(comp.step_distance, 0.0))
+	assert_eq(comp.spawned_footprints.size(), 1, "A footprint should be spawned via fallback")
+	assert_true(comp.spawned_footprints[0].get("is_blood", false),
+		"Fallback must produce red snow prints for enemies even when on_snow was not set (Issue #1909)")
+
+
 func test_signal_captured_blood_color_survives_bloody_feet_drain() -> void:
 	## The visible red snow print should use the color captured at blood contact time,
 	## even if BloodyFeetComponent has already drained before SnowyFeetComponent steps.


### PR DESCRIPTION
## Problem

Enemies left regular boot-print `BloodFootprint` decals instead of oval red `SnowBloodFootprint` prints after stepping in blood on the snow-covered Winter Forest level. Players received the correct snow blood prints; enemies did not.

**Root cause**: The `BloodyFeetComponent.on_snow` flag must be `true` for a character to defer blood-print rendering to `SnowyFeetComponent`. Three separate setup-race conditions could prevent enemies from being treated correctly:

1. `on_snow` was set *after* `SnowyFeetComponent` was added as a child, meaning the first `blood_contact` signal could fire with `on_snow = false` still.
2. The fallback path (`_arm_blood_snow_steps_from_bloody_feet_if_needed`) returned early if `on_snow` was not yet `true`, preventing red snow steps from being armed even when blood was active.
3. `BloodyFeetComponent._spawn_footprint` only checked `on_snow` — if the flag wasn't set yet, it spawned regular boot prints and drained the blood level before `SnowyFeetComponent` could use it.

## Fix

**`WinterForestLevel._add_snowy_feet`** — set `BloodyFeetComponent.on_snow = true` *before* `add_child(SnowyFeetComponent)` so the flag is already `true` when `SnowyFeetComponent._ready()` connects to `blood_contact`.

**`SnowyFeetComponent._arm_blood_snow_steps_from_bloody_feet_if_needed`** — remove the `not _bloody_feet.on_snow` guard. `SnowyFeetComponent` is only ever attached on snow levels via `_add_snowy_feet`, so this check was redundant and blocked the fallback from arming red prints when `on_snow` hadn't been applied yet.

**`BloodyFeetComponent._spawn_footprint`** — also skip boot-print spawning when a `SnowyFeetComponent` sibling node exists (regardless of `on_snow`). This is the decisive safety net: even in the worst-case race, `BloodyFeetComponent` never spawns boot prints or drains the blood level that `SnowyFeetComponent` needs for red snow prints.

## Tests

- `test_spawn_footprint_defers_to_snowy_feet_component_when_sibling_exists` — verifies `BloodyFeetComponent` does not drain blood when a `SnowyFeetComponent` sibling exists.
- `test_enemy_gets_snow_blood_prints_via_signal_even_when_on_snow_not_yet_set` — verifies the signal path arms red snow steps for enemies regardless of `on_snow`.
- `test_fallback_arms_snow_prints_even_when_on_snow_false_on_bloody_feet` — verifies the fallback path no longer requires `on_snow = true`.

## How to reproduce

1. Load Winter Forest level.
2. Walk an enemy into a blood puddle on the snow.
3. **Before**: enemy leaves dark red boot prints (`BloodFootprint`).
4. **After**: enemy leaves oval red snow prints (`SnowBloodFootprint`), matching player behavior.


Fixes Jhon-Crow/godot-topdown-MVP#1909