### PR TITLE
fix(#1911): stop reparenting Camera2D — drive via local position

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T10:20:48.258Z for PR creation at branch issue-1911-a1398f8e7722 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1911

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T10:20:48.258Z for PR creation at branch issue-1911-a1398f8e7722 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1911

--- a/docs/case-studies/issue-1911/README.md
+++ b/docs/case-studies/issue-1911/README.md
@@ -1,0 +1,150 @@
+# Case Study: Issue #1911 — Drone Camera Jerk on Control Switch
+
+## Overview
+
+**Issue:** Camera jerks when switching control between player and drone grenade.  
+**Reporter:** Jhon-Crow  
+**PR:** #1912  
+**Status:** Under investigation / fix iteration
+
+---
+
+## Timeline of Events
+
+### Initial Report (Issue #1911)
+
+The user reported two symptoms:
+1. Camera jerks when switching from player → drone (at throw end / THROWING→PILOTING transition)
+2. Camera jerks when switching from drone → player (at explosion / EXPLODED→player transition)
+
+### First Fix Attempt (commit `3b1ec7cc`)
+
+The first fix preserved the camera's `global_position` before reparenting and restored it after reparenting. The idea: keep the camera at the same world location and let `position_smoothing` animate it toward the new parent.
+
+**Code:**
+```gdscript
+var cam_global_pos := _player_camera.global_position
+old_parent.remove_child(_player_camera)
+add_child(_player_camera)
+_player_camera.global_position = cam_global_pos  # ← preserve world pos
+```
+
+**Why this was wrong:** Setting `global_position` after reparenting sets a large local `position` offset (= `cam_global_pos - new_parent.global_position`). Camera2D's smoothing target is `parent.global_position + camera.position`, which evaluates to `cam_global_pos`. This means:
+- The camera's **node** global position = `cam_global_pos` (correct for 1 frame)
+- But as the drone moves, `camera.global_position = drone_pos + fixed_offset` — a rigid world-space offset from the drone
+- The viewport tracks this, staying permanently `cam_global_pos - drone_spawn_pos` pixels offset from the drone
+- Result: **camera moves incorrectly in pilot mode** (offset view, not centered on drone)
+
+### User Feedback on First Fix
+
+From PR comment by Jhon-Crow (2026-04-20T10:49:27Z):
+> "камера теперь двигается не правильно в режиме пилота. так же камера всё ещё дёргается в момент окончания броска."
+> (Camera now moves incorrectly in pilot mode. Also the camera still jerks at end of throw.)
+
+Attached: `game_log_20260420_134731.txt`
+
+---
+
+## Root Cause Analysis
+
+### How Camera2D Position Smoothing Works in Godot 4
+
+`Camera2D` with `position_smoothing_enabled = true` interpolates the **viewport** toward the camera node's `global_position`. The camera node's global position is: `parent.global_position + camera.position` (local offset).
+
+When `position_smoothing_speed = 5.0`, the viewport center moves ~63% of the way to the target each second.
+
+### Bug: Non-Zero Local Position After Reparent
+
+After reparenting camera to drone and setting `global_position = old_world_pos`:
+
+```
+camera.position = old_world_pos - drone.global_position   # e.g. (−800, +300)
+camera.global_position = drone.global_position + camera.position = old_world_pos
+```
+
+The camera node is at the old player position. The smoothing target = `old_world_pos`. No smoothing occurs initially. But as the **drone moves**:
+
+```
+drone moves by (+10, 0) each frame
+camera.global_position = (drone_pos + Δ) + fixed_offset = old_world_pos + Δ
+```
+
+The camera moves with the drone but at a permanent world-space offset. The viewport shows a location `offset` pixels away from the drone — not centered on it.
+
+**This is why the camera moved incorrectly in pilot mode.**
+
+### Bug: Throw-End Jerk
+
+During THROWING phase, the camera remains parented to the player (viewport shows player area). When PILOTING starts (`_start_piloting` → `_attach_camera_to_drone`):
+
+- With first fix: `global_position = cam_global_pos` = player position ≈ camera's current position
+  - Sets `camera.position = player_pos - drone_pos` = large negative offset (drone just arrived at aim point, which is far from player)
+  - Camera global pos = `drone_pos + (player_pos - drone_pos)` = `player_pos`
+  - Viewport smooths toward `player_pos`... but viewport is ALREADY at `player_pos` → no visible movement
+  - BUT: camera `position` is a large offset → broken pilot mode as described above
+  - The jerk may come from position_smoothing jerking as offset resolves
+
+### Correct Fix
+
+The Camera2D should always have `position = Vector2.ZERO` when parented to a moving node, so it properly centers on that node. Godot's built-in `position_smoothing` then handles smooth viewport animation automatically:
+
+```gdscript
+# Reparent camera to drone
+old_parent.remove_child(_player_camera)
+add_child(_player_camera)
+_player_camera.position = Vector2.ZERO   # center on drone
+_player_camera.make_current()
+```
+
+Result:
+- Camera node global_position = `drone.global_position` (= aim point, far from player)
+- Viewport is currently showing player's area
+- `position_smoothing` animates viewport from player's area → drone's position: **smooth pan**
+- As drone moves, camera.global_pos = drone.global_pos (no offset): **correct centering**
+
+Same logic applies on detach (explosion → player).
+
+---
+
+## Sequence of Events (from game_log_20260420_134731.txt)
+
+```
+[13:47:40] DroneGrenade: Player found: Player, Camera: Camera2D
+[13:47:40] DroneGrenade: THROWING phase started toward (335.9328, 1097.945)
+[13:47:40] DroneGrenade: Drone launched at (203.0851, 1027.964)
+[13:47:40] DroneGrenade: Throw target reached — switching to PILOTING
+[13:47:40] DroneGrenade: Camera attached to drone          ← BUG: wrong position set here
+[13:47:40] DroneGrenade: Player control disabled
+[13:47:40] DroneGrenade: PILOTING phase started at (319.2086, 1089.135)
+```
+
+Key observation: throw target reached almost immediately (same timestamp as launch), meaning the drone covered a short distance. Camera was still at ~(150, 1000) while drone was at (319, 1089). The first fix set `camera.position = (150,1000) - (319,1089) = (-169, -89)` — a small-ish offset in this case, but still incorrect.
+
+In the second tutorial throw:
+```
+[13:47:47] THROWING phase started toward (1040.033, 146.1519)
+[13:47:47] Drone launched at (223.1104, 375.1772)
+[13:47:47] Throw target reached — switching to PILOTING
+[13:47:47] Camera attached to drone
+[13:47:47] PILOTING phase started at (1017.002, 152.6086)
+```
+
+Player at ~(150, 360), drone at (1017, 152). Camera offset = `(150,360) - (1017,152) = (-867, +208)`. This large offset causes the camera to orbit the drone at nearly 900px distance — clearly broken pilot mode.
+
+---
+
+## Fix Applied (Second Iteration)
+
+File: `scripts/projectiles/drone_grenade.gd`
+
+**`_attach_camera_to_drone()`:** Remove the `global_position` manipulation. Set `position = Vector2.ZERO` to center camera on drone. Let `position_smoothing` animate the viewport smoothly.
+
+**`_detach_camera_from_drone()`:** Same — set `position = Vector2.ZERO` on player, let smoothing handle the return pan.
+
+---
+
+## Possible Future Improvements
+
+1. **During THROWING phase:** Optionally keep camera on player (current behavior) or smoothly track the drone mid-flight. Currently camera attaches only when PILOTING starts, which is correct UX.
+2. **Smoothing speed tuning:** `position_smoothing_speed = 5.0` may feel too slow for long throws. Could dynamically adjust speed based on distance.
+3. **Camera limits:** Level scripts set Camera2D limits. After reparenting to drone, limits still apply (good). After returning to player, same limits. No issue here.

--- a/docs/case-studies/issue-1911/README.md
+++ b/docs/case-studies/issue-1911/README.md
@@ -2,149 +2,186 @@
 
 ## Overview
 
-**Issue:** Camera jerks when switching control between player and drone grenade.  
-**Reporter:** Jhon-Crow  
-**PR:** #1912  
-**Status:** Under investigation / fix iteration
+**Issue:** Camera jerks when switching control between player and drone grenade.
+**Reporter:** Jhon-Crow
+**PR:** #1912
+**Status:** Under investigation / fix iteration (3rd iteration)
+
+User's latest report (2026-04-20T11:38:17Z):
+> "в момент перехода в режим управления дроном камера дёргается как при перезапуске уровня."
+> "At the moment of transition to drone control mode, the camera jerks as if the level is restarting."
+
+Attached log: `logs/game_log_20260420_143657.txt`
 
 ---
 
-## Timeline of Events
+## Timeline of Iterations
 
-### Initial Report (Issue #1911)
+### Iteration 1 — preserve `global_position` after reparent (commit `3b1ec7cc`)
 
-The user reported two symptoms:
-1. Camera jerks when switching from player → drone (at throw end / THROWING→PILOTING transition)
-2. Camera jerks when switching from drone → player (at explosion / EXPLODED→player transition)
-
-### First Fix Attempt (commit `3b1ec7cc`)
-
-The first fix preserved the camera's `global_position` before reparenting and restored it after reparenting. The idea: keep the camera at the same world location and let `position_smoothing` animate it toward the new parent.
-
-**Code:**
 ```gdscript
 var cam_global_pos := _player_camera.global_position
 old_parent.remove_child(_player_camera)
 add_child(_player_camera)
-_player_camera.global_position = cam_global_pos  # ← preserve world pos
+_player_camera.global_position = cam_global_pos   # preserve world pos
 ```
 
-**Why this was wrong:** Setting `global_position` after reparenting sets a large local `position` offset (= `cam_global_pos - new_parent.global_position`). Camera2D's smoothing target is `parent.global_position + camera.position`, which evaluates to `cam_global_pos`. This means:
-- The camera's **node** global position = `cam_global_pos` (correct for 1 frame)
-- But as the drone moves, `camera.global_position = drone_pos + fixed_offset` — a rigid world-space offset from the drone
-- The viewport tracks this, staying permanently `cam_global_pos - drone_spawn_pos` pixels offset from the drone
-- Result: **camera moves incorrectly in pilot mode** (offset view, not centered on drone)
+**Problem:** Setting `global_position` after reparenting created a large local `position` offset equal to `cam_world_pos - drone_world_pos`. As the drone moved, `camera.global_position = drone_pos + fixed_offset` — the camera tracked the drone at a permanent world-space offset. User reported "camera moves incorrectly in pilot mode" plus "still jerks at throw end".
 
-### User Feedback on First Fix
-
-From PR comment by Jhon-Crow (2026-04-20T10:49:27Z):
-> "камера теперь двигается не правильно в режиме пилота. так же камера всё ещё дёргается в момент окончания броска."
-> (Camera now moves incorrectly in pilot mode. Also the camera still jerks at end of throw.)
-
-Attached: `game_log_20260420_134731.txt`
-
----
-
-## Root Cause Analysis
-
-### How Camera2D Position Smoothing Works in Godot 4
-
-`Camera2D` with `position_smoothing_enabled = true` interpolates the **viewport** toward the camera node's `global_position`. The camera node's global position is: `parent.global_position + camera.position` (local offset).
-
-When `position_smoothing_speed = 5.0`, the viewport center moves ~63% of the way to the target each second.
-
-### Bug: Non-Zero Local Position After Reparent
-
-After reparenting camera to drone and setting `global_position = old_world_pos`:
-
-```
-camera.position = old_world_pos - drone.global_position   # e.g. (−800, +300)
-camera.global_position = drone.global_position + camera.position = old_world_pos
-```
-
-The camera node is at the old player position. The smoothing target = `old_world_pos`. No smoothing occurs initially. But as the **drone moves**:
-
-```
-drone moves by (+10, 0) each frame
-camera.global_position = (drone_pos + Δ) + fixed_offset = old_world_pos + Δ
-```
-
-The camera moves with the drone but at a permanent world-space offset. The viewport shows a location `offset` pixels away from the drone — not centered on it.
-
-**This is why the camera moved incorrectly in pilot mode.**
-
-### Bug: Throw-End Jerk
-
-During THROWING phase, the camera remains parented to the player (viewport shows player area). When PILOTING starts (`_start_piloting` → `_attach_camera_to_drone`):
-
-- With first fix: `global_position = cam_global_pos` = player position ≈ camera's current position
-  - Sets `camera.position = player_pos - drone_pos` = large negative offset (drone just arrived at aim point, which is far from player)
-  - Camera global pos = `drone_pos + (player_pos - drone_pos)` = `player_pos`
-  - Viewport smooths toward `player_pos`... but viewport is ALREADY at `player_pos` → no visible movement
-  - BUT: camera `position` is a large offset → broken pilot mode as described above
-  - The jerk may come from position_smoothing jerking as offset resolves
-
-### Correct Fix
-
-The Camera2D should always have `position = Vector2.ZERO` when parented to a moving node, so it properly centers on that node. Godot's built-in `position_smoothing` then handles smooth viewport animation automatically:
+### Iteration 2 — zero local position after reparent (commit `8b1b76fe`)
 
 ```gdscript
-# Reparent camera to drone
 old_parent.remove_child(_player_camera)
 add_child(_player_camera)
-_player_camera.position = Vector2.ZERO   # center on drone
+_player_camera.position = Vector2.ZERO
 _player_camera.make_current()
 ```
 
-Result:
-- Camera node global_position = `drone.global_position` (= aim point, far from player)
-- Viewport is currently showing player's area
-- `position_smoothing` animates viewport from player's area → drone's position: **smooth pan**
-- As drone moves, camera.global_pos = drone.global_pos (no offset): **correct centering**
-
-Same logic applies on detach (explosion → player).
+Pilot-mode positioning is correct now (camera centers on drone). **But the jerk remains**: user reports a hard cut at the moment of switching to pilot mode, described as "like the level restarts".
 
 ---
 
-## Sequence of Events (from game_log_20260420_134731.txt)
+## Root Cause (Iteration 3 Analysis)
+
+### Observation from the new log
+
+From `logs/game_log_20260420_143657.txt`, representative throw:
 
 ```
-[13:47:40] DroneGrenade: Player found: Player, Camera: Camera2D
-[13:47:40] DroneGrenade: THROWING phase started toward (335.9328, 1097.945)
-[13:47:40] DroneGrenade: Drone launched at (203.0851, 1027.964)
-[13:47:40] DroneGrenade: Throw target reached — switching to PILOTING
-[13:47:40] DroneGrenade: Camera attached to drone          ← BUG: wrong position set here
-[13:47:40] DroneGrenade: Player control disabled
-[13:47:40] DroneGrenade: PILOTING phase started at (319.2086, 1089.135)
+[14:37:06] THROWING phase started toward (830.8714, 261.6926)
+[14:37:06] Drone launched at (209.3842, 351.4258)
+[14:37:07] Throw target reached — switching to PILOTING
+[14:37:07] Camera attached to drone
+[14:37:07] PILOTING phase started at (803.144, 265.696)
 ```
 
-Key observation: throw target reached almost immediately (same timestamp as launch), meaning the drone covered a short distance. Camera was still at ~(150, 1000) while drone was at (319, 1089). The first fix set `camera.position = (150,1000) - (319,1089) = (-169, -89)` — a small-ish offset in this case, but still incorrect.
+Player at ~(209, 351). Drone at (803, 266). Expected behavior: `position_smoothing_speed = 5.0` should pan the viewport smoothly from player area to drone area over ~0.5–1.0 seconds. **Observed behavior: an instantaneous hard cut** — the hallmark of a smoothing-state reset.
 
-In the second tutorial throw:
-```
-[13:47:47] THROWING phase started toward (1040.033, 146.1519)
-[13:47:47] Drone launched at (223.1104, 375.1772)
-[13:47:47] Throw target reached — switching to PILOTING
-[13:47:47] Camera attached to drone
-[13:47:47] PILOTING phase started at (1017.002, 152.6086)
-```
+### The real bug: Camera2D smoothing state resets on reparent
 
-Player at ~(150, 360), drone at (1017, 152). Camera offset = `(150,360) - (1017,152) = (-867, +208)`. This large offset causes the camera to orbit the drone at nearly 900px distance — clearly broken pilot mode.
+In Godot 4, `Camera2D` keeps an internal `smoothed_camera_pos` value that is updated each (physics) frame, lerping toward the camera node's `global_position`. When the camera is **reparented**, Godot fires `NOTIFICATION_TRANSFORM_CHANGED` / `NOTIFICATION_PARENTED`, and the internal smoothing state is re-synced to the new parent's transform. The net visual effect is a hard cut to the new target — exactly matching the "like level restart" description the user reported.
+
+This is a documented Godot community issue:
+
+- [godotforums.org — Camera2D jumps when player character reparented](https://godotforums.org/d/27618-camera2d-jumps-when-player-character-reparented-to-new-node): "Camera2D resets when the node hierarchy changes, causing sudden position jumps despite smoothing being enabled."
+- [forum.godotengine.org — How to prevent discrete camera jumps when re-parenting](https://forum.godotengine.org/t/how-to-prevent-discrete-camera-jumps-when-re-parenting-a-node/26582): official recommendation is to **not reparent the Camera2D**; instead use a controller/rig that tracks the target without changing hierarchy.
+- [Godot Issue #50807 — `reset_smoothing()` does not work as described](https://github.com/godotengine/godot/issues/50807): internal order-of-operations bug makes smoothing-state reset visually inconsistent.
+- [Godot Issue #68394 — Camera2D intermittent jumps with smoothing](https://github.com/godotengine/godot/issues/68394): related reports.
+
+### Why the THROWING→PILOTING transition produces the hardest visible jump
+
+During THROWING phase, the camera stays parented to the player — viewport smoothly follows the player. When `_start_piloting()` fires, two things happen on the **same frame**:
+
+1. `_attach_camera_to_drone()` removes the camera from the player and adds it as a child of the drone (which is at the aim point, often hundreds of pixels away).
+2. The Camera2D's internal smoothing state gets reset because the parent transform changed from `(player_pos)` to `(drone_pos)`.
+
+The viewport snaps to the drone's position rather than smoothly panning — visually indistinguishable from a scene reload.
+
+### Why iteration 1 (`global_position` preservation) felt partially smoother
+
+In iteration 1, the camera's node-level `global_position` was kept at the old player location for 1 frame before drone motion pulled it along. This briefly preserved the smoothing target at the old spot, reducing the visible jump. BUT it broke pilot-mode tracking (permanent world offset). Iteration 2 traded one bug for the other.
 
 ---
 
-## Fix Applied (Second Iteration)
+## The Correct Fix: avoid reparenting entirely
+
+Use **`top_level = true`** on the Camera2D while in pilot mode. This decouples the camera's transform from its parent (the Player) without changing the node hierarchy. We then write `camera.global_position = drone.global_position` each physics frame. Godot's built-in `position_smoothing` continues to operate on its internal state uninterrupted — producing the smooth pan the user expects.
+
+When the drone explodes (or is otherwise dismissed):
+- Set `camera.top_level = false` and `camera.position = Vector2.ZERO`.
+- The camera re-attaches to the player's transform. Its `global_position` now resolves to `player.global_position`, and `position_smoothing` smoothly pans the viewport from the drone's last location back to the player — no reparenting, no smoothing reset.
+
+### Why this works
+
+- `top_level = true` turns a child node into a world-space node without changing its place in the scene tree (see [Godot docs — CanvasItem.top_level](https://docs.godotengine.org/en/4.3/classes/class_canvasitem.html#class-canvasitem-property-top-level)).
+- No `remove_child` / `add_child` fires, so `NOTIFICATION_PARENTED` never triggers on the Camera2D.
+- `position_smoothing`'s internal `smoothed_camera_pos` is never invalidated by hierarchy changes; only the camera's `global_position` changes, which is exactly what smoothing is designed to handle.
+- The community's established solution ("stable camera rig with a tracked target") is functionally equivalent to this, but `top_level` is a one-line in-place change that requires no scene restructuring.
+
+---
+
+## Timeline of Events (new log `game_log_20260420_143657.txt`)
+
+Session starts at `14:36:57`. Player is on `LabyrinthLevel` (camera limits 48..1968 × 48..1128).
+
+| Time | Event |
+|------|-------|
+| 14:36:58 | Camera2D limits set for labyrinth level |
+| 14:37:00 | Drone grenade ready; pin pulled |
+| 14:37:01 | 1st throw — target `(354, 547)`, launched at `(174, 945)` |
+| 14:37:02 | Throw target reached → `Camera attached to drone` → PILOTING at `(343, 570)` |
+| 14:37:06 | 2nd throw — target `(830, 261)`, launched at `(209, 351)` |
+| 14:37:07 | Throw reached → PILOTING at `(803, 265)` |
+| 14:37:14 | 3rd throw — target `(965, 214)`, launched at `(209, 349)` |
+| 14:37:15 | PILOTING at `(945, 218)` |
+| 14:37:23 | 4th throw — target `(1159, 151)`, launched at `(208, 347)` |
+| 14:37:25 | PILOTING at `(1135, 156)` |
+| 14:37:29 | 5th throw — target `(1343, 161)`, launched at `(209, 350)` |
+| 14:37:31 | PILOTING at `(1317, 165)` |
+
+Every PILOTING transition involves a camera move of 400–1100 px. With `position_smoothing_speed = 5.0` these should pan smoothly over ~0.5–1.0 s. They do not — they hard-cut. The user perceives "as if level restarts".
+
+---
+
+## Fix Applied (Iteration 3)
 
 File: `scripts/projectiles/drone_grenade.gd`
 
-**`_attach_camera_to_drone()`:** Remove the `global_position` manipulation. Set `position = Vector2.ZERO` to center camera on drone. Let `position_smoothing` animate the viewport smoothly.
+### Changes
 
-**`_detach_camera_from_drone()`:** Same — set `position = Vector2.ZERO` on player, let smoothing handle the return pan.
+- Remove the `remove_child` + `add_child` reparenting in both `_attach_camera_to_drone()` and `_detach_camera_from_drone()`.
+- Keep the Camera2D a child of the Player. Flip `top_level` to decouple/recouple its transform.
+- In `_physics_process`, while the drone owns the camera, write `_player_camera.global_position = global_position`.
+- On detach, set `top_level = false` and `position = Vector2.ZERO` so the camera reverts to a normal child of the player.
+
+### Pseudocode
+
+```gdscript
+func _attach_camera_to_drone() -> void:
+    if _player_camera == null:
+        return
+    _player_camera.top_level = true               # decouple from player transform
+    _player_camera.global_position = global_position
+    _player_camera.make_current()
+    _camera_owned_by_drone = true
+
+func _detach_camera_from_drone() -> void:
+    if _player_camera == null or not is_instance_valid(_player_camera):
+        return
+    _camera_owned_by_drone = false
+    _player_camera.top_level = false              # re-attach to player transform
+    _player_camera.position = Vector2.ZERO        # local offset back to center
+    _player_camera.make_current()
+
+func _physics_process(delta):
+    ...
+    if _camera_owned_by_drone and _player_camera:
+        _player_camera.global_position = global_position
+```
+
+### Why this matches the user's expectation
+
+- THROWING→PILOTING: camera's `global_position` changes from player position to drone position in one frame. `position_smoothing` interpolates the viewport smoothly from player area to drone area. No jerk.
+- PILOTING: every physics frame the camera's global_position equals drone's global_position. `position_smoothing` keeps the viewport slightly trailing but centered on the drone (same feel as normal player tracking). No world-space offset bug from iteration 1.
+- Explosion: `top_level = false` + `position = Vector2.ZERO` puts the camera back under player's transform. Its new `global_position = player.global_position`. `position_smoothing` pans back smoothly from the drone's last location.
 
 ---
 
-## Possible Future Improvements
+## Verification Checklist
 
-1. **During THROWING phase:** Optionally keep camera on player (current behavior) or smoothly track the drone mid-flight. Currently camera attaches only when PILOTING starts, which is correct UX.
-2. **Smoothing speed tuning:** `position_smoothing_speed = 5.0` may feel too slow for long throws. Could dynamically adjust speed based on distance.
-3. **Camera limits:** Level scripts set Camera2D limits. After reparenting to drone, limits still apply (good). After returning to player, same limits. No issue here.
+1. Throw drone from player position to a far aim point (≥ 400 px).
+2. Observe: camera smoothly pans from player to drone over ~0.5–1.0 s (no snap).
+3. Pilot the drone with WASD — camera stays centered on drone, no world-offset drift.
+4. Let the drone explode — camera smoothly pans back to player.
+5. Repeat with multiple consecutive throws — no degradation.
+
+---
+
+## References
+
+- [Godot Engine docs — Camera2D (4.3)](https://docs.godotengine.org/en/4.3/classes/class_camera2d.html)
+- [Godot Engine docs — CanvasItem.top_level (4.3)](https://docs.godotengine.org/en/4.3/classes/class_canvasitem.html#class-canvasitem-property-top-level)
+- [godotforums.org — Camera2D jumps when player character reparented](https://godotforums.org/d/27618-camera2d-jumps-when-player-character-reparented-to-new-node)
+- [forum.godotengine.org — How to prevent discrete camera jumps when re-parenting](https://forum.godotengine.org/t/how-to-prevent-discrete-camera-jumps-when-re-parenting-a-node/26582)
+- [Godot Issue #50807 — `reset_smoothing()` does not work as described](https://github.com/godotengine/godot/issues/50807)
+- [Godot Issue #68394 — Camera2D intermittent position jumps with smoothing](https://github.com/godotengine/godot/issues/68394)

--- a/docs/case-studies/issue-1911/logs/game_log_20260420_134731.txt
+++ b/docs/case-studies/issue-1911/logs/game_log_20260420_134731.txt
@@ -1,0 +1,1331 @@
+[13:47:31] [INFO] ============================================================
+[13:47:31] [INFO] GAME LOG STARTED
+[13:47:31] [INFO] ============================================================
+[13:47:31] [INFO] Timestamp: 2026-04-20T13:47:31
+[13:47:31] [INFO] Log file: I:/Загрузки/godot exe/hud/game_log_20260420_134731.txt
+[13:47:31] [INFO] Executable: I:/Загрузки/godot exe/hud/Godot-Top-Down-Template.exe
+[13:47:31] [INFO] OS: Windows
+[13:47:31] [INFO] Debug build: false
+[13:47:31] [INFO] Engine version: 4.3-stable (official)
+[13:47:31] [INFO] Project: Godot Top-Down Template
+[13:47:31] [INFO] Build info: not available (build_info.cfg not found)
+[13:47:31] [INFO] ------------------------------------------------------------
+[13:47:31] [INFO] [GameManager] GameManager ready
+[13:47:31] [INFO] [ScoreManager] ScoreManager ready
+[13:47:31] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[13:47:31] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[13:47:31] [INFO] [DifficultyManager] Loaded difficulty: Power Fantasy (value: 3)
+[13:47:31] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[13:47:31] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[13:47:31] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[13:47:31] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[13:47:31] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[13:47:31] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[13:47:31] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[13:47:31] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[13:47:31] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[13:47:31] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[13:47:31] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[13:47:31] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[13:47:31] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[13:47:31] [INFO] [LastChance] Resetting all effects (scene change detected)
+[13:47:31] [INFO] [LastChance] Last chance shader loaded successfully
+[13:47:31] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[13:47:31] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[13:47:31] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[13:47:31] [INFO] [LastChance]   Sepia intensity: 0.70
+[13:47:31] [INFO] [LastChance]   Brightness: 0.60
+[13:47:31] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[13:47:31] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[13:47:31] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[13:47:31] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[13:47:31] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DroneGrenade.tscn
+[13:47:31] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: false, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: false, FPS drop logging: true, All weapons unlocked: true, All maps unlocked: true, Global stuck max time: 20.0s, Nav mesh visible: false, Search path visible: false, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false, Enemy path visible: false, Cover raycast visible: false, Tactical group: false, Cover infinite rays: true, Cover sector rays: true, Roguelike unlocked: false
+[13:47:31] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[13:47:31] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.50, music: 1.00
+[13:47:31] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true, revolver_aim_assist: true, unlock_notifications: true, combo_font_size: 140
+[13:47:31] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[13:47:31] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[13:47:31] [INFO] [CinemaEffects] Created effects layer at layer 99
+[13:47:31] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[13:47:31] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[13:47:31] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[13:47:31] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[13:47:31] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[13:47:31] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[13:47:31] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[13:47:31] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[13:47:31] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[13:47:31] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[13:47:31] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[13:47:31] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[13:47:31] [INFO] [GrenadeTimerHelper] Autoload ready
+[13:47:31] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[13:47:31] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[13:47:31] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[13:47:31] [INFO] [PowerFantasy]   Kill effect duration: 600ms
+[13:47:31] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[13:47:31] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[13:47:31] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[13:47:31] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[13:47:31] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[13:47:31] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[13:47:31] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[13:47:31] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[13:47:31] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[13:47:31] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[13:47:31] [INFO] [ProgressManager] ProgressManager ready, loaded 7 entries
+[13:47:31] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[13:47:31] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[13:47:31] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[13:47:31] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[13:47:31] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[13:47:31] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[13:47:31] [INFO] [SceneLoader] SceneLoader initialized
+[13:47:31] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[13:47:31] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[13:47:31] [INFO] [PersistManager] Restored unlocked weapon: mini_uzi
+[13:47:31] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[13:47:31] [INFO] [PersistManager] Restored kills_without_laser_sight: 75
+[13:47:31] [INFO] [PersistManager] Restored shots_fired_special_weapons: 0
+[13:47:31] [INFO] [PersistManager] Restored total_deaths: 5
+[13:47:31] [INFO] [PersistManager] Restored no_damage_levels_completed: 3
+[13:47:31] [INFO] [PersistManager] Restored levels_completed_rank_a_or_higher: 6
+[13:47:31] [INFO] [PersistManager] Restored kills_through_wall: 1
+[13:47:31] [INFO] [PersistManager] Restored levels_completed_with_silenced_pistol: 0
+[13:47:31] [INFO] [GameManager] Weapon selected: ak_gl
+[13:47:31] [INFO] [PersistManager] Restored selected weapon: ak_gl
+[13:47:31] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[13:47:31] [INFO] [PersistManager] Restored unlocked grenade type: 1
+[13:47:31] [INFO] [PersistManager] Restored unlocked grenade type: 4
+[13:47:31] [INFO] [GrenadeManager] Grenade type changed from Flashbang to Drone
+[13:47:31] [INFO] [PersistManager] Restored selected grenade type: 4
+[13:47:31] [INFO] [PersistManager] Restored unlocked active item type: 0
+[13:47:31] [INFO] [PersistManager] Restored unlocked active item type: 1
+[13:47:31] [INFO] [PersistManager] Restored unlocked active item type: 4
+[13:47:31] [INFO] [PersistManager] Restored unlocked active item type: 11
+[13:47:31] [INFO] [PersistManager] Restored unlocked active item type: 12
+[13:47:31] [INFO] [PersistManager] Restored unlocked active item type: 16
+[13:47:31] [INFO] [PersistManager] Restored unlocked active item type: 17
+[13:47:31] [INFO] [ActiveItemManager] Active item changed from None to Flashlight
+[13:47:31] [INFO] [PersistManager] Restored selected active item type: 1
+[13:47:31] [INFO] [PersistManager] Loudspeaker progress restored: level 1, levels_completed=0
+[13:47:31] [INFO] [PersistManager] State loaded successfully
+[13:47:31] [INFO] [PersistManager] PersistManager ready
+[13:47:31] [INFO] [UnlockManager] UnlockManager ready
+[13:47:31] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["makarov_pm", "silenced_pistol", "ak_gl", "sniper", "revolver", "shotgun"]
+[13:47:31] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, warm_lights: true, ai: true
+[13:47:31] [INFO] [LocalizationSettings] Loaded 2 translation(s)
+[13:47:31] [INFO] [LocalizationSettings] LocalizationSettings initialized — locale: en
+[13:47:31] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_condition
+[13:47:31] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_kill_condition
+[13:47:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:47:31] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[13:47:31] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[13:47:31] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[13:47:31] [ENEMY] [Enemy1] Death animation component initialized
+[13:47:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:47:31] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[13:47:31] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[13:47:31] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[13:47:31] [ENEMY] [Enemy2] Death animation component initialized
+[13:47:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:47:31] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[13:47:31] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[13:47:31] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[13:47:31] [ENEMY] [Enemy3] Death animation component initialized
+[13:47:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:47:31] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[13:47:31] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[13:47:31] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[13:47:31] [ENEMY] [Enemy4] Death animation component initialized
+[13:47:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:47:31] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[13:47:31] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[13:47:31] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[13:47:31] [ENEMY] [Enemy5] Death animation component initialized
+[13:47:31] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:47:31] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[13:47:31] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[13:47:31] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[13:47:31] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[13:47:31] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[13:47:31] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[13:47:31] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[13:47:32] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[13:47:32] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[13:47:32] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[13:47:32] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[13:47:32] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[13:47:32] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[13:47:32] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[13:47:32] [INFO] [Player.Flashlight] Flashlight is selected, initializing...
+[13:47:32] [INFO] [FlashlightEffect] PointLight2D found, energy=0.0, shadow=true
+[13:47:32] [INFO] [FlashlightEffect] Scatter light created (Issue #644)
+[13:47:32] [INFO] [FlashlightEffect] Flashlight sound loaded
+[13:47:32] [INFO] [Player.Flashlight] Flashlight equipped and attached to PlayerModel at offset (20, 0)
+[13:47:32] [INFO] [Player.Flashlight] GDScript methods available: True
+[13:47:32] [INFO] [Player.Flashlight] PointLight2D found, shadow=True
+[13:47:32] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[13:47:32] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[13:47:32] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[13:47:32] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[13:47:32] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[13:47:32] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[13:47:32] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[13:47:32] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[13:47:32] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[13:47:32] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[13:47:32] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[13:47:32] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[13:47:32] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[13:47:32] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[13:47:32] [INFO] [Player.ItemVisual] Visual applied for item type: 1
+[13:47:32] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[13:47:32] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[13:47:32] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[13:47:32] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[13:47:32] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[13:47:32] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[13:47:32] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[13:47:32] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[13:47:32] [INFO] [Player.Jammer] JammerHUD initialized
+[13:47:32] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[13:47:32] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 10/10
+[13:47:32] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[13:47:32] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[13:47:32] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[13:47:32] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[13:47:32] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[13:47:32] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[13:47:32] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[13:47:32] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[13:47:32] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[13:47:32] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[13:47:32] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[13:47:32] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/150
+[13:47:32] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[13:47:32] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/150
+[13:47:32] [INFO] [GameManager] set_player() called with: <CharacterBody2D#86922757902> (class: CharacterBody2D)
+[13:47:32] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[13:47:32] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[13:47:32] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[13:47:32] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[13:47:32] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[13:47:32] [INFO] [ScoreManager] Level started with 5 enemies
+[13:47:32] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[13:47:32] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[13:47:32] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[13:47:32] [INFO] [ReplayManager] Replay data cleared
+[13:47:32] [INFO] [LabyrinthLevel] Previous replay data cleared
+[13:47:32] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[13:47:32] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[13:47:32] [INFO] [ReplayManager] Level: LabyrinthLevel
+[13:47:32] [INFO] [ReplayManager] Player: Player (valid: True)
+[13:47:32] [INFO] [ReplayManager] Enemies count: 5
+[13:47:32] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[13:47:32] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[13:47:32] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[13:47:32] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[13:47:32] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[13:47:32] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[13:47:32] [INFO] [LabyrinthLevel] Replay recording started successfully
+[13:47:32] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[13:47:32] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[13:47:32] [INFO] [CinemaEffects] Found player node: Player
+[13:47:32] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[13:47:32] [INFO] [PersistManager] Already at last played level: res://scenes/levels/LabyrinthLevel.tscn
+[13:47:32] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[13:47:32] [INFO] [UnlockManager] Restored saved unlock for weapon: mini_uzi
+[13:47:32] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[13:47:32] [INFO] [UnlockManager] Skipped restore for weapon 'ak_gl' (condition not met — treating as corrupt save)
+[13:47:32] [INFO] [UnlockManager] Restored saved unlock for grenade type: 1
+[13:47:32] [INFO] [UnlockManager] Restored saved unlock for grenade type: 4
+[13:47:32] [INFO] [UnlockManager] Restored saved unlock for active item type: 1
+[13:47:32] [INFO] [UnlockManager] Restored saved unlock for active item type: 16
+[13:47:32] [INFO] [UnlockManager] Restored saved unlock for active item type: 12
+[13:47:32] [INFO] [UnlockManager] Restored saved unlock for active item type: 4
+[13:47:32] [INFO] [UnlockManager] Restored saved unlock for active item type: 17
+[13:47:32] [INFO] [PersistManager] State saved to user://game_state.cfg
+[13:47:32] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/LabyrinthLevel.tscn
+[13:47:32] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[13:47:32] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[13:47:32] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[13:47:32] [ENEMY] [Enemy1] Registered as sound listener
+[13:47:32] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 2, behavior: GUARD
+[13:47:32] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[13:47:32] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[13:47:32] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[13:47:32] [ENEMY] [Enemy2] Registered as sound listener
+[13:47:32] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 2, behavior: GUARD
+[13:47:32] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[13:47:32] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[13:47:32] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[13:47:32] [ENEMY] [Enemy3] Registered as sound listener
+[13:47:32] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 2, behavior: PATROL
+[13:47:32] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[13:47:32] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[13:47:32] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[13:47:32] [ENEMY] [Enemy4] Registered as sound listener
+[13:47:32] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[13:47:32] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[13:47:32] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[13:47:32] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[13:47:32] [ENEMY] [Enemy5] Registered as sound listener
+[13:47:32] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 4, behavior: GUARD
+[13:47:32] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[13:47:32] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[13:47:32] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:47:32] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:47:32] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:47:32] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:47:32] [INFO] [Player] Detecting weapon pose (frame 3)...
+[13:47:32] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[13:47:32] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[13:47:32] [INFO] [PenultimateHit] Shader warmup complete in 1336 ms
+[13:47:32] [INFO] [LastChance] Shader warmup complete in 1335 ms
+[13:47:32] [INFO] [CinemaEffects] Cinema shader warmup complete in 1210 ms
+[13:47:32] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1202 ms
+[13:47:32] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[13:47:32] [INFO] [FlashbangPlayer] Shader warmup complete in 1199 ms
+[13:47:32] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[13:47:33] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 1767 ms
+[13:47:34] [WARN] [FPS] Drop detected: 1 fps (threshold: 30)
+[13:47:34] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[13:47:34] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:47:35] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[13:47:35] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[13:47:36] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[13:47:36] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-54.4°, player=(150,1000), corner_timer=-0.02
+[13:47:36] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:47:36] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(150,1000), corner_timer=0.30
+[13:47:36] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[13:47:36] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:47:36] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[13:47:37] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[13:47:37] [INFO] [Player] Invincibility mode: ON
+[13:47:37] [INFO] [GameManager] Invincibility mode toggled: ON
+[13:47:38] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:47:38] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[13:47:38] [INFO] [Player.Grenade] G pressed - starting grab animation
+[13:47:38] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=5
+[13:47:38] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:47:38] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (486.91403, 861.50684)
+[13:47:38] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[13:47:38] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[13:47:38] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[13:47:38] [INFO] [DroneGrenade] Ready
+[13:47:38] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[13:47:38] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[13:47:38] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[13:47:38] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[13:47:38] [INFO] [Player.Grenade] Timer started, grenade created at (150, 1000)
+[13:47:38] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[13:47:38] [INFO] [Player.Grenade] Step 1 complete! Drag: (178.37161, 17.365479)
+[13:47:38] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[13:47:38] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[13:47:38] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:38] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:38] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:38] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:38] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:38] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:38] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:38] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:38] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-85.8°, player=(150,1000), corner_timer=-0.02
+[13:47:38] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:47:38] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[13:47:38] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-85.6°, player=(150,1000), corner_timer=0.30
+[13:47:38] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-82.0°, player=(150,1000), corner_timer=-0.02
+[13:47:38] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:47:38] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-81.8°, player=(150,1000), corner_timer=0.30
+[13:47:39] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-78.2°, player=(150,1000), corner_timer=-0.02
+[13:47:39] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:47:39] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=5
+[13:47:39] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-78.0°, player=(150,1000), corner_timer=0.30
+[13:47:39] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-89.3°, player=(150,1000), corner_timer=-0.02
+[13:47:39] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:47:39] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-172.4°, player=(150,1000), corner_timer=0.30
+[13:47:40] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=5
+[13:47:40] [INFO] [Player.Grenade.Simple] Throwing! Target: (335.93283, 1097.9447), Distance: 150,2, Speed: 300,2, Friction: 300,0
+[13:47:40] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,4848372
+[13:47:40] [INFO] [Player.Grenade] Drone aim point set to (335.93283, 1097.9447)
+[13:47:40] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[13:47:40] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.88475084, 0.46606433), speed=300,2, spawn=(203.08505, 1027.9639)
+[13:47:40] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.884751, 0.466064), Speed: 300.2 (clamped from 300.2, max: 850.0)
+[13:47:40] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[13:47:40] [INFO] [DroneGrenade] THROWING phase started toward (335.9328, 1097.945)
+[13:47:40] [INFO] [DroneGrenade] Drone launched at (203.0851, 1027.964)
+[13:47:40] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[13:47:40] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[13:47:40] [INFO] [Player.Grenade] State reset to IDLE
+[13:47:40] [INFO] [Player.Grenade] State reset to IDLE
+[13:47:40] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[13:47:40] [INFO] [Player.Grenade] Player rotation restored to 0
+[13:47:40] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[13:47:40] [INFO] [DroneGrenade] Camera attached to drone
+[13:47:40] [INFO] [DroneGrenade] Player control disabled
+[13:47:40] [INFO] [DroneGrenade] PILOTING phase started at (319.2086, 1089.135)
+[13:47:40] [INFO] [GrenadeTimer] Flashbang grenade landed at (319.20862, 1089.1348)
+[13:47:40] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(319.2086, 1089.135), source=NEUTRAL (DroneGrenade), range=112, listeners=5
+[13:47:40] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0
+[13:47:40] [INFO] [GrenadeTimer] Emitted grenade landing sound at (319.20862, 1089.1348)
+[13:47:41] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=5
+[13:47:41] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[13:47:41] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-84.6°, player=(150,1000), corner_timer=-0.02
+[13:47:41] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:47:41] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-78.6°, player=(150,1000), corner_timer=0.30
+[13:47:42] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-75.0°, player=(150,1000), corner_timer=-0.02
+[13:47:42] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=5
+[13:47:43] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[13:47:43] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[13:47:43] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[13:47:43] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[13:47:43] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[13:47:43] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[13:47:43] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[13:47:43] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[13:47:43] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[13:47:43] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[13:47:43] [INFO] [LastChance] Resetting all effects (scene change detected)
+[13:47:43] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[13:47:43] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[13:47:43] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[13:47:43] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[13:47:43] [INFO] [PersistManager] State saved to user://game_state.cfg
+[13:47:43] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[13:47:43] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:47:43] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[13:47:43] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[13:47:43] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[13:47:43] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[13:47:43] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[13:47:43] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[13:47:43] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[13:47:43] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[13:47:43] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[13:47:43] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[13:47:43] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[13:47:43] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[13:47:43] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[13:47:43] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[13:47:43] [INFO] [Player.Flashlight] Flashlight is selected, initializing...
+[13:47:43] [INFO] [FlashlightEffect] PointLight2D found, energy=0.0, shadow=true
+[13:47:43] [INFO] [FlashlightEffect] Scatter light created (Issue #644)
+[13:47:43] [INFO] [FlashlightEffect] Flashlight sound loaded
+[13:47:43] [INFO] [Player.Flashlight] Flashlight equipped and attached to PlayerModel at offset (20, 0)
+[13:47:43] [INFO] [Player.Flashlight] GDScript methods available: True
+[13:47:43] [INFO] [Player.Flashlight] PointLight2D found, shadow=True
+[13:47:43] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[13:47:43] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[13:47:43] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[13:47:43] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[13:47:43] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[13:47:43] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[13:47:43] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[13:47:43] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[13:47:43] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[13:47:43] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[13:47:43] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[13:47:43] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[13:47:43] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[13:47:43] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[13:47:43] [INFO] [Player.ItemVisual] Visual applied for item type: 1
+[13:47:43] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[13:47:43] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[13:47:43] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[13:47:43] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[13:47:43] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[13:47:43] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[13:47:43] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[13:47:43] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[13:47:43] [INFO] [Player.Jammer] JammerHUD initialized
+[13:47:43] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[13:47:43] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 10/10
+[13:47:43] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[13:47:43] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[13:47:43] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[13:47:43] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[13:47:43] [INFO] [GameManager] set_player() called with: <CharacterBody2D#189934865687> (class: CharacterBody2D)
+[13:47:43] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[13:47:43] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[13:47:43] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[13:47:43] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[13:47:43] [INFO] [CinemaEffects] Found player node: Player
+[13:47:43] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[13:47:43] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[13:47:43] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[13:47:43] [INFO] [Player] Detecting weapon pose (frame 3)...
+[13:47:43] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[13:47:43] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[13:47:43] [INFO] [ReplayManager] Recording frame 600 (10,2s): player_valid=False, enemies=5
+[13:47:43] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[13:47:43] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[13:47:43] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[13:47:43] [INFO] [LastChance] Found player: Player
+[13:47:43] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[13:47:43] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[13:47:43] [INFO] [LastChance] Connected to player Died signal (C#)
+[13:47:43] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[13:47:44] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:47:44] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[13:47:44] [INFO] [Player.Grenade] G pressed - starting grab animation
+[13:47:44] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[13:47:44] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[13:47:44] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[13:47:44] [INFO] [ReplayManager] Recording frame 660 (11,2s): player_valid=False, enemies=5
+[13:47:44] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:47:44] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (591.4742, 435.8342)
+[13:47:44] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[13:47:44] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[13:47:44] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[13:47:44] [INFO] [DroneGrenade] Ready
+[13:47:44] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[13:47:44] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[13:47:44] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[13:47:44] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[13:47:44] [INFO] [Player.Grenade] Timer started, grenade created at (150, 360)
+[13:47:44] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[13:47:44] [INFO] [Player.Grenade] Step 1 complete! Drag: (197.55585, 14.081299)
+[13:47:44] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[13:47:44] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[13:47:44] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:44] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:44] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:44] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:44] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:44] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:44] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:44] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:44] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:44] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[13:47:45] [INFO] [ReplayManager] Recording frame 720 (12,1s): player_valid=False, enemies=5
+[13:47:46] [INFO] [Player.Grenade.Simple] Throwing! Target: (1040.033, 146.15195), Distance: 848,4, Speed: 713,5, Friction: 300,0
+[13:47:46] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,2733344
+[13:47:46] [INFO] [Player.Grenade] Drone aim point set to (1040.033, 146.15195)
+[13:47:46] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[13:47:46] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.96287614, -0.26994357), speed=713,5, spawn=(223.11044, 375.17722)
+[13:47:46] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.962876, -0.269944), Speed: 713.5 (clamped from 713.5, max: 850.0)
+[13:47:46] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[13:47:46] [INFO] [DroneGrenade] THROWING phase started toward (1040.033, 146.1519)
+[13:47:46] [INFO] [DroneGrenade] Drone launched at (223.1104, 375.1772)
+[13:47:46] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[13:47:46] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[13:47:46] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[13:47:46] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[13:47:46] [INFO] [Player.Grenade] State reset to IDLE
+[13:47:46] [INFO] [Player.Grenade] State reset to IDLE
+[13:47:46] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[13:47:46] [INFO] [Player.Grenade] Player rotation restored to 0
+[13:47:46] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[13:47:46] [INFO] [ReplayManager] Recording frame 780 (13,1s): player_valid=False, enemies=5
+[13:47:46] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[13:47:47] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[13:47:47] [INFO] [DroneGrenade] Camera attached to drone
+[13:47:47] [INFO] [DroneGrenade] Player control disabled
+[13:47:47] [INFO] [DroneGrenade] PILOTING phase started at (1017.002, 152.6086)
+[13:47:47] [INFO] [GrenadeTimer] Flashbang grenade landed at (1017.0015, 152.60863)
+[13:47:47] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(1017.002, 152.6086), source=NEUTRAL (DroneGrenade), range=112, listeners=0
+[13:47:47] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[13:47:47] [INFO] [GrenadeTimer] Emitted grenade landing sound at (1017.0015, 152.60863)
+[13:47:47] [INFO] [ReplayManager] Recording frame 840 (14,1s): player_valid=False, enemies=5
+[13:47:47] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[13:47:48] [INFO] [ReplayManager] Recording frame 900 (15,1s): player_valid=False, enemies=5
+[13:47:49] [INFO] [ReplayManager] Recording frame 960 (16,1s): player_valid=False, enemies=5
+[13:47:50] [INFO] [ReplayManager] Recording frame 1020 (17,1s): player_valid=False, enemies=5
+[13:47:51] [INFO] [ReplayManager] Recording frame 1080 (18,1s): player_valid=False, enemies=5
+[13:47:52] [INFO] [ReplayManager] Recording frame 1140 (19,1s): player_valid=False, enemies=5
+[13:47:53] [INFO] [GameManager] restart_scene() — starting scene reload
+[13:47:53] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[13:47:53] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[13:47:53] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[13:47:53] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[13:47:53] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[13:47:53] [INFO] [LastChance] Resetting all effects (scene change detected)
+[13:47:53] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[13:47:53] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[13:47:53] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[13:47:53] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[13:47:53] [INFO] [PersistManager] State saved to user://game_state.cfg
+[13:47:53] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[13:47:53] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:47:53] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[13:47:53] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[13:47:53] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[13:47:53] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[13:47:53] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[13:47:53] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[13:47:53] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[13:47:53] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[13:47:53] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[13:47:53] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[13:47:53] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[13:47:53] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[13:47:53] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[13:47:53] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[13:47:53] [INFO] [Player.Flashlight] Flashlight is selected, initializing...
+[13:47:53] [INFO] [FlashlightEffect] PointLight2D found, energy=0.0, shadow=true
+[13:47:53] [INFO] [FlashlightEffect] Scatter light created (Issue #644)
+[13:47:53] [INFO] [FlashlightEffect] Flashlight sound loaded
+[13:47:53] [INFO] [Player.Flashlight] Flashlight equipped and attached to PlayerModel at offset (20, 0)
+[13:47:53] [INFO] [Player.Flashlight] GDScript methods available: True
+[13:47:53] [INFO] [Player.Flashlight] PointLight2D found, shadow=True
+[13:47:53] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[13:47:53] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[13:47:53] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[13:47:53] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[13:47:53] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[13:47:53] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[13:47:53] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[13:47:53] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[13:47:53] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[13:47:53] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[13:47:53] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[13:47:53] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[13:47:53] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[13:47:53] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[13:47:53] [INFO] [Player.ItemVisual] Visual applied for item type: 1
+[13:47:53] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[13:47:53] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[13:47:53] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[13:47:53] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[13:47:53] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[13:47:53] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[13:47:53] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[13:47:53] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[13:47:53] [INFO] [Player.Jammer] JammerHUD initialized
+[13:47:53] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[13:47:53] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 10/10
+[13:47:53] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[13:47:53] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[13:47:53] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[13:47:53] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[13:47:53] [INFO] [GameManager] set_player() called with: <CharacterBody2D#237364054918> (class: CharacterBody2D)
+[13:47:53] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[13:47:53] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[13:47:53] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[13:47:53] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[13:47:53] [INFO] [CinemaEffects] Found player node: Player
+[13:47:53] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[13:47:53] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[13:47:53] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[13:47:53] [INFO] [Player] Detecting weapon pose (frame 3)...
+[13:47:53] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[13:47:53] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[13:47:53] [INFO] [ReplayManager] Recording frame 1200 (20,1s): player_valid=False, enemies=5
+[13:47:53] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[13:47:53] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[13:47:53] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[13:47:53] [INFO] [LastChance] Found player: Player
+[13:47:53] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[13:47:53] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[13:47:53] [INFO] [LastChance] Connected to player Died signal (C#)
+[13:47:53] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[13:47:53] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:47:53] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[13:47:53] [INFO] [Player.Grenade] G pressed - starting grab animation
+[13:47:53] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[13:47:53] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[13:47:53] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[13:47:54] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:47:54] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (883.40216, 240.67427)
+[13:47:54] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[13:47:54] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[13:47:54] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[13:47:54] [INFO] [DroneGrenade] Ready
+[13:47:54] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[13:47:54] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[13:47:54] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[13:47:54] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[13:47:54] [INFO] [Player.Grenade] Timer started, grenade created at (150, 360)
+[13:47:54] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[13:47:54] [INFO] [Player.Grenade] Step 1 complete! Drag: (192.78143, 11.270645)
+[13:47:54] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[13:47:54] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[13:47:54] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:54] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:54] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:54] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:54] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:54] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:54] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:54] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:47:54] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[13:47:54] [INFO] [ReplayManager] Recording frame 1260 (21,1s): player_valid=False, enemies=5
+[13:47:55] [INFO] [Player.Grenade.Simple] Throwing! Target: (1293.1626, 193.56578), Distance: 1095,2, Speed: 810,6, Friction: 300,0
+[13:47:55] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,14457522
+[13:47:55] [INFO] [Player.Grenade] Drone aim point set to (1293.1626, 193.56578)
+[13:47:55] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[13:47:55] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.9895672, -0.1440721), speed=810,6, spawn=(209.37404, 351.35568)
+[13:47:55] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.989567, -0.144072), Speed: 810.6 (clamped from 810.6, max: 850.0)
+[13:47:55] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[13:47:55] [INFO] [DroneGrenade] THROWING phase started toward (1293.163, 193.5658)
+[13:47:55] [INFO] [DroneGrenade] Drone launched at (209.374, 351.3557)
+[13:47:55] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[13:47:55] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[13:47:55] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[13:47:55] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[13:47:55] [INFO] [Player.Grenade] State reset to IDLE
+[13:47:55] [INFO] [Player.Grenade] State reset to IDLE
+[13:47:55] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[13:47:55] [INFO] [Player.Grenade] Player rotation restored to 0
+[13:47:55] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[13:47:55] [INFO] [ReplayManager] Recording frame 1320 (22,1s): player_valid=False, enemies=5
+[13:47:55] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[13:47:56] [INFO] [ReplayManager] Recording frame 1380 (23,1s): player_valid=False, enemies=5
+[13:47:56] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[13:47:56] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[13:47:56] [INFO] [DroneGrenade] Camera attached to drone
+[13:47:56] [INFO] [DroneGrenade] Player control disabled
+[13:47:56] [INFO] [DroneGrenade] PILOTING phase started at (1264.007, 197.8108)
+[13:47:56] [INFO] [GrenadeTimer] Flashbang grenade landed at (1264.0068, 197.81079)
+[13:47:56] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(1264.007, 197.8108), source=NEUTRAL (DroneGrenade), range=112, listeners=0
+[13:47:56] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[13:47:56] [INFO] [GrenadeTimer] Emitted grenade landing sound at (1264.0068, 197.81079)
+[13:47:57] [INFO] [ReplayManager] Recording frame 1440 (24,1s): player_valid=False, enemies=5
+[13:47:58] [INFO] [ReplayManager] Recording frame 1500 (25,1s): player_valid=False, enemies=5
+[13:47:59] [INFO] [ReplayManager] Recording frame 1560 (26,1s): player_valid=False, enemies=5
+[13:48:00] [INFO] [ReplayManager] Recording frame 1620 (27,1s): player_valid=False, enemies=5
+[13:48:01] [INFO] [ReplayManager] Recording frame 1680 (28,1s): player_valid=False, enemies=5
+[13:48:02] [INFO] [PersistManager] State saved to user://game_state.cfg
+[13:48:02] [INFO] [PersistManager] Last level saved: res://scenes/levels/LabyrinthLevel.tscn
+[13:48:02] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/LabyrinthLevel.tscn
+[13:48:02] [INFO] [SceneLoader] Background load started successfully
+[13:48:02] [INFO] [SceneLoader] Background load complete: res://scenes/levels/LabyrinthLevel.tscn
+[13:48:02] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[13:48:02] [INFO] [SceneLoader] Scene changed successfully
+[13:48:02] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[13:48:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:02] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[13:48:02] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[13:48:02] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[13:48:02] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[13:48:02] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[13:48:02] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[13:48:02] [INFO] [LastChance] Resetting all effects (scene change detected)
+[13:48:02] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[13:48:02] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[13:48:02] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[13:48:02] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[13:48:02] [INFO] [PersistManager] State saved to user://game_state.cfg
+[13:48:02] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/LabyrinthLevel.tscn
+[13:48:02] [ENEMY] [Enemy1] Death animation component initialized
+[13:48:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:02] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[13:48:02] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[13:48:02] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[13:48:02] [ENEMY] [Enemy2] Death animation component initialized
+[13:48:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:02] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[13:48:02] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[13:48:02] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[13:48:02] [ENEMY] [Enemy3] Death animation component initialized
+[13:48:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:02] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[13:48:02] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[13:48:02] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[13:48:02] [ENEMY] [Enemy4] Death animation component initialized
+[13:48:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:02] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[13:48:02] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[13:48:02] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[13:48:02] [ENEMY] [Enemy5] Death animation component initialized
+[13:48:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:02] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[13:48:02] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[13:48:02] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[13:48:02] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[13:48:02] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[13:48:02] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[13:48:02] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[13:48:02] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[13:48:02] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[13:48:02] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[13:48:02] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[13:48:02] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[13:48:02] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[13:48:02] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[13:48:02] [INFO] [Player.Flashlight] Flashlight is selected, initializing...
+[13:48:02] [INFO] [FlashlightEffect] PointLight2D found, energy=0.0, shadow=true
+[13:48:02] [INFO] [FlashlightEffect] Scatter light created (Issue #644)
+[13:48:02] [INFO] [FlashlightEffect] Flashlight sound loaded
+[13:48:02] [INFO] [Player.Flashlight] Flashlight equipped and attached to PlayerModel at offset (20, 0)
+[13:48:02] [INFO] [Player.Flashlight] GDScript methods available: True
+[13:48:02] [INFO] [Player.Flashlight] PointLight2D found, shadow=True
+[13:48:02] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[13:48:02] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[13:48:02] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[13:48:02] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[13:48:02] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[13:48:02] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[13:48:02] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[13:48:02] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[13:48:02] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[13:48:02] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[13:48:02] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[13:48:02] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[13:48:02] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[13:48:02] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[13:48:02] [INFO] [Player.ItemVisual] Visual applied for item type: 1
+[13:48:02] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[13:48:02] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[13:48:02] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[13:48:02] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[13:48:02] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[13:48:02] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[13:48:02] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[13:48:02] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[13:48:02] [INFO] [Player.Jammer] JammerHUD initialized
+[13:48:02] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[13:48:02] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 10/10
+[13:48:02] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[13:48:02] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[13:48:02] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[13:48:02] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[13:48:02] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[13:48:02] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[13:48:02] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[13:48:02] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[13:48:02] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[13:48:02] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[13:48:02] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/150
+[13:48:02] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[13:48:02] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/150
+[13:48:02] [INFO] [GameManager] set_player() called with: <CharacterBody2D#298600894335> (class: CharacterBody2D)
+[13:48:02] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[13:48:02] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[13:48:02] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[13:48:02] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[13:48:02] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[13:48:02] [INFO] [ScoreManager] Level started with 5 enemies
+[13:48:02] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[13:48:02] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[13:48:02] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[13:48:02] [INFO] [ReplayManager] Replay data cleared
+[13:48:02] [INFO] [LabyrinthLevel] Previous replay data cleared
+[13:48:02] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[13:48:02] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[13:48:02] [INFO] [ReplayManager] Level: LabyrinthLevel
+[13:48:02] [INFO] [ReplayManager] Player: Player (valid: True)
+[13:48:02] [INFO] [ReplayManager] Enemies count: 5
+[13:48:02] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[13:48:02] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[13:48:02] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[13:48:02] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[13:48:02] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[13:48:02] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[13:48:02] [INFO] [LabyrinthLevel] Replay recording started successfully
+[13:48:02] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[13:48:02] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[13:48:02] [INFO] [CinemaEffects] Found player node: Player
+[13:48:02] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[13:48:02] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[13:48:02] [ENEMY] [Enemy1] Registered as sound listener
+[13:48:02] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 2, behavior: GUARD
+[13:48:02] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[13:48:02] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[13:48:02] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[13:48:02] [ENEMY] [Enemy2] Registered as sound listener
+[13:48:02] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 2, behavior: GUARD
+[13:48:02] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[13:48:02] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[13:48:02] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[13:48:02] [ENEMY] [Enemy3] Registered as sound listener
+[13:48:02] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 2, behavior: PATROL
+[13:48:02] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[13:48:02] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[13:48:02] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[13:48:02] [ENEMY] [Enemy4] Registered as sound listener
+[13:48:02] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 2, behavior: GUARD
+[13:48:02] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[13:48:02] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[13:48:02] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[13:48:02] [ENEMY] [Enemy5] Registered as sound listener
+[13:48:02] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 2, behavior: GUARD
+[13:48:02] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[13:48:02] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[13:48:03] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[13:48:03] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[13:48:03] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:48:03] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:48:03] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:48:03] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:48:03] [INFO] [Player] Detecting weapon pose (frame 3)...
+[13:48:03] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[13:48:03] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[13:48:03] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[13:48:03] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[13:48:03] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[13:48:03] [INFO] [LastChance] Found player: Player
+[13:48:03] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[13:48:03] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[13:48:03] [INFO] [LastChance] Connected to player Died signal (C#)
+[13:48:03] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[13:48:03] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:48:03] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[13:48:03] [INFO] [Player.Grenade] G pressed - starting grab animation
+[13:48:03] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:48:03] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (209.93874, 721.0247)
+[13:48:03] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[13:48:03] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[13:48:03] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[13:48:03] [INFO] [DroneGrenade] Ready
+[13:48:03] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[13:48:03] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[13:48:03] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[13:48:03] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[13:48:03] [INFO] [Player.Grenade] Timer started, grenade created at (150, 1000)
+[13:48:03] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[13:48:03] [INFO] [Player.Grenade] Step 1 complete! Drag: (229.46199, 12.343933)
+[13:48:03] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[13:48:03] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:03] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[13:48:03] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[13:48:04] [WARN] [FPS] Drop detected: 14 fps (threshold: 30)
+[13:48:04] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:04] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=-0.0°, player=(150,1000), corner_timer=0.30
+[13:48:04] [INFO] [Player.Grenade.Simple] Throwing! Target: (337.87415, 1093.9641), Distance: 150,1, Speed: 300,1, Friction: 300,0
+[13:48:04] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,46376273
+[13:48:04] [INFO] [Player.Grenade] Drone aim point set to (337.87415, 1093.9641)
+[13:48:04] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[13:48:04] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.89437574, 0.4473166), speed=300,1, spawn=(203.66254, 1026.839)
+[13:48:04] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.894376, 0.447317), Speed: 300.1 (clamped from 300.1, max: 850.0)
+[13:48:04] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[13:48:04] [INFO] [DroneGrenade] THROWING phase started toward (337.8741, 1093.964)
+[13:48:04] [INFO] [DroneGrenade] Drone launched at (203.6625, 1026.839)
+[13:48:04] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[13:48:04] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[13:48:04] [INFO] [Player.Grenade] State reset to IDLE
+[13:48:04] [INFO] [Player.Grenade] State reset to IDLE
+[13:48:04] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[13:48:04] [INFO] [Player.Grenade] Player rotation restored to 0
+[13:48:04] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-54.4°, player=(150,1000), corner_timer=-0.02
+[13:48:04] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:04] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(150,1000), corner_timer=0.30
+[13:48:04] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[13:48:04] [INFO] [DroneGrenade] Camera attached to drone
+[13:48:04] [INFO] [DroneGrenade] Player control disabled
+[13:48:04] [INFO] [DroneGrenade] PILOTING phase started at (321.0493, 1085.549)
+[13:48:04] [INFO] [GrenadeTimer] Flashbang grenade landed at (321.04935, 1085.5493)
+[13:48:04] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(321.0493, 1085.549), source=NEUTRAL (DroneGrenade), range=112, listeners=5
+[13:48:04] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0
+[13:48:04] [INFO] [GrenadeTimer] Emitted grenade landing sound at (321.04935, 1085.5493)
+[13:48:04] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[13:48:05] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[13:48:05] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:05] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[13:48:05] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[13:48:06] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[13:48:06] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[13:48:07] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-85.8°, player=(150,1000), corner_timer=-0.02
+[13:48:07] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:07] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-85.6°, player=(150,1000), corner_timer=0.30
+[13:48:07] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-82.0°, player=(150,1000), corner_timer=-0.02
+[13:48:07] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:07] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-81.8°, player=(150,1000), corner_timer=0.30
+[13:48:07] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-78.2°, player=(150,1000), corner_timer=-0.02
+[13:48:07] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:07] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-78.0°, player=(150,1000), corner_timer=0.30
+[13:48:07] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=5
+[13:48:08] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-89.3°, player=(150,1000), corner_timer=-0.02
+[13:48:08] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:08] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-172.4°, player=(150,1000), corner_timer=0.30
+[13:48:08] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=5
+[13:48:09] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=5
+[13:48:10] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-84.6°, player=(150,1000), corner_timer=-0.02
+[13:48:10] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:10] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-78.6°, player=(150,1000), corner_timer=0.30
+[13:48:10] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-75.0°, player=(150,1000), corner_timer=-0.02
+[13:48:10] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:10] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-15.8°, player=(150,1000), corner_timer=0.30
+[13:48:10] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=5
+[13:48:11] [INFO] [ReplayManager] Recording frame 540 (9,0s): player_valid=True, enemies=5
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [INFO] [GrenadeBase] Collision detected with WallLeft (type: StaticBody2D)
+[13:48:12] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-86.4°, player=(150,1000), corner_timer=-0.02
+[13:48:12] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:12] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-83.5°, player=(150,1000), corner_timer=0.30
+[13:48:12] [INFO] [ReplayManager] Recording frame 600 (10,0s): player_valid=True, enemies=5
+[13:48:13] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[13:48:13] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:13] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[13:48:13] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[13:48:13] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:13] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[13:48:13] [ENEMY] [Enemy1] GRENADE DANGER: Entering EVADING_GRENADE state from IDLE
+[13:48:13] [ENEMY] [Enemy1] EVADING_GRENADE started: escaping to (316.8716, 472.5999)
+[13:48:13] [ENEMY] [Enemy1] ROT_CHANGE: P5:idle_scan -> P4:velocity, state=EVADING_GRENADE, target=115.7°, current=-153.5°, player=(150,1000), corner_timer=0.00
+[13:48:13] [ENEMY] [Enemy1] EVADING_GRENADE: Escaped to safe distance
+[13:48:13] [ENEMY] [Enemy1] State: EVADING_GRENADE -> IDLE
+[13:48:13] [ENEMY] [Enemy1] ROT_CHANGE: P4:velocity -> P5:idle_scan, state=IDLE, target=213.8°, current=-156.7°, player=(150,1000), corner_timer=0.00
+[13:48:13] [INFO] [ReplayManager] Recording frame 660 (11,0s): player_valid=True, enemies=5
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:14] [INFO] [ReplayManager] Recording frame 720 (12,0s): player_valid=True, enemies=5
+[13:48:14] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:15] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:15] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:15] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:15] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:15] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:15] [INFO] [GrenadeBase] Collision detected with GeneratorCrate2 (type: StaticBody2D)
+[13:48:15] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-84.5°, player=(150,1000), corner_timer=-0.02
+[13:48:15] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:15] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-84.3°, player=(150,1000), corner_timer=0.30
+[13:48:15] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-80.6°, player=(150,1000), corner_timer=-0.02
+[13:48:15] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:15] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-80.5°, player=(150,1000), corner_timer=0.30
+[13:48:15] [INFO] [GrenadeBase] Collision detected with HorizontalDivider (type: StaticBody2D)
+[13:48:15] [INFO] [GrenadeBase] Collision detected with HorizontalDivider (type: StaticBody2D)
+[13:48:15] [INFO] [GrenadeBase] Collision detected with HorizontalDivider (type: StaticBody2D)
+[13:48:15] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-76.8°, player=(150,1000), corner_timer=-0.02
+[13:48:15] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:15] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-76.6°, player=(150,1000), corner_timer=0.30
+[13:48:15] [INFO] [ReplayManager] Recording frame 780 (13,0s): player_valid=True, enemies=5
+[13:48:16] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-89.3°, player=(150,1000), corner_timer=-0.02
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:16] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-149.5°, player=(150,1000), corner_timer=0.30
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:16] [INFO] [ReplayManager] Recording frame 840 (14,0s): player_valid=True, enemies=5
+[13:48:17] [ENEMY] [Enemy2] GRENADE DANGER: Entering EVADING_GRENADE state from IDLE
+[13:48:17] [ENEMY] [Enemy2] EVADING_GRENADE started: escaping to (956.2687, 928.5826)
+[13:48:17] [ENEMY] [Enemy2] ROT_CHANGE: P5:idle_scan -> P4:velocity, state=EVADING_GRENADE, target=-6.1°, current=-171.8°, player=(150,1000), corner_timer=0.00
+[13:48:17] [ENEMY] [Enemy2] EVADING_GRENADE: Escaped to safe distance
+[13:48:17] [ENEMY] [Enemy2] State: EVADING_GRENADE -> IDLE
+[13:48:17] [ENEMY] [Enemy2] ROT_CHANGE: P4:velocity -> P5:idle_scan, state=IDLE, target=56.3°, current=-117.5°, player=(150,1000), corner_timer=0.00
+[13:48:17] [INFO] [ReplayManager] Recording frame 900 (15,0s): player_valid=True, enemies=5
+[13:48:18] [INFO] [GrenadeBase] Collision detected with WallBottom (type: StaticBody2D)
+[13:48:18] [INFO] [GrenadeBase] Collision detected with WallBottom (type: StaticBody2D)
+[13:48:18] [INFO] [GrenadeBase] Collision detected with WallBottom (type: StaticBody2D)
+[13:48:18] [INFO] [GrenadeBase] Collision detected with WallBottom (type: StaticBody2D)
+[13:48:18] [INFO] [GrenadeBase] Collision detected with WallBottom (type: StaticBody2D)
+[13:48:18] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-84.8°, player=(150,1000), corner_timer=-0.02
+[13:48:18] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:18] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-78.8°, player=(150,1000), corner_timer=0.30
+[13:48:18] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-75.2°, player=(150,1000), corner_timer=-0.02
+[13:48:18] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:18] [INFO] [ReplayManager] Recording frame 960 (16,0s): player_valid=True, enemies=5
+[13:48:18] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-10.1°, player=(150,1000), corner_timer=0.30
+[13:48:19] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:19] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:19] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:19] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:19] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:19] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:19] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:19] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:19] [INFO] [ReplayManager] Recording frame 1020 (17,0s): player_valid=True, enemies=5
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Corridor_WallBottom (type: StaticBody2D)
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Storage_WallRight (type: StaticBody2D)
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Storage_WallRight (type: StaticBody2D)
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Storage_WallRight (type: StaticBody2D)
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Storage_WallRight (type: StaticBody2D)
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Storage_WallRight (type: StaticBody2D)
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Storage_WallRight (type: StaticBody2D)
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Storage_WallRight (type: StaticBody2D)
+[13:48:20] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-86.4°, player=(150,1000), corner_timer=-0.02
+[13:48:20] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:20] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-83.5°, player=(150,1000), corner_timer=0.30
+[13:48:20] [INFO] [GrenadeBase] Collision detected with Storage_WallRight (type: StaticBody2D)
+[13:48:20] [INFO] [ReplayManager] Recording frame 1080 (18,0s): player_valid=True, enemies=5
+[13:48:21] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[13:48:21] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:21] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[13:48:21] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[13:48:21] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:21] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[13:48:21] [INFO] [GameManager] restart_scene() — starting scene reload
+[13:48:21] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[13:48:21] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[13:48:21] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[13:48:21] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[13:48:21] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[13:48:21] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[13:48:21] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[13:48:21] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:21] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[13:48:21] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[13:48:21] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[13:48:21] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[13:48:21] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[13:48:21] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[13:48:21] [INFO] [LastChance] Resetting all effects (scene change detected)
+[13:48:21] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[13:48:21] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[13:48:21] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[13:48:21] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[13:48:21] [INFO] [PersistManager] State saved to user://game_state.cfg
+[13:48:21] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/LabyrinthLevel.tscn
+[13:48:21] [ENEMY] [Enemy1] Death animation component initialized
+[13:48:21] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:21] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[13:48:21] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[13:48:21] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[13:48:21] [ENEMY] [Enemy2] Death animation component initialized
+[13:48:21] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:21] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[13:48:21] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[13:48:21] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[13:48:21] [ENEMY] [Enemy3] Death animation component initialized
+[13:48:21] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:21] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[13:48:21] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[13:48:21] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[13:48:21] [ENEMY] [Enemy4] Death animation component initialized
+[13:48:21] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:21] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[13:48:21] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[13:48:21] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[13:48:21] [ENEMY] [Enemy5] Death animation component initialized
+[13:48:21] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[13:48:21] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[13:48:21] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[13:48:21] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[13:48:21] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[13:48:21] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[13:48:21] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[13:48:21] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[13:48:21] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[13:48:21] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[13:48:21] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[13:48:21] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[13:48:21] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[13:48:21] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[13:48:21] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: True
+[13:48:21] [INFO] [Player.Flashlight] Flashlight is selected, initializing...
+[13:48:21] [INFO] [FlashlightEffect] PointLight2D found, energy=0.0, shadow=true
+[13:48:21] [INFO] [FlashlightEffect] Scatter light created (Issue #644)
+[13:48:21] [INFO] [FlashlightEffect] Flashlight sound loaded
+[13:48:21] [INFO] [Player.Flashlight] Flashlight equipped and attached to PlayerModel at offset (20, 0)
+[13:48:21] [INFO] [Player.Flashlight] GDScript methods available: True
+[13:48:21] [INFO] [Player.Flashlight] PointLight2D found, shadow=True
+[13:48:21] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[13:48:21] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[13:48:21] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[13:48:21] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[13:48:21] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[13:48:21] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[13:48:21] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[13:48:21] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[13:48:21] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[13:48:21] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[13:48:21] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[13:48:21] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[13:48:21] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[13:48:21] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[13:48:21] [INFO] [Player.ItemVisual] Visual applied for item type: 1
+[13:48:21] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[13:48:21] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[13:48:21] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[13:48:21] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[13:48:21] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[13:48:21] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[13:48:21] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[13:48:21] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[13:48:21] [INFO] [Player.Jammer] JammerHUD initialized
+[13:48:21] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[13:48:21] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 10/10
+[13:48:21] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[13:48:21] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[13:48:21] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[13:48:21] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[13:48:21] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[13:48:21] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[13:48:21] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[13:48:21] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[13:48:21] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[13:48:21] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[13:48:21] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/150
+[13:48:21] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[13:48:21] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/150
+[13:48:21] [INFO] [GameManager] set_player() called with: <CharacterBody2D#414531456417> (class: CharacterBody2D)
+[13:48:21] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[13:48:21] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[13:48:21] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[13:48:21] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[13:48:21] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[13:48:22] [INFO] [ScoreManager] Level started with 5 enemies
+[13:48:22] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[13:48:22] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[13:48:22] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[13:48:22] [INFO] [ReplayManager] Replay data cleared
+[13:48:22] [INFO] [LabyrinthLevel] Previous replay data cleared
+[13:48:22] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[13:48:22] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[13:48:22] [INFO] [ReplayManager] Level: LabyrinthLevel
+[13:48:22] [INFO] [ReplayManager] Player: Player (valid: True)
+[13:48:22] [INFO] [ReplayManager] Enemies count: 5
+[13:48:22] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[13:48:22] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[13:48:22] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[13:48:22] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[13:48:22] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[13:48:22] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[13:48:22] [INFO] [LabyrinthLevel] Replay recording started successfully
+[13:48:22] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[13:48:22] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[13:48:22] [INFO] [CinemaEffects] Found player node: Player
+[13:48:22] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[13:48:22] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[13:48:22] [ENEMY] [Enemy1] Registered as sound listener
+[13:48:22] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 2, behavior: GUARD
+[13:48:22] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[13:48:22] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[13:48:22] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[13:48:22] [ENEMY] [Enemy2] Registered as sound listener
+[13:48:22] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 2, behavior: GUARD
+[13:48:22] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[13:48:22] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[13:48:22] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[13:48:22] [ENEMY] [Enemy3] Registered as sound listener
+[13:48:22] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[13:48:22] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[13:48:22] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[13:48:22] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[13:48:22] [ENEMY] [Enemy4] Registered as sound listener
+[13:48:22] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 2, behavior: GUARD
+[13:48:22] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[13:48:22] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[13:48:22] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[13:48:22] [ENEMY] [Enemy5] Registered as sound listener
+[13:48:22] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 3, behavior: GUARD
+[13:48:22] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[13:48:22] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[13:48:22] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[13:48:22] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[13:48:22] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:48:22] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:48:22] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:48:22] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[13:48:22] [INFO] [Player] Detecting weapon pose (frame 3)...
+[13:48:22] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[13:48:22] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[13:48:22] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[13:48:22] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[13:48:22] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[13:48:22] [INFO] [LastChance] Found player: Player
+[13:48:22] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[13:48:22] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[13:48:22] [INFO] [LastChance] Connected to player Died signal (C#)
+[13:48:22] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[13:48:23] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:48:23] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[13:48:23] [INFO] [Player.Grenade] G pressed - starting grab animation
+[13:48:23] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[13:48:23] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (299.38193, 1104.1866)
+[13:48:23] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[13:48:23] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[13:48:23] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[13:48:23] [INFO] [DroneGrenade] Ready
+[13:48:23] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[13:48:23] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[13:48:23] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[13:48:23] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[13:48:23] [INFO] [Player.Grenade] Timer started, grenade created at (150, 1000)
+[13:48:23] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[13:48:23] [INFO] [Player.Grenade] Step 1 complete! Drag: (105.10199, 24.1344)
+[13:48:23] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[13:48:23] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[13:48:23] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:23] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:23] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:23] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:23] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:23] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[13:48:23] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:23] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:23] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[13:48:23] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[13:48:24] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:24] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[13:48:24] [INFO] [Player.Grenade.Simple] Throwing! Target: (333.21225, 1093.958), Distance: 145,9, Speed: 295,9, Friction: 300,0
+[13:48:24] [INFO] [Player.Grenade] Player rotated for throw: 0 -> 0,47386432
+[13:48:24] [INFO] [Player.Grenade] Drone aim point set to (333.21225, 1093.958)
+[13:48:24] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[13:48:24] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.8898115, 0.45632818), speed=295,9, spawn=(203.38869, 1027.3796)
+[13:48:24] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.889812, 0.456328), Speed: 295.9 (clamped from 295.9, max: 850.0)
+[13:48:24] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[13:48:24] [INFO] [DroneGrenade] THROWING phase started toward (333.2122, 1093.958)
+[13:48:24] [INFO] [DroneGrenade] Drone launched at (203.3887, 1027.38)
+[13:48:24] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[13:48:24] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[13:48:24] [INFO] [Player.Grenade] State reset to IDLE
+[13:48:24] [INFO] [Player.Grenade] State reset to IDLE
+[13:48:24] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[13:48:24] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-54.4°, player=(150,1000), corner_timer=-0.02
+[13:48:24] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:24] [INFO] [Player.Grenade] Player rotation restored to 0
+[13:48:24] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(150,1000), corner_timer=0.30
+[13:48:24] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[13:48:24] [INFO] [DroneGrenade] Camera attached to drone
+[13:48:24] [INFO] [DroneGrenade] Player control disabled
+[13:48:24] [INFO] [DroneGrenade] PILOTING phase started at (307.4966, 1080.77)
+[13:48:24] [INFO] [GrenadeTimer] Flashbang grenade landed at (307.49664, 1080.7701)
+[13:48:24] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(307.4966, 1080.77), source=NEUTRAL (DroneGrenade), range=112, listeners=5
+[13:48:24] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0
+[13:48:24] [INFO] [GrenadeTimer] Emitted grenade landing sound at (307.49664, 1080.7701)
+[13:48:24] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[13:48:24] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[13:48:24] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[13:48:24] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[13:48:25] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[13:48:25] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[13:48:26] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[13:48:26] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-85.8°, player=(150,1000), corner_timer=-0.02
+[13:48:26] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:26] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-85.6°, player=(150,1000), corner_timer=0.30
+[13:48:26] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-82.0°, player=(150,1000), corner_timer=-0.02
+[13:48:26] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:26] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-81.8°, player=(150,1000), corner_timer=0.30
+[13:48:27] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-78.2°, player=(150,1000), corner_timer=-0.02
+[13:48:27] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:27] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-78.0°, player=(150,1000), corner_timer=0.30
+[13:48:27] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=5
+[13:48:27] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-89.3°, player=(150,1000), corner_timer=-0.02
+[13:48:28] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[13:48:28] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-172.4°, player=(150,1000), corner_timer=0.30
+[13:48:28] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=5
+[13:48:29] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=5
+[13:48:29] [INFO] ------------------------------------------------------------
+[13:48:29] [INFO] GAME LOG ENDED: 2026-04-20T13:48:29
+[13:48:29] [INFO] ============================================================

--- a/docs/case-studies/issue-1911/logs/game_log_20260420_143657.txt
+++ b/docs/case-studies/issue-1911/logs/game_log_20260420_143657.txt
@@ -1,0 +1,1069 @@
+[14:36:57] [INFO] ============================================================
+[14:36:57] [INFO] GAME LOG STARTED
+[14:36:57] [INFO] ============================================================
+[14:36:57] [INFO] Timestamp: 2026-04-20T14:36:57
+[14:36:57] [INFO] Log file: I:/Загрузки/godot exe/дрон/game_log_20260420_143657.txt
+[14:36:57] [INFO] Executable: I:/Загрузки/godot exe/дрон/Godot-Top-Down-Template.exe
+[14:36:57] [INFO] OS: Windows
+[14:36:57] [INFO] Debug build: false
+[14:36:57] [INFO] Engine version: 4.3-stable (official)
+[14:36:57] [INFO] Project: Godot Top-Down Template
+[14:36:57] [INFO] Build info: not available (build_info.cfg not found)
+[14:36:57] [INFO] ------------------------------------------------------------
+[14:36:57] [INFO] [GameManager] GameManager ready
+[14:36:57] [INFO] [ScoreManager] ScoreManager ready
+[14:36:57] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[14:36:57] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[14:36:57] [INFO] [DifficultyManager] Loaded difficulty: Power Fantasy (value: 3)
+[14:36:57] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal
+[14:36:57] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[14:36:57] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[14:36:57] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[14:36:57] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[14:36:57] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[14:36:57] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[14:36:57] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[14:36:57] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[14:36:57] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[14:36:57] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[14:36:57] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[14:36:57] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[14:36:57] [INFO] [LastChance] Resetting all effects (scene change detected)
+[14:36:57] [INFO] [LastChance] Last chance shader loaded successfully
+[14:36:57] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[14:36:57] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[14:36:57] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[14:36:57] [INFO] [LastChance]   Sepia intensity: 0.70
+[14:36:57] [INFO] [LastChance]   Brightness: 0.60
+[14:36:57] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[14:36:57] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[14:36:57] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[14:36:57] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[14:36:58] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DroneGrenade.tscn
+[14:36:58] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: false, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: false, FPS drop logging: true, All weapons unlocked: true, All maps unlocked: true, Global stuck max time: 20.0s, Nav mesh visible: false, Search path visible: false, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false, Enemy path visible: false, Cover raycast visible: false, Tactical group: false, Cover infinite rays: true, Cover sector rays: true, Roguelike unlocked: false
+[14:36:58] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[14:36:58] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.50, music: 1.00
+[14:36:58] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true, revolver_aim_assist: true, unlock_notifications: true, combo_font_size: 140
+[14:36:58] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[14:36:58] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[14:36:58] [INFO] [CinemaEffects] Created effects layer at layer 99
+[14:36:58] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[14:36:58] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[14:36:58] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[14:36:58] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[14:36:58] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[14:36:58] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[14:36:58] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[14:36:58] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[14:36:58] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[14:36:58] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[14:36:58] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[14:36:58] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[14:36:58] [INFO] [GrenadeTimerHelper] Autoload ready
+[14:36:58] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[14:36:58] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[14:36:58] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[14:36:58] [INFO] [PowerFantasy]   Kill effect duration: 600ms
+[14:36:58] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[14:36:58] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[14:36:58] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[14:36:58] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[14:36:58] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[14:36:58] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[14:36:58] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[14:36:58] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[14:36:58] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[14:36:58] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[14:36:58] [INFO] [ProgressManager] ProgressManager ready, loaded 7 entries
+[14:36:58] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[14:36:58] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[14:36:58] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[14:36:58] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[14:36:58] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[14:36:58] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[14:36:58] [INFO] [SceneLoader] SceneLoader initialized
+[14:36:58] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[14:36:58] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[14:36:58] [INFO] [PersistManager] Restored unlocked weapon: mini_uzi
+[14:36:58] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[14:36:58] [INFO] [PersistManager] Restored kills_without_laser_sight: 75
+[14:36:58] [INFO] [PersistManager] Restored shots_fired_special_weapons: 0
+[14:36:58] [INFO] [PersistManager] Restored total_deaths: 5
+[14:36:58] [INFO] [PersistManager] Restored no_damage_levels_completed: 4
+[14:36:58] [INFO] [PersistManager] Restored levels_completed_rank_a_or_higher: 6
+[14:36:58] [INFO] [PersistManager] Restored kills_through_wall: 1
+[14:36:58] [INFO] [PersistManager] Restored levels_completed_with_silenced_pistol: 0
+[14:36:58] [INFO] [GameManager] Weapon selected: ak_gl
+[14:36:58] [INFO] [PersistManager] Restored selected weapon: ak_gl
+[14:36:58] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[14:36:58] [INFO] [PersistManager] Restored unlocked grenade type: 1
+[14:36:58] [INFO] [PersistManager] Restored unlocked grenade type: 4
+[14:36:58] [INFO] [GrenadeManager] Grenade type changed from Flashbang to Drone
+[14:36:58] [INFO] [PersistManager] Restored selected grenade type: 4
+[14:36:58] [INFO] [PersistManager] Restored unlocked active item type: 0
+[14:36:58] [INFO] [PersistManager] Restored unlocked active item type: 1
+[14:36:58] [INFO] [PersistManager] Restored unlocked active item type: 4
+[14:36:58] [INFO] [PersistManager] Restored unlocked active item type: 11
+[14:36:58] [INFO] [PersistManager] Restored unlocked active item type: 12
+[14:36:58] [INFO] [PersistManager] Restored unlocked active item type: 16
+[14:36:58] [INFO] [PersistManager] Restored unlocked active item type: 17
+[14:36:58] [INFO] [ActiveItemManager] Active item changed from None to BFF Pendant
+[14:36:58] [INFO] [PersistManager] Restored selected active item type: 4
+[14:36:58] [INFO] [PersistManager] Loudspeaker progress restored: level 1, levels_completed=0
+[14:36:58] [INFO] [PersistManager] State loaded successfully
+[14:36:58] [INFO] [PersistManager] PersistManager ready
+[14:36:58] [INFO] [UnlockManager] UnlockManager ready
+[14:36:58] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["makarov_pm", "silenced_pistol", "ak_gl", "sniper", "revolver", "shotgun"]
+[14:36:58] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, warm_lights: true, ai: true
+[14:36:58] [INFO] [LocalizationSettings] Loaded 2 translation(s)
+[14:36:58] [INFO] [LocalizationSettings] LocalizationSettings initialized — locale: en
+[14:36:58] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_condition
+[14:36:58] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_kill_condition
+[14:36:58] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:58] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[14:36:58] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[14:36:58] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[14:36:58] [ENEMY] [Enemy1] Death animation component initialized
+[14:36:58] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:58] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[14:36:58] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[14:36:58] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[14:36:58] [ENEMY] [Enemy2] Death animation component initialized
+[14:36:58] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:58] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[14:36:58] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[14:36:58] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[14:36:58] [ENEMY] [Enemy3] Death animation component initialized
+[14:36:58] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:58] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[14:36:58] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[14:36:58] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[14:36:58] [ENEMY] [Enemy4] Death animation component initialized
+[14:36:58] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:58] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[14:36:58] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[14:36:58] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[14:36:58] [ENEMY] [Enemy5] Death animation component initialized
+[14:36:58] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:36:58] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[14:36:58] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[14:36:58] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[14:36:58] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[14:36:58] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[14:36:58] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[14:36:58] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[14:36:58] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[14:36:58] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[14:36:58] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[14:36:58] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[14:36:58] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[14:36:58] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[14:36:58] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[14:36:58] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[14:36:58] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[14:36:58] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[14:36:58] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[14:36:58] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[14:36:58] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[14:36:58] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[14:36:58] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[14:36:58] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[14:36:58] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[14:36:58] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[14:36:58] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[14:36:58] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[14:36:58] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[14:36:58] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[14:36:58] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[14:36:58] [INFO] [Player.ItemVisual] Visual applied for item type: 4
+[14:36:58] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[14:36:58] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[14:36:58] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[14:36:58] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[14:36:58] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[14:36:58] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[14:36:58] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[14:36:58] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[14:36:58] [INFO] [Player.Jammer] JammerHUD initialized
+[14:36:58] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[14:36:58] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 1/3, Health: 10/10
+[14:36:58] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[14:36:58] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[14:36:58] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[14:36:58] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[14:36:58] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[14:36:58] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[14:36:58] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[14:36:58] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[14:36:58] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[14:36:58] [INFO] [LabyrinthLevel] Setting up weapon: ak_gl
+[14:36:58] [INFO] [LabyrinthLevel] AKGL already equipped by C# Player - applying labyrinth ammo config
+[14:36:58] [INFO] [LabyrinthLevel] HUD ammo refreshed (labyrinth ammo config): AKGL 30/150
+[14:36:58] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for ak_gl
+[14:36:58] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): AKGL 30/150
+[14:36:58] [INFO] [GameManager] set_player() called with: <CharacterBody2D#86922757902> (class: CharacterBody2D)
+[14:36:58] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[14:36:58] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[14:36:58] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[14:36:58] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[14:36:58] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[14:36:58] [INFO] [ScoreManager] Level started with 5 enemies
+[14:36:58] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[14:36:58] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[14:36:58] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[14:36:58] [INFO] [ReplayManager] Replay data cleared
+[14:36:58] [INFO] [LabyrinthLevel] Previous replay data cleared
+[14:36:58] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[14:36:58] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[14:36:58] [INFO] [ReplayManager] Level: LabyrinthLevel
+[14:36:58] [INFO] [ReplayManager] Player: Player (valid: True)
+[14:36:58] [INFO] [ReplayManager] Enemies count: 5
+[14:36:58] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[14:36:58] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[14:36:58] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[14:36:58] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[14:36:58] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[14:36:58] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[14:36:58] [INFO] [LabyrinthLevel] Replay recording started successfully
+[14:36:58] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[14:36:58] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[14:36:58] [INFO] [CinemaEffects] Found player node: Player
+[14:36:58] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[14:36:58] [INFO] [PersistManager] Already at last played level: res://scenes/levels/LabyrinthLevel.tscn
+[14:36:58] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[14:36:58] [INFO] [UnlockManager] Restored saved unlock for weapon: mini_uzi
+[14:36:58] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[14:36:58] [INFO] [UnlockManager] Skipped restore for weapon 'ak_gl' (condition not met — treating as corrupt save)
+[14:36:58] [INFO] [UnlockManager] Restored saved unlock for grenade type: 1
+[14:36:58] [INFO] [UnlockManager] Restored saved unlock for grenade type: 4
+[14:36:58] [INFO] [UnlockManager] Restored saved unlock for active item type: 1
+[14:36:58] [INFO] [UnlockManager] Restored saved unlock for active item type: 16
+[14:36:58] [INFO] [UnlockManager] Restored saved unlock for active item type: 12
+[14:36:58] [INFO] [UnlockManager] Restored saved unlock for active item type: 4
+[14:36:58] [INFO] [UnlockManager] Restored saved unlock for active item type: 17
+[14:36:58] [INFO] [PersistManager] State saved to user://game_state.cfg
+[14:36:58] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/LabyrinthLevel.tscn
+[14:36:58] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[14:36:58] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[14:36:58] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[14:36:58] [ENEMY] [Enemy1] Registered as sound listener
+[14:36:58] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 2, behavior: GUARD
+[14:36:58] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[14:36:58] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[14:36:58] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[14:36:58] [ENEMY] [Enemy2] Registered as sound listener
+[14:36:58] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[14:36:58] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[14:36:58] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[14:36:58] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[14:36:58] [ENEMY] [Enemy3] Registered as sound listener
+[14:36:58] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 2, behavior: PATROL
+[14:36:58] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[14:36:58] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[14:36:58] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[14:36:58] [ENEMY] [Enemy4] Registered as sound listener
+[14:36:58] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 2, behavior: GUARD
+[14:36:58] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[14:36:58] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[14:36:58] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[14:36:58] [ENEMY] [Enemy5] Registered as sound listener
+[14:36:58] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 3, behavior: GUARD
+[14:36:58] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[14:36:58] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[14:36:59] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[14:36:59] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[14:36:59] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=315.0°, current=0.0°, player=(150,1000), corner_timer=0.00
+[14:36:59] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(150,1000), corner_timer=0.00
+[14:36:59] [INFO] [Player] Detecting weapon pose (frame 3)...
+[14:36:59] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[14:36:59] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[14:36:59] [INFO] [PenultimateHit] Shader warmup complete in 1237 ms
+[14:36:59] [INFO] [LastChance] Shader warmup complete in 1235 ms
+[14:36:59] [INFO] [CinemaEffects] Cinema shader warmup complete in 1114 ms
+[14:36:59] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1105 ms
+[14:36:59] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[14:36:59] [INFO] [FlashbangPlayer] Shader warmup complete in 1102 ms
+[14:36:59] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[14:36:59] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 1656 ms
+[14:37:00] [WARN] [FPS] Drop detected: 1 fps (threshold: 30)
+[14:37:00] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[14:37:00] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:00] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[14:37:00] [INFO] [Player.Grenade] G pressed - starting grab animation
+[14:37:00] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:00] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (584.00275, 820.5779)
+[14:37:00] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[14:37:00] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[14:37:00] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[14:37:00] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[14:37:00] [INFO] [DroneGrenade] Ready
+[14:37:00] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[14:37:00] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[14:37:00] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[14:37:00] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[14:37:00] [INFO] [Player.Grenade] Timer started, grenade created at (150, 1000)
+[14:37:00] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[14:37:00] [INFO] [Player.Grenade] Step 1 complete! Drag: (64.40222, -25.78418)
+[14:37:00] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[14:37:00] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[14:37:00] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[14:37:00] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:00] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:00] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:00] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:00] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:00] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:00] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:00] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:01] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:01] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:01] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:01] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:01] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:01] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:01] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:01] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-54.4°, player=(150,1000), corner_timer=-0.02
+[14:37:01] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[14:37:01] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[14:37:01] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(150,1000), corner_timer=0.30
+[14:37:01] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[14:37:01] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[14:37:01] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[14:37:01] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[14:37:01] [INFO] [Player.Grenade.Simple] Throwing! Target: (354.63846, 546.9243), Distance: 437,1, Speed: 512,1, Friction: 300,0
+[14:37:01] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -1,1465585
+[14:37:01] [INFO] [Player.Grenade] Drone aim point set to (354.63846, 546.9243)
+[14:37:01] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[14:37:01] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.41162622, -0.91135275), speed=512,1, spawn=(174.69757, 945.31885)
+[14:37:01] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.411626, -0.911353), Speed: 512.1 (clamped from 512.1, max: 850.0)
+[14:37:01] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[14:37:01] [INFO] [DroneGrenade] THROWING phase started toward (354.6385, 546.9243)
+[14:37:01] [INFO] [DroneGrenade] Drone launched at (174.6976, 945.3188)
+[14:37:01] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[14:37:01] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[14:37:01] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:01] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:01] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[14:37:02] [INFO] [Player.Grenade] Player rotation restored to 0
+[14:37:02] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[14:37:02] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[14:37:02] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[14:37:02] [INFO] [DroneGrenade] Camera attached to drone
+[14:37:02] [INFO] [DroneGrenade] Player control disabled
+[14:37:02] [INFO] [DroneGrenade] PILOTING phase started at (343.9788, 570.525)
+[14:37:02] [INFO] [GrenadeTimer] Flashbang grenade landed at (343.9788, 570.525)
+[14:37:02] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(343.9788, 570.525), source=NEUTRAL (DroneGrenade), range=112, listeners=5
+[14:37:02] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=5, self=0
+[14:37:02] [INFO] [GrenadeTimer] Emitted grenade landing sound at (343.9788, 570.525)
+[14:37:03] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[14:37:03] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-85.8°, player=(150,1000), corner_timer=-0.02
+[14:37:03] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[14:37:03] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-85.6°, player=(150,1000), corner_timer=0.30
+[14:37:03] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[14:37:03] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-82.0°, player=(150,1000), corner_timer=-0.02
+[14:37:03] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[14:37:03] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-81.8°, player=(150,1000), corner_timer=0.30
+[14:37:03] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=-179.3°, current=-78.2°, player=(150,1000), corner_timer=-0.02
+[14:37:03] [ENEMY] [Enemy3] PATROL corner check: angle -89.3°
+[14:37:04] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-89.3°, current=-78.0°, player=(150,1000), corner_timer=0.30
+[14:37:04] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=5
+[14:37:05] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[14:37:05] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[14:37:05] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[14:37:05] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[14:37:05] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[14:37:05] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:05] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[14:37:05] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[14:37:05] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:05] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[14:37:05] [INFO] [LastChance] Resetting all effects (scene change detected)
+[14:37:05] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[14:37:05] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[14:37:05] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[14:37:05] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[14:37:05] [INFO] [PersistManager] State saved to user://game_state.cfg
+[14:37:05] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[14:37:05] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:05] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[14:37:05] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[14:37:05] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[14:37:05] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[14:37:05] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[14:37:05] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[14:37:05] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[14:37:05] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[14:37:05] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[14:37:05] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[14:37:05] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[14:37:05] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[14:37:05] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[14:37:05] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[14:37:05] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[14:37:05] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[14:37:05] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[14:37:05] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[14:37:05] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[14:37:05] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[14:37:05] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[14:37:05] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[14:37:05] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[14:37:05] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[14:37:05] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[14:37:05] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[14:37:05] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[14:37:05] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[14:37:05] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[14:37:05] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[14:37:05] [INFO] [Player.ItemVisual] Visual applied for item type: 4
+[14:37:05] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[14:37:05] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[14:37:05] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[14:37:05] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[14:37:05] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[14:37:05] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[14:37:05] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[14:37:05] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[14:37:05] [INFO] [Player.Jammer] JammerHUD initialized
+[14:37:05] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[14:37:05] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 10/10
+[14:37:05] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[14:37:05] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[14:37:05] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[14:37:05] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[14:37:05] [INFO] [GameManager] set_player() called with: <CharacterBody2D#163057765653> (class: CharacterBody2D)
+[14:37:05] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[14:37:05] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[14:37:05] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[14:37:05] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[14:37:05] [INFO] [CinemaEffects] Found player node: Player
+[14:37:05] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[14:37:05] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[14:37:05] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[14:37:05] [INFO] [Player] Detecting weapon pose (frame 3)...
+[14:37:05] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[14:37:05] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[14:37:05] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[14:37:05] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[14:37:05] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[14:37:05] [INFO] [LastChance] Found player: Player
+[14:37:05] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[14:37:05] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[14:37:05] [INFO] [LastChance] Connected to player Died signal (C#)
+[14:37:05] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[14:37:05] [INFO] [ReplayManager] Recording frame 360 (6,2s): player_valid=False, enemies=5
+[14:37:05] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:05] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[14:37:05] [INFO] [Player.Grenade] G pressed - starting grab animation
+[14:37:05] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[14:37:05] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[14:37:05] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[14:37:05] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:05] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (586.9785, 439.91013)
+[14:37:05] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[14:37:05] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[14:37:05] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[14:37:05] [INFO] [DroneGrenade] Ready
+[14:37:05] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[14:37:05] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[14:37:05] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[14:37:05] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[14:37:05] [INFO] [Player.Grenade] Timer started, grenade created at (150, 360)
+[14:37:05] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[14:37:05] [INFO] [Player.Grenade] Step 1 complete! Drag: (242.34387, 45.066284)
+[14:37:05] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[14:37:05] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[14:37:05] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:05] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:05] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:05] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:05] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:05] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:06] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:06] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:06] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:06] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:06] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[14:37:06] [INFO] [ReplayManager] Recording frame 420 (7,2s): player_valid=False, enemies=5
+[14:37:06] [INFO] [Player.Grenade.Simple] Throwing! Target: (830.8714, 261.69257), Distance: 627,9, Speed: 613,8, Friction: 300,0
+[14:37:06] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,14339377
+[14:37:06] [INFO] [Player.Grenade] Drone aim point set to (830.8714, 261.69257)
+[14:37:06] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[14:37:06] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.98973674, -0.14290287), speed=613,8, spawn=(209.3842, 351.42584)
+[14:37:06] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.989737, -0.142903), Speed: 613.8 (clamped from 613.8, max: 850.0)
+[14:37:06] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[14:37:06] [INFO] [DroneGrenade] THROWING phase started toward (830.8714, 261.6926)
+[14:37:06] [INFO] [DroneGrenade] Drone launched at (209.3842, 351.4258)
+[14:37:06] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[14:37:06] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[14:37:06] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[14:37:06] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[14:37:06] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:06] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:06] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[14:37:06] [INFO] [Player.Grenade] Player rotation restored to 0
+[14:37:07] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[14:37:07] [INFO] [ReplayManager] Recording frame 480 (8,2s): player_valid=False, enemies=5
+[14:37:07] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[14:37:07] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[14:37:07] [INFO] [DroneGrenade] Camera attached to drone
+[14:37:07] [INFO] [DroneGrenade] Player control disabled
+[14:37:07] [INFO] [DroneGrenade] PILOTING phase started at (803.144, 265.696)
+[14:37:07] [INFO] [GrenadeTimer] Flashbang grenade landed at (803.144, 265.69604)
+[14:37:07] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(803.144, 265.696), source=NEUTRAL (DroneGrenade), range=112, listeners=0
+[14:37:07] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[14:37:07] [INFO] [GrenadeTimer] Emitted grenade landing sound at (803.144, 265.69604)
+[14:37:08] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[14:37:08] [INFO] [ReplayManager] Recording frame 540 (9,2s): player_valid=False, enemies=5
+[14:37:09] [INFO] [ReplayManager] Recording frame 600 (10,2s): player_valid=False, enemies=5
+[14:37:10] [INFO] [ReplayManager] Recording frame 660 (11,2s): player_valid=False, enemies=5
+[14:37:11] [INFO] [ReplayManager] Recording frame 720 (12,1s): player_valid=False, enemies=5
+[14:37:12] [INFO] [GameManager] restart_scene() — starting scene reload
+[14:37:12] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:12] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[14:37:12] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[14:37:12] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:12] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[14:37:12] [INFO] [LastChance] Resetting all effects (scene change detected)
+[14:37:12] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[14:37:12] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[14:37:12] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[14:37:12] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[14:37:12] [INFO] [PersistManager] State saved to user://game_state.cfg
+[14:37:12] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[14:37:12] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:12] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[14:37:12] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[14:37:12] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[14:37:12] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[14:37:12] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[14:37:12] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[14:37:12] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[14:37:12] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[14:37:12] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[14:37:12] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[14:37:12] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[14:37:12] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[14:37:12] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[14:37:12] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[14:37:12] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[14:37:12] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[14:37:12] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[14:37:12] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[14:37:12] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[14:37:12] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[14:37:12] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[14:37:12] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[14:37:12] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[14:37:12] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[14:37:12] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[14:37:12] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[14:37:12] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[14:37:12] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[14:37:12] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[14:37:12] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[14:37:12] [INFO] [Player.ItemVisual] Visual applied for item type: 4
+[14:37:12] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[14:37:12] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[14:37:12] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[14:37:12] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[14:37:12] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[14:37:12] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[14:37:12] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[14:37:12] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[14:37:12] [INFO] [Player.Jammer] JammerHUD initialized
+[14:37:12] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[14:37:12] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 10/10
+[14:37:12] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[14:37:12] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[14:37:12] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[14:37:12] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[14:37:12] [INFO] [GameManager] set_player() called with: <CharacterBody2D#182754216601> (class: CharacterBody2D)
+[14:37:12] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[14:37:12] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[14:37:12] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[14:37:12] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[14:37:12] [INFO] [CinemaEffects] Found player node: Player
+[14:37:12] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[14:37:12] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[14:37:12] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[14:37:12] [INFO] [Player] Detecting weapon pose (frame 3)...
+[14:37:12] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[14:37:12] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[14:37:12] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[14:37:12] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[14:37:12] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[14:37:12] [INFO] [LastChance] Found player: Player
+[14:37:12] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[14:37:12] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[14:37:12] [INFO] [LastChance] Connected to player Died signal (C#)
+[14:37:12] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[14:37:12] [INFO] [ReplayManager] Recording frame 780 (13,1s): player_valid=False, enemies=5
+[14:37:12] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:12] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[14:37:12] [INFO] [Player.Grenade] G pressed - starting grab animation
+[14:37:12] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[14:37:12] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[14:37:12] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[14:37:12] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:12] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (672.5811, 256.96844)
+[14:37:12] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[14:37:12] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[14:37:12] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[14:37:12] [INFO] [DroneGrenade] Ready
+[14:37:12] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[14:37:12] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[14:37:12] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[14:37:12] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[14:37:12] [INFO] [Player.Grenade] Timer started, grenade created at (150, 360)
+[14:37:12] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[14:37:12] [INFO] [Player.Grenade] Step 1 complete! Drag: (46.85919, 9.670349)
+[14:37:13] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[14:37:13] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:13] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[14:37:13] [INFO] [ReplayManager] Recording frame 840 (14,1s): player_valid=False, enemies=5
+[14:37:14] [INFO] [Player.Grenade.Simple] Throwing! Target: (965.1723, 214.94171), Distance: 768,0, Speed: 678,8, Friction: 300,0
+[14:37:14] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,17610465
+[14:37:14] [INFO] [Player.Grenade] Drone aim point set to (965.1723, 214.94171)
+[14:37:14] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[14:37:14] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.98453367, -0.17519581), speed=678,8, spawn=(209.07202, 349.48825)
+[14:37:14] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.984534, -0.175196), Speed: 678.8 (clamped from 678.8, max: 850.0)
+[14:37:14] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[14:37:14] [INFO] [DroneGrenade] THROWING phase started toward (965.1723, 214.9417)
+[14:37:14] [INFO] [DroneGrenade] Drone launched at (209.072, 349.4883)
+[14:37:14] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[14:37:14] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[14:37:14] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[14:37:14] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[14:37:14] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:14] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:14] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[14:37:14] [INFO] [Player.Grenade] Player rotation restored to 0
+[14:37:14] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[14:37:14] [INFO] [ReplayManager] Recording frame 900 (15,1s): player_valid=False, enemies=5
+[14:37:14] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[14:37:15] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[14:37:15] [INFO] [DroneGrenade] Camera attached to drone
+[14:37:15] [INFO] [DroneGrenade] Player control disabled
+[14:37:15] [INFO] [DroneGrenade] PILOTING phase started at (945.011, 218.5294)
+[14:37:15] [INFO] [GrenadeTimer] Flashbang grenade landed at (945.011, 218.52939)
+[14:37:15] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(945.011, 218.5294), source=NEUTRAL (DroneGrenade), range=112, listeners=0
+[14:37:15] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[14:37:15] [INFO] [GrenadeTimer] Emitted grenade landing sound at (945.011, 218.52939)
+[14:37:15] [INFO] [ReplayManager] Recording frame 960 (16,1s): player_valid=False, enemies=5
+[14:37:15] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[14:37:16] [INFO] [ReplayManager] Recording frame 1020 (17,1s): player_valid=False, enemies=5
+[14:37:17] [INFO] [ReplayManager] Recording frame 1080 (18,1s): player_valid=False, enemies=5
+[14:37:17] [INFO] [GameManager] restart_scene() — starting scene reload
+[14:37:17] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:17] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[14:37:17] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[14:37:17] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:17] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[14:37:17] [INFO] [LastChance] Resetting all effects (scene change detected)
+[14:37:17] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[14:37:17] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[14:37:17] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[14:37:17] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[14:37:17] [INFO] [PersistManager] State saved to user://game_state.cfg
+[14:37:17] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[14:37:18] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:18] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[14:37:18] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[14:37:18] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[14:37:18] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[14:37:18] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[14:37:18] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[14:37:18] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[14:37:18] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[14:37:18] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[14:37:18] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[14:37:18] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[14:37:18] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[14:37:18] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[14:37:18] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[14:37:18] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[14:37:18] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[14:37:18] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[14:37:18] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[14:37:18] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[14:37:18] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[14:37:18] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[14:37:18] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[14:37:18] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[14:37:18] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[14:37:18] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[14:37:18] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[14:37:18] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[14:37:18] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[14:37:18] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[14:37:18] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[14:37:18] [INFO] [Player.ItemVisual] Visual applied for item type: 4
+[14:37:18] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[14:37:18] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[14:37:18] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[14:37:18] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[14:37:18] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[14:37:18] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[14:37:18] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[14:37:18] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[14:37:18] [INFO] [Player.Jammer] JammerHUD initialized
+[14:37:18] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[14:37:18] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 10/10
+[14:37:18] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[14:37:18] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[14:37:18] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[14:37:18] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[14:37:18] [INFO] [GameManager] set_player() called with: <CharacterBody2D#200655505609> (class: CharacterBody2D)
+[14:37:18] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[14:37:18] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[14:37:18] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[14:37:18] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[14:37:18] [INFO] [CinemaEffects] Found player node: Player
+[14:37:18] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[14:37:18] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[14:37:18] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[14:37:18] [INFO] [Player] Detecting weapon pose (frame 3)...
+[14:37:18] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[14:37:18] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[14:37:18] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[14:37:18] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[14:37:18] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[14:37:18] [INFO] [LastChance] Found player: Player
+[14:37:18] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[14:37:18] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[14:37:18] [INFO] [LastChance] Connected to player Died signal (C#)
+[14:37:18] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[14:37:18] [INFO] [ReplayManager] Recording frame 1140 (19,1s): player_valid=False, enemies=5
+[14:37:18] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:18] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[14:37:18] [INFO] [Player.Grenade] G pressed - starting grab animation
+[14:37:18] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[14:37:18] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[14:37:18] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[14:37:18] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:18] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (728.27106, 245.4876)
+[14:37:18] [INFO] [Player.Grenade] Step 1 failed: drag not far enough right (19,720398 < 30)
+[14:37:18] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:18] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (829.1293, 247.51584)
+[14:37:19] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[14:37:19] [INFO] [ReplayManager] Recording frame 1200 (20,1s): player_valid=False, enemies=5
+[14:37:19] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[14:37:20] [INFO] [GameManager] restart_scene() — starting scene reload
+[14:37:20] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:20] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[14:37:20] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[14:37:20] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:20] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[14:37:20] [INFO] [LastChance] Resetting all effects (scene change detected)
+[14:37:20] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[14:37:20] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[14:37:20] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[14:37:20] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[14:37:20] [INFO] [PersistManager] State saved to user://game_state.cfg
+[14:37:20] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[14:37:20] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:20] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[14:37:20] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[14:37:20] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[14:37:20] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[14:37:20] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[14:37:20] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[14:37:20] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[14:37:20] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[14:37:20] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[14:37:20] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[14:37:20] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[14:37:20] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[14:37:20] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[14:37:20] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[14:37:20] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[14:37:20] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[14:37:20] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[14:37:20] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[14:37:20] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[14:37:20] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[14:37:20] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[14:37:20] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[14:37:20] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[14:37:20] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[14:37:20] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[14:37:20] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[14:37:20] [INFO] [Player.ItemVisual] Visual applied for item type: 4
+[14:37:20] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[14:37:20] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[14:37:20] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[14:37:20] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[14:37:20] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[14:37:20] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[14:37:20] [INFO] [Player.Jammer] JammerHUD initialized
+[14:37:20] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[14:37:20] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 10/10
+[14:37:20] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[14:37:20] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[14:37:20] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[14:37:20] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[14:37:20] [INFO] [GameManager] set_player() called with: <CharacterBody2D#212902874445> (class: CharacterBody2D)
+[14:37:20] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[14:37:20] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[14:37:20] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[14:37:20] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[14:37:20] [INFO] [CinemaEffects] Found player node: Player
+[14:37:20] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[14:37:20] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[14:37:20] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[14:37:20] [INFO] [ReplayManager] Recording frame 1260 (21,1s): player_valid=False, enemies=5
+[14:37:20] [INFO] [Player] Detecting weapon pose (frame 3)...
+[14:37:20] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[14:37:20] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[14:37:20] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[14:37:20] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[14:37:20] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[14:37:20] [INFO] [LastChance] Found player: Player
+[14:37:20] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[14:37:20] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[14:37:20] [INFO] [LastChance] Connected to player Died signal (C#)
+[14:37:20] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[14:37:21] [INFO] [ReplayManager] Recording frame 1320 (22,1s): player_valid=False, enemies=5
+[14:37:21] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:21] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[14:37:21] [INFO] [Player.Grenade] G pressed - starting grab animation
+[14:37:21] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[14:37:21] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[14:37:21] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[14:37:21] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:21] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (762.6456, 260.9378)
+[14:37:21] [INFO] [Player.Grenade] Step 1 failed: drag not far enough right (2,9585571 < 30)
+[14:37:21] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:21] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (888.01324, 283.69745)
+[14:37:22] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[14:37:22] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:22] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[14:37:22] [INFO] [Player.Grenade] G pressed - starting grab animation
+[14:37:22] [INFO] [ReplayManager] Recording frame 1380 (23,1s): player_valid=False, enemies=5
+[14:37:22] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:22] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (624.4958, 268.37787)
+[14:37:22] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[14:37:22] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[14:37:22] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[14:37:22] [INFO] [DroneGrenade] Ready
+[14:37:22] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[14:37:22] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[14:37:22] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[14:37:22] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[14:37:22] [INFO] [Player.Grenade] Timer started, grenade created at (150, 360)
+[14:37:22] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[14:37:22] [INFO] [Player.Grenade] Step 1 complete! Drag: (178.37347, 2.0039062)
+[14:37:22] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[14:37:22] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:22] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:23] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[14:37:23] [INFO] [ReplayManager] Recording frame 1440 (24,1s): player_valid=False, enemies=5
+[14:37:23] [INFO] [Player.Grenade.Simple] Throwing! Target: (1159.6156, 151.49518), Distance: 970,9, Speed: 763,3, Friction: 300,0
+[14:37:23] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,20365591
+[14:37:23] [INFO] [Player.Grenade] Drone aim point set to (1159.6156, 151.49518)
+[14:37:23] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[14:37:23] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.9793337, -0.20225103), speed=763,3, spawn=(208.76003, 347.86493)
+[14:37:23] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.979334, -0.202251), Speed: 763.3 (clamped from 763.3, max: 850.0)
+[14:37:23] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[14:37:23] [INFO] [DroneGrenade] THROWING phase started toward (1159.616, 151.4952)
+[14:37:23] [INFO] [DroneGrenade] Drone launched at (208.76, 347.8649)
+[14:37:23] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[14:37:23] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[14:37:23] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[14:37:23] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[14:37:23] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:23] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:23] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[14:37:23] [INFO] [Player.Grenade] Player rotation restored to 0
+[14:37:24] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[14:37:24] [INFO] [ReplayManager] Recording frame 1500 (25,1s): player_valid=False, enemies=5
+[14:37:24] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[14:37:25] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[14:37:25] [INFO] [DroneGrenade] Camera attached to drone
+[14:37:25] [INFO] [DroneGrenade] Player control disabled
+[14:37:25] [INFO] [DroneGrenade] PILOTING phase started at (1135.618, 156.4514)
+[14:37:25] [INFO] [GrenadeTimer] Flashbang grenade landed at (1135.6179, 156.45143)
+[14:37:25] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(1135.618, 156.4514), source=NEUTRAL (DroneGrenade), range=112, listeners=0
+[14:37:25] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[14:37:25] [INFO] [GrenadeTimer] Emitted grenade landing sound at (1135.6179, 156.45143)
+[14:37:25] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[14:37:25] [INFO] [ReplayManager] Recording frame 1560 (26,1s): player_valid=False, enemies=5
+[14:37:26] [INFO] [ReplayManager] Recording frame 1620 (27,1s): player_valid=False, enemies=5
+[14:37:27] [INFO] [ReplayManager] Recording frame 1680 (28,1s): player_valid=False, enemies=5
+[14:37:28] [INFO] [GameManager] restart_scene() — starting scene reload
+[14:37:28] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:28] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[14:37:28] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[14:37:28] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[14:37:28] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[14:37:28] [INFO] [LastChance] Resetting all effects (scene change detected)
+[14:37:28] [INFO] [CinemaEffects] Scene changed to: Tutorial
+[14:37:28] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[14:37:28] [INFO] [BlackMetalEffectsManager] Scene changed to: Tutorial
+[14:37:28] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[14:37:28] [INFO] [PersistManager] State saved to user://game_state.cfg
+[14:37:28] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/csharp/TestTier.tscn
+[14:37:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[14:37:28] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[14:37:28] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[14:37:28] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[14:37:28] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: Drone
+[14:37:28] [INFO] [Player.Grenade] Tutorial level detected - infinite grenades enabled
+[14:37:28] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[14:37:28] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[14:37:28] [INFO] [Player.Weapon] Equipped AKGL (ammo: 30/30)
+[14:37:28] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[14:37:28] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[14:37:28] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[14:37:28] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[14:37:28] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[14:37:28] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[14:37:28] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[14:37:28] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[14:37:28] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[14:37:28] [INFO] [Player.BffPendant] BFF pendant is selected, ready to summon companion
+[14:37:28] [INFO] [Player.BffPendant] BFF pendant equipped — press Space to summon companion
+[14:37:28] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[14:37:28] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[14:37:28] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[14:37:28] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[14:37:28] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[14:37:28] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[14:37:28] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[14:37:28] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[14:37:28] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[14:37:28] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[14:37:28] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[14:37:28] [INFO] [Player.ItemVisual] Visual applied for item type: 4
+[14:37:28] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[14:37:28] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[14:37:28] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[14:37:28] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[14:37:28] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[14:37:28] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[14:37:28] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[14:37:28] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[14:37:28] [INFO] [Player.Jammer] JammerHUD initialized
+[14:37:28] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[14:37:28] [INFO] [Player] Ready! Ammo: 30/30, Grenades: 3/3, Health: 10/10
+[14:37:28] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[14:37:28] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[14:37:28] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[14:37:28] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[14:37:28] [INFO] [GameManager] set_player() called with: <CharacterBody2D#237162728677> (class: CharacterBody2D)
+[14:37:28] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[14:37:28] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[14:37:28] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[14:37:28] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[14:37:28] [INFO] [CinemaEffects] Found player node: Player
+[14:37:28] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[14:37:28] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[14:37:28] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[14:37:28] [INFO] [Player] Detecting weapon pose (frame 3)...
+[14:37:28] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[14:37:28] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[14:37:28] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[14:37:28] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[14:37:28] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[14:37:28] [INFO] [LastChance] Found player: Player
+[14:37:28] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[14:37:28] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[14:37:28] [INFO] [LastChance] Connected to player Died signal (C#)
+[14:37:28] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[14:37:28] [INFO] [ReplayManager] Recording frame 1740 (29,1s): player_valid=False, enemies=5
+[14:37:28] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:28] [INFO] [Player.Grenade.Anim] Phase changed to: GrabGrenade (duration: 0,20s)
+[14:37:28] [INFO] [Player.Grenade] G pressed - starting grab animation
+[14:37:28] [INFO] [WeaponHintsComponent] Hint added 'grenade': [color=#ff4444][hold G+RMB][/color] [color=#888888][flick mouse right][/color] [color=#888888][release RMB][/color] [color=#888888][hold RMB][/color] [color=#888888][release G][/color] [color=#888888][aim and release RMB][/color]
+[14:37:28] [INFO] [WeaponHintsComponent] Grenade hint shown after grenade_prepare
+[14:37:28] [INFO] [WeaponHintsComponent] Strikethrough setup 'grenade': 4 lines
+[14:37:28] [INFO] [Player.Grenade] Mode check: complex=False, settings_node=True
+[14:37:28] [INFO] [Player.Grenade] Step 1 started: G held, RMB pressed at (1025.7007, 165.81595)
+[14:37:28] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[14:37:28] [INFO] [GrenadeBase] Grenade created at (0, 0) (frozen)
+[14:37:28] [INFO] [DroneGrenade] Drone visual set up (quadcopter style)
+[14:37:28] [INFO] [DroneGrenade] Ready
+[14:37:28] [INFO] [GrenadeTimer] Initialized for Flashbang grenade, effect radius: 400
+[14:37:28] [INFO] [Player.Grenade] Added GrenadeTimer component (type: Flashbang)
+[14:37:28] [INFO] [DroneGrenade] Pin pulled — drone will launch on throw
+[14:37:28] [INFO] [GrenadeTimer] Timer activated! 9999 seconds until explosion
+[14:37:28] [INFO] [Player.Grenade] Timer started, grenade created at (150, 360)
+[14:37:28] [INFO] [Player.Grenade.Anim] Phase changed to: PullPin (duration: 0,15s)
+[14:37:28] [INFO] [Player.Grenade] Step 1 complete! Drag: (71.21289, -3.1124115)
+[14:37:28] [INFO] [Player.Grenade.Anim] Phase changed to: HandsApproach (duration: 0,20s)
+[14:37:28] [INFO] [Player.Grenade.Simple] RMB pressed after pin pull - waiting for valid G release handoff before trajectory aiming
+[14:37:28] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:28] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:28] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:28] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:29] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:29] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:29] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:29] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:29] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:29] [INFO] [Player.Grenade.Simple] G still held during right-hand aiming - waiting for release before aim/throw
+[14:37:29] [INFO] [Player.Grenade.Simple] G released while RMB held - valid handoff completed, trajectory aiming is now active
+[14:37:29] [INFO] [ReplayManager] Recording frame 1800 (30,1s): player_valid=False, enemies=5
+[14:37:29] [INFO] [Player.Grenade.Simple] Throwing! Target: (1343.8151, 161.49258), Distance: 1150,2, Speed: 830,7, Friction: 300,0
+[14:37:29] [INFO] [Player.Grenade] Player rotated for throw: 0 -> -0,16477232
+[14:37:29] [INFO] [Player.Grenade] Drone aim point set to (1343.8151, 161.49258)
+[14:37:29] [INFO] [GrenadeTimer] Grenade marked as thrown - impact detection enabled
+[14:37:29] [INFO] [Player.Grenade.Simple] C# set velocity directly: dir=(0.98645574, -0.16402774), speed=830,7, spawn=(209.18735, 350.15833)
+[14:37:29] [INFO] [GrenadeBase] Simple mode throw! Dir: (0.986456, -0.164028), Speed: 830.7 (clamped from 830.7, max: 850.0)
+[14:37:29] [INFO] [DroneGrenade] Player found: Player, Camera: Camera2D
+[14:37:29] [INFO] [DroneGrenade] THROWING phase started toward (1343.815, 161.4926)
+[14:37:29] [INFO] [DroneGrenade] Drone launched at (209.1873, 350.1583)
+[14:37:29] [INFO] [Player.Grenade.Anim] Phase changed to: Throw (duration: 0,20s)
+[14:37:29] [INFO] [WeaponHintsComponent] Dismissing hint 'grenade'
+[14:37:29] [INFO] [WeaponHintsComponent] Grenade thrown — grenade hint dismissed
+[14:37:29] [INFO] [Player.Grenade.Simple] Grenade thrown!
+[14:37:29] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:29] [INFO] [Player.Grenade] State reset to IDLE
+[14:37:29] [INFO] [Player.Grenade.Anim] Phase changed to: ReturnIdle (duration: 0,30s)
+[14:37:29] [INFO] [Player.Grenade] Player rotation restored to 0
+[14:37:30] [INFO] [Player.Grenade.Anim] Animation complete, returning to normal
+[14:37:30] [INFO] [WeaponHintsComponent] Hint 'grenade' dismissed
+[14:37:30] [INFO] [ReplayManager] Recording frame 1860 (31,1s): player_valid=False, enemies=5
+[14:37:31] [INFO] [DroneGrenade] Enemy targeting now active (delay elapsed)
+[14:37:31] [INFO] [ReplayManager] Recording frame 1920 (32,1s): player_valid=False, enemies=5
+[14:37:31] [INFO] [DroneGrenade] Throw target reached — switching to PILOTING
+[14:37:31] [INFO] [DroneGrenade] Camera attached to drone
+[14:37:31] [INFO] [DroneGrenade] Player control disabled
+[14:37:31] [INFO] [DroneGrenade] PILOTING phase started at (1317.473, 165.8733)
+[14:37:31] [INFO] [GrenadeTimer] Flashbang grenade landed at (1317.4728, 165.87329)
+[14:37:31] [INFO] [SoundPropagation] Sound emitted: type=GRENADE_LANDING, pos=(1317.473, 165.8733), source=NEUTRAL (DroneGrenade), range=112, listeners=0
+[14:37:31] [INFO] [SoundPropagation] Sound result: notified=0, out_of_range=0, self=0
+[14:37:31] [INFO] [GrenadeTimer] Emitted grenade landing sound at (1317.4728, 165.87329)
+[14:37:32] [INFO] [ReplayManager] Recording frame 1980 (33,1s): player_valid=False, enemies=5
+[14:37:33] [INFO] [ReplayManager] Recording frame 2040 (34,1s): player_valid=False, enemies=5
+[14:37:34] [INFO] ------------------------------------------------------------
+[14:37:34] [INFO] GAME LOG ENDED: 2026-04-20T14:37:34
+[14:37:34] [INFO] ============================================================

--- a/scripts/projectiles/drone_grenade.gd
+++ b/scripts/projectiles/drone_grenade.gd
@@ -218,13 +218,14 @@ func _find_player_and_camera() -> void:
 func _attach_camera_to_drone() -> void:
 	if _player_camera == null:
 		return
-	var cam_global_pos := _player_camera.global_position
 	var old_parent := _player_camera.get_parent()
 	if old_parent:
 		old_parent.remove_child(_player_camera)
 	add_child(_player_camera)
-	# Keep camera at its current world position so smoothing can interpolate toward drone.
-	_player_camera.global_position = cam_global_pos
+	# Zero local position so Camera2D centers on the drone.
+	# position_smoothing will animate the viewport from its current location
+	# toward the drone automatically — no manual position math required.
+	_player_camera.position = Vector2.ZERO
 	_player_camera.make_current()
 	FileLogger.info("[DroneGrenade] Camera attached to drone")
 
@@ -233,13 +234,13 @@ func _attach_camera_to_drone() -> void:
 func _detach_camera_from_drone() -> void:
 	if _player_camera == null or not is_instance_valid(_player_camera):
 		return
-	var cam_global_pos := _player_camera.global_position
 	if _player_camera.get_parent() == self:
 		remove_child(_player_camera)
 	if _player != null and is_instance_valid(_player):
 		_player.add_child(_player_camera)
-		# Keep camera at its current world position so smoothing can interpolate toward player.
-		_player_camera.global_position = cam_global_pos
+		# Zero local position so Camera2D centers on the player.
+		# position_smoothing animates the viewport back smoothly.
+		_player_camera.position = Vector2.ZERO
 		_player_camera.make_current()
 	FileLogger.info("[DroneGrenade] Camera returned to player")
 

--- a/scripts/projectiles/drone_grenade.gd
+++ b/scripts/projectiles/drone_grenade.gd
@@ -214,28 +214,32 @@ func _find_player_and_camera() -> void:
 	])
 
 
-## Reparent the player's camera to follow the drone.
+## Reparent the player's camera to follow the drone with a smooth transition.
 func _attach_camera_to_drone() -> void:
 	if _player_camera == null:
 		return
+	var cam_global_pos := _player_camera.global_position
 	var old_parent := _player_camera.get_parent()
 	if old_parent:
 		old_parent.remove_child(_player_camera)
 	add_child(_player_camera)
-	_player_camera.global_position = global_position
+	# Keep camera at its current world position so smoothing can interpolate toward drone.
+	_player_camera.global_position = cam_global_pos
 	_player_camera.make_current()
 	FileLogger.info("[DroneGrenade] Camera attached to drone")
 
 
-## Return the camera to the player.
+## Return the camera to the player with a smooth transition.
 func _detach_camera_from_drone() -> void:
 	if _player_camera == null or not is_instance_valid(_player_camera):
 		return
+	var cam_global_pos := _player_camera.global_position
 	if _player_camera.get_parent() == self:
 		remove_child(_player_camera)
 	if _player != null and is_instance_valid(_player):
 		_player.add_child(_player_camera)
-		_player_camera.global_position = _player.global_position
+		# Keep camera at its current world position so smoothing can interpolate toward player.
+		_player_camera.global_position = cam_global_pos
 		_player_camera.make_current()
 	FileLogger.info("[DroneGrenade] Camera returned to player")
 

--- a/scripts/projectiles/drone_grenade.gd
+++ b/scripts/projectiles/drone_grenade.gd
@@ -52,8 +52,16 @@ var _drone_launched: bool = false
 ## Whether the drone is alive (not yet exploded).
 var _drone_alive: bool = false
 
-## Reference to the Camera2D that follows the player (reparented to drone while active).
+## Reference to the Camera2D that follows the player.
+## Issue #1911: the camera is NOT reparented — reparenting a Camera2D in Godot 4
+## resets its internal position_smoothing state, producing a hard cut that the
+## user perceives as "the level restarting". Instead we keep the camera a child
+## of the player and, while the drone owns the view, write its LOCAL `position`
+## each physics frame so its `global_position` equals the drone's.
 var _player_camera: Camera2D = null
+
+## True while the drone is driving the camera's position (pilot/throw view).
+var _camera_owned_by_drone: bool = false
 
 ## Reference to the player node (to return control after explosion).
 var _player: Node2D = null
@@ -214,35 +222,47 @@ func _find_player_and_camera() -> void:
 	])
 
 
-## Reparent the player's camera to follow the drone with a smooth transition.
+## Start having the drone drive the player's Camera2D.
+## Issue #1911: do NOT reparent the Camera2D. Reparenting (or toggling `top_level`)
+## resets Camera2D's internal position_smoothing state in Godot 4, producing a hard
+## cut the user perceives as a level reset. Instead we leave the camera a child of
+## the player and, each physics frame, set its LOCAL `position` so that
+## `global_position = player.global_position + camera.position = drone.global_position`.
+## The hierarchy and top_level flag never change, so position_smoothing runs
+## uninterrupted and smoothly pans the viewport from player area to drone area.
 func _attach_camera_to_drone() -> void:
 	if _player_camera == null:
 		return
-	var old_parent := _player_camera.get_parent()
-	if old_parent:
-		old_parent.remove_child(_player_camera)
-	add_child(_player_camera)
-	# Zero local position so Camera2D centers on the drone.
-	# position_smoothing will animate the viewport from its current location
-	# toward the drone automatically — no manual position math required.
-	_player_camera.position = Vector2.ZERO
+	_camera_owned_by_drone = true
 	_player_camera.make_current()
+	_sync_camera_to_drone()
 	FileLogger.info("[DroneGrenade] Camera attached to drone")
 
 
-## Return the camera to the player with a smooth transition.
+## Return the camera to the player (Issue #1911).
+## Zeroing the camera's local position re-centers it on the player without touching
+## the node hierarchy. position_smoothing then pans the viewport back smoothly
+## from the drone's last location to the player.
 func _detach_camera_from_drone() -> void:
 	if _player_camera == null or not is_instance_valid(_player_camera):
 		return
-	if _player_camera.get_parent() == self:
-		remove_child(_player_camera)
+	_camera_owned_by_drone = false
 	if _player != null and is_instance_valid(_player):
-		_player.add_child(_player_camera)
-		# Zero local position so Camera2D centers on the player.
-		# position_smoothing animates the viewport back smoothly.
 		_player_camera.position = Vector2.ZERO
 		_player_camera.make_current()
 	FileLogger.info("[DroneGrenade] Camera returned to player")
+
+
+## Write the camera's local offset so its global_position equals the drone's.
+## Called each physics frame while the drone owns the view (Issue #1911).
+func _sync_camera_to_drone() -> void:
+	if not _camera_owned_by_drone:
+		return
+	if _player_camera == null or not is_instance_valid(_player_camera):
+		return
+	if _player == null or not is_instance_valid(_player):
+		return
+	_player_camera.position = global_position - _player.global_position
 
 
 ## Disable player movement + shooting while drone is active.
@@ -282,6 +302,11 @@ func _physics_process(delta: float) -> void:
 
 	if not _drone_launched or not _drone_alive:
 		return
+
+	# Issue #1911: keep the camera's global_position centered on the drone
+	# while the drone owns the view. This drives position_smoothing's target
+	# without ever reparenting the camera, so smoothing state is preserved.
+	_sync_camera_to_drone()
 
 	# Issue #1667: tick down enemy-targeting delay.
 	if not _enemy_targeting_active:

--- a/tests/unit/test_drone_grenade.gd
+++ b/tests/unit/test_drone_grenade.gd
@@ -503,3 +503,96 @@ func test_csharp_drone_aim_helper_calls_snake_case_gdscript_method() -> void:
 		"C# interop must look for DroneGrenade's snake_case GDScript method")
 	assert_true(method.contains("_activeGrenade.Call(\"set_aim_point\", aimPoint)"),
 		"C# interop must call DroneGrenade.set_aim_point with the world-space aim point")
+
+
+# ============================================================================
+# Camera reparent regression tests (Issue #1911)
+# ============================================================================
+#
+# Reparenting a Camera2D resets its internal position_smoothing state in Godot
+# 4, producing a hard cut the user perceives as "the level restarting". The
+# source of DroneGrenade must therefore NOT call add_child/remove_child on the
+# player's Camera2D when switching control — it must drive the camera via its
+# local `position` while the drone owns the view.
+
+
+func _read_drone_grenade_source() -> String:
+	var file := FileAccess.open("res://scripts/projectiles/drone_grenade.gd", FileAccess.READ)
+	assert_not_null(file, "drone_grenade.gd must be readable for camera regression tests")
+	if file == null:
+		return ""
+	return file.get_as_text()
+
+
+func _extract_gd_function(source: String, signature: String) -> String:
+	## Extract a GDScript function body by scanning for a matching header and
+	## capturing all indented lines that follow.
+	var start := source.find(signature)
+	assert_gt(start, -1, "Expected function signature to exist: %s" % signature)
+	if start == -1:
+		return ""
+	var header_end := source.find("\n", start)
+	if header_end == -1:
+		return source.substr(start)
+	var body := ""
+	var i := header_end + 1
+	while i < source.length():
+		var line_end := source.find("\n", i)
+		if line_end == -1:
+			line_end = source.length()
+		var line := source.substr(i, line_end - i)
+		if line.strip_edges() == "":
+			body += line + "\n"
+			i = line_end + 1
+			continue
+		if line.begins_with("\t") or line.begins_with(" "):
+			body += line + "\n"
+			i = line_end + 1
+		else:
+			break
+	return body
+
+
+func test_attach_camera_does_not_reparent_issue_1911() -> void:
+	var source := _read_drone_grenade_source()
+	var body := _extract_gd_function(source, "func _attach_camera_to_drone()")
+	assert_false(body.contains("add_child(_player_camera)"),
+		"Issue #1911: _attach_camera_to_drone must NOT add_child the camera — " +
+		"reparenting resets Camera2D position_smoothing (visible as a hard cut)")
+	assert_false(body.contains("remove_child(_player_camera)"),
+		"Issue #1911: _attach_camera_to_drone must NOT remove_child the camera")
+
+
+func test_detach_camera_does_not_reparent_issue_1911() -> void:
+	var source := _read_drone_grenade_source()
+	var body := _extract_gd_function(source, "func _detach_camera_from_drone()")
+	assert_false(body.contains("remove_child(_player_camera)"),
+		"Issue #1911: _detach_camera_from_drone must NOT remove_child the camera")
+	assert_false(body.contains("add_child(_player_camera)"),
+		"Issue #1911: _detach_camera_from_drone must NOT add the camera back to any parent — " +
+		"the camera is never reparented in the first place")
+
+
+func test_detach_camera_zeroes_local_position_issue_1911() -> void:
+	var source := _read_drone_grenade_source()
+	var body := _extract_gd_function(source, "func _detach_camera_from_drone()")
+	assert_true(body.contains("_player_camera.position = Vector2.ZERO"),
+		"Issue #1911: _detach_camera_from_drone must reset the camera's LOCAL position to zero " +
+		"so it re-centers on the player; position_smoothing then pans the viewport back")
+
+
+func test_sync_camera_uses_local_position_not_reparent_issue_1911() -> void:
+	var source := _read_drone_grenade_source()
+	var body := _extract_gd_function(source, "func _sync_camera_to_drone()")
+	assert_true(body.contains("_player_camera.position = global_position - _player.global_position"),
+		"Issue #1911: _sync_camera_to_drone must set the camera's LOCAL position so that its " +
+		"global_position equals the drone's — this drives position_smoothing's target without " +
+		"ever reparenting the camera")
+
+
+func test_physics_process_calls_sync_camera_each_frame_issue_1911() -> void:
+	var source := _read_drone_grenade_source()
+	var body := _extract_gd_function(source, "func _physics_process(delta: float)")
+	assert_true(body.contains("_sync_camera_to_drone()"),
+		"Issue #1911: _physics_process must call _sync_camera_to_drone() each frame so the " +
+		"smoothing target tracks the drone's movement")


### PR DESCRIPTION
## Problem

When switching the camera between the player and the drone grenade, the camera visibly jerks.

Three user-reported symptoms across three iterations:

1. (original) jerk at throw end (THROWING→PILOTING) and at explosion (EXPLODED→player)
2. (after iteration 1) camera displaced from drone in pilot mode + still jerking at throw end
3. (after iteration 2) camera still jerks at moment of switching to drone control "as if the level restarts"

## Root Cause (iteration 3)

**Reparenting a `Camera2D` in Godot 4 resets its internal `position_smoothing` state.** When the scene-tree parent of a Camera2D changes, the smoothing snapshot is invalidated and the viewport snaps to the new target on the same frame — exactly what the user perceives as a "level restart" hard cut.

This is a known Godot community gotcha. Sources in the case study:

- [godotforums.org — Camera2D jumps when player reparented](https://godotforums.org/d/27618-camera2d-jumps-when-player-character-reparented-to-new-node)
- [forum.godotengine.org — Prevent discrete camera jumps when re-parenting](https://forum.godotengine.org/t/how-to-prevent-discrete-camera-jumps-when-re-parenting-a-node/26582)
- [Godot Issue #50807 — reset_smoothing() does not work as described](https://github.com/godotengine/godot/issues/50807)

Iterations 1 and 2 both reparented the camera; only the post-reparent `position` differed. Either way the smoothing reset still fired, so the jerk persisted. Iteration 1 additionally created a permanent world-space offset, which is why the camera "moved incorrectly in pilot mode".

## Fix (iteration 3)

**Never reparent the Camera2D.** Keep it a child of the Player at all times. While the drone owns the view, write the camera's LOCAL `position` each physics frame so that
`camera.global_position = player.global_position + camera.position = drone.global_position`.

```gdscript
func _attach_camera_to_drone() -> void:
    _camera_owned_by_drone = true
    _player_camera.make_current()
    _sync_camera_to_drone()

func _detach_camera_from_drone() -> void:
    _camera_owned_by_drone = false
    _player_camera.position = Vector2.ZERO  # re-center on player
    _player_camera.make_current()

func _sync_camera_to_drone() -> void:                       # called in _physics_process
    _player_camera.position = global_position - _player.global_position

func _physics_process(delta):
    ...
    _sync_camera_to_drone()                                  # runs every physics frame
```

Because the node hierarchy never changes, `position_smoothing`'s internal state is preserved. The camera's target moves from player to drone in one frame, and Godot's built-in smoothing panoramas the viewport to follow. Same applies in reverse on detach.

## Verification

1. Throw drone at a far aim point (≥ 400 px). Camera smoothly pans from player to drone — no snap.
2. Pilot with WASD. Camera stays centered on drone.
3. Let drone explode. Camera pans back smoothly to player.
4. Repeat multiple times — no degradation.

## Tests

Added source-level regression tests in `tests/unit/test_drone_grenade.gd`:

- `test_attach_camera_does_not_reparent_issue_1911` — asserts `_attach_camera_to_drone` has no `add_child`/`remove_child` on the camera.
- `test_detach_camera_does_not_reparent_issue_1911` — same for `_detach_camera_from_drone`.
- `test_detach_camera_zeroes_local_position_issue_1911` — asserts the re-centering.
- `test_sync_camera_uses_local_position_not_reparent_issue_1911` — asserts the local-position math.
- `test_physics_process_calls_sync_camera_each_frame_issue_1911` — asserts the per-frame sync call.

## Case Study

Both user-provided game logs and a full deep-analysis writeup are compiled at [`docs/case-studies/issue-1911/`](docs/case-studies/issue-1911/README.md).

Fixes Jhon-Crow/godot-topdown-MVP#1911