### PR TITLE
Add pause music muffle effect

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-03T11:54:06.228Z for PR creation at branch issue-1931-00bcd7d31ef5 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1931

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-03T11:54:06.228Z for PR creation at branch issue-1931-00bcd7d31ef5 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1931

--- a/docs/case-studies/issue-1931/README.md
+++ b/docs/case-studies/issue-1931/README.md
@@ -19,6 +19,7 @@
 Downloaded owner feedback log:
 
 - `docs/case-studies/issue-1931/artifacts/game_log_20260503_154901.txt`
+- `docs/case-studies/issue-1931/artifacts/game_log_20260503_160550.txt`
 
 The log was produced from branch `issue-1931-00bcd7d31ef5` at build commit `10ffb3f19765645f1a5e52db6accdc73ccdbf152`. It shows several level transitions through `SceneLoader`, including:
 
@@ -27,6 +28,14 @@ The log was produced from branch `issue-1931-00bcd7d31ef5` at build commit `10ff
 - 15:49:27: `SceneLoader` loads `RailwayStationLevel.tscn`
 
 Owner feedback: "сейчас при переключении уровня эффект не исчезает" ("now when switching levels the effect does not disappear").
+
+The second log was produced from the same branch at build commit `40bfff67adf4e9627c0eb5d92ec3cc689eaded28`. It confirms the level-switch fix and shows a remaining pause-menu armory path:
+
+- 16:06:11: `PauseMenu` opens `ArmoryMenu`.
+- 16:06:13: `ArmoryMenu` changes weapon selection to `ak_gl`.
+- 16:06:14: `GameManager.restart_scene()` starts a scene reload.
+
+Owner feedback: "проблема с выбором уровня решена! но обнаружена проблема - эффект не исчезает после выбора оружия в армори. во всех ситуациях, приводящих к перезапуску уровня должен отключаться эффект." ("the level selection problem is solved, but the effect does not disappear after selecting a weapon in the armory; in all situations that restart the level, the effect should be disabled").
 
 ## Root Cause
 
@@ -40,6 +49,8 @@ The first implementation enabled the low-pass filter from `PauseMenu.pause_game(
 6. The global `AudioServer` bus effect remains enabled because the scene transition bypassed `PauseMenu.resume_game()`.
 
 Because the effect lives on the global `Music` bus, it survives scene changes unless explicitly disabled.
+
+The first follow-up fix only cleared the effect when the active scene path changed. The armory restart path exposed a second case: `GameManager.restart_scene()` reloads the current level, so `MusicManager` sees the same `scene_file_path` and intentionally avoids replaying the music. The level scene object is still replaced, though, and that replacement is enough to identify a gameplay restart that must clear pause-only audio effects.
 
 ## External Research
 
@@ -70,7 +81,7 @@ Sources:
 
 `MusicManager` installs a disabled `AudioEffectLowPassFilter` named `PauseMuffleLowPass` on the `Music` bus. `PauseMenu` calls `MusicManager.set_pause_muffle_enabled(true)` when opening and disables it when resuming, leaving for another level, or quitting.
 
-After owner feedback, `MusicManager._sync_to_current_scene()` also disables the pause muffle whenever the active scene path changes. This makes scene transition cleanup independent of the initiating UI path (`PauseMenu`, `LevelsMenu`, `SceneLoader`, startup navigation, or a direct `change_scene_to_file` fallback).
+After owner feedback, `MusicManager._sync_to_current_scene()` also disables the pause muffle whenever the active scene path changes or when the same scene path is represented by a replacement scene instance. This makes cleanup independent of the initiating UI path (`PauseMenu`, `LevelsMenu`, `SceneLoader`, startup navigation, direct `change_scene_to_file` fallback, armory apply, death restart, score-screen restart, or quick restart) while preserving the existing requirement that music does not restart on same-level reloads.
 
 Chosen filter parameters:
 
@@ -88,3 +99,4 @@ Added regression coverage in `tests/unit/test_music_manager.gd`:
 - The filter starts disabled during gameplay.
 - `set_pause_muffle_enabled(true/false)` toggles the bus effect.
 - `_sync_to_current_scene()` disables the muffle effect when the current scene changes, reproducing the paused Levels menu transition failure mode.
+- `_sync_to_current_scene()` disables the muffle effect when the same scene path is reloaded as a new scene instance, reproducing the pause-menu armory restart failure mode, without replaying the track.

--- a/docs/case-studies/issue-1931/README.md
+++ b/docs/case-studies/issue-1931/README.md
@@ -1,0 +1,59 @@
+# Case Study: Pause-Screen Music Muffle (Issue #1931)
+
+## Issue Data
+
+- Issue: <https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1931>
+- Request: add a strong muted music effect, like underwater audio, while the game is paused on the pause screen.
+- Additional requirement: collect repository data in `docs/case-studies/issue-1931`, research relevant facts, analyze possible solutions, and implement the selected fix.
+
+## Repository Context
+
+- `MusicManager` (`scripts/autoload/music_manager.gd`) creates a dedicated `Music` audio bus and routes its `AudioStreamPlayer` through it.
+- The music player uses `Node.PROCESS_MODE_ALWAYS`, so music continues while the scene tree is paused.
+- `PauseMenu` (`scripts/ui/pause_menu.gd`) is responsible for toggling `get_tree().paused` and remains active during pause through `PROCESS_MODE_ALWAYS`.
+- Sound settings already target the `Music` bus for music volume, so bus-level effects are the narrowest place to alter music without changing SFX.
+
+## External Research
+
+Godot's official audio filter API supports low-pass filters through `AudioEffectLowPassFilter`, which cuts frequencies above `AudioEffectFilter.cutoff_hz`. The `AudioServer` API can add effects to buses at runtime with `add_bus_effect(bus_idx, effect, at_position=-1)`.
+
+Sources:
+
+- Godot 4.3 `AudioEffectFilter` documentation: <https://docs.godotengine.org/en/4.3/classes/class_audioeffectfilter.html>
+- Godot 4.5 `AudioServer` documentation: <https://docs.godotengine.org/en/4.5/classes/class_audioserver.html>
+- Godot latest `AudioEffectLowPassFilter` documentation: <https://docs.godotengine.org/en/latest/classes/class_audioeffectlowpassfilter.html>
+
+## Solution Options
+
+1. Lower music volume during pause.
+   - Simple, but it does not sound underwater or strongly muffled.
+   - It also fights the user's music-volume setting.
+
+2. Add a duplicate filtered pause music player.
+   - Allows custom processing, but duplicates playback state and risks phase/restart bugs.
+   - More complex than needed because a Music bus already exists.
+
+3. Add a low-pass filter to the existing Music bus and enable it only while paused.
+   - Matches the "underwater" requirement by removing high frequencies.
+   - Keeps playback continuous and preserves the existing music slider.
+   - Does not affect SFX if they remain on their own buses.
+
+## Selected Implementation
+
+`MusicManager` now installs a disabled `AudioEffectLowPassFilter` named `PauseMuffleLowPass` on the `Music` bus. `PauseMenu` calls `MusicManager.set_pause_muffle_enabled(true)` when opening and disables it when resuming, leaving for another level, or quitting.
+
+Chosen filter parameters:
+
+- `cutoff_hz = 650.0`
+- `db = FILTER_24DB`
+- `resonance = 0.45`
+
+This is intentionally strong: most high-frequency content is removed while preserving enough low-frequency energy that the music remains audible under the pause screen.
+
+## Verification
+
+Added regression coverage in `tests/unit/test_music_manager.gd`:
+
+- Music bus includes a pause low-pass filter.
+- The filter starts disabled during gameplay.
+- `set_pause_muffle_enabled(true/false)` toggles the bus effect.

--- a/docs/case-studies/issue-1931/README.md
+++ b/docs/case-studies/issue-1931/README.md
@@ -11,7 +11,35 @@
 - `MusicManager` (`scripts/autoload/music_manager.gd`) creates a dedicated `Music` audio bus and routes its `AudioStreamPlayer` through it.
 - The music player uses `Node.PROCESS_MODE_ALWAYS`, so music continues while the scene tree is paused.
 - `PauseMenu` (`scripts/ui/pause_menu.gd`) is responsible for toggling `get_tree().paused` and remains active during pause through `PROCESS_MODE_ALWAYS`.
+- `LevelsMenu` (`scripts/ui/levels_menu.gd`) can be opened from the pause screen and then routes selected levels through `SceneLoader.load_level()`.
 - Sound settings already target the `Music` bus for music volume, so bus-level effects are the narrowest place to alter music without changing SFX.
+
+## Feedback Artifact
+
+Downloaded owner feedback log:
+
+- `docs/case-studies/issue-1931/artifacts/game_log_20260503_154901.txt`
+
+The log was produced from branch `issue-1931-00bcd7d31ef5` at build commit `10ffb3f19765645f1a5e52db6accdc73ccdbf152`. It shows several level transitions through `SceneLoader`, including:
+
+- 15:49:10: `SceneLoader` loads `LabyrinthLevel.tscn`
+- 15:49:18-15:49:19: `SceneLoader` loads `BuildingLevel.tscn`
+- 15:49:27: `SceneLoader` loads `RailwayStationLevel.tscn`
+
+Owner feedback: "сейчас при переключении уровня эффект не исчезает" ("now when switching levels the effect does not disappear").
+
+## Root Cause
+
+The first implementation enabled the low-pass filter from `PauseMenu.pause_game()` and disabled it from direct PauseMenu exit paths such as resume, training, roguelike, arena, and quit. The missed path was:
+
+1. Player opens pause menu.
+2. `PauseMenu` enables the global Music bus low-pass effect.
+3. Player opens `LevelsMenu`.
+4. `LevelsMenu._on_level_selected()` emits `back_pressed` and calls `SceneLoader.load_level(level_path)`.
+5. `SceneLoader` unpauses and changes the scene.
+6. The global `AudioServer` bus effect remains enabled because the scene transition bypassed `PauseMenu.resume_game()`.
+
+Because the effect lives on the global `Music` bus, it survives scene changes unless explicitly disabled.
 
 ## External Research
 
@@ -40,7 +68,9 @@ Sources:
 
 ## Selected Implementation
 
-`MusicManager` now installs a disabled `AudioEffectLowPassFilter` named `PauseMuffleLowPass` on the `Music` bus. `PauseMenu` calls `MusicManager.set_pause_muffle_enabled(true)` when opening and disables it when resuming, leaving for another level, or quitting.
+`MusicManager` installs a disabled `AudioEffectLowPassFilter` named `PauseMuffleLowPass` on the `Music` bus. `PauseMenu` calls `MusicManager.set_pause_muffle_enabled(true)` when opening and disables it when resuming, leaving for another level, or quitting.
+
+After owner feedback, `MusicManager._sync_to_current_scene()` also disables the pause muffle whenever the active scene path changes. This makes scene transition cleanup independent of the initiating UI path (`PauseMenu`, `LevelsMenu`, `SceneLoader`, startup navigation, or a direct `change_scene_to_file` fallback).
 
 Chosen filter parameters:
 
@@ -57,3 +87,4 @@ Added regression coverage in `tests/unit/test_music_manager.gd`:
 - Music bus includes a pause low-pass filter.
 - The filter starts disabled during gameplay.
 - `set_pause_muffle_enabled(true/false)` toggles the bus effect.
+- `_sync_to_current_scene()` disables the muffle effect when the current scene changes, reproducing the paused Levels menu transition failure mode.

--- a/docs/case-studies/issue-1931/artifacts/game_log_20260503_154901.txt
+++ b/docs/case-studies/issue-1931/artifacts/game_log_20260503_154901.txt
@@ -1,0 +1,5060 @@
+[15:49:01] [INFO] ============================================================
+[15:49:01] [INFO] GAME LOG STARTED
+[15:49:01] [INFO] ============================================================
+[15:49:01] [INFO] Timestamp: 2026-05-03T15:49:01
+[15:49:01] [INFO] Log file: I:/Загрузки/godot exe/звУк/game_log_20260503_154901.txt
+[15:49:01] [INFO] Executable: I:/Загрузки/godot exe/звУк/Godot-Top-Down-Template.exe
+[15:49:01] [INFO] OS: Windows
+[15:49:01] [INFO] Debug build: false
+[15:49:01] [INFO] Engine version: 4.3-stable (official)
+[15:49:01] [INFO] Project: Godot Top-Down Template
+[15:49:01] [INFO] Build branch: issue-1931-00bcd7d31ef5
+[15:49:01] [INFO] Build commit: 10ffb3f19765645f1a5e52db6accdc73ccdbf152
+[15:49:01] [INFO] Build date: 2026-05-03T12:02:12Z
+[15:49:01] [INFO] ------------------------------------------------------------
+[15:49:01] [INFO] [GameManager] GameManager ready
+[15:49:01] [INFO] [ScoreManager] ScoreManager ready
+[15:49:01] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[15:49:01] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[15:49:01] [INFO] [DifficultyManager] Loaded difficulty: Gunslinger (value: 5)
+[15:49:01] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal, WaterBloodDiffusion
+[15:49:01] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[15:49:01] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[15:49:01] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[15:49:01] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[15:49:01] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[15:49:01] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[15:49:01] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[15:49:01] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[15:49:01] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[15:49:01] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[15:49:01] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[15:49:01] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[15:49:01] [INFO] [LastChance] Resetting all effects (scene change detected)
+[15:49:01] [INFO] [LastChance] Last chance shader loaded successfully
+[15:49:01] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[15:49:01] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[15:49:01] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[15:49:01] [INFO] [LastChance]   Sepia intensity: 0.70
+[15:49:01] [INFO] [LastChance]   Brightness: 0.60
+[15:49:01] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[15:49:01] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[15:49:01] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[15:49:01] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[15:49:01] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DroneGrenade.tscn
+[15:49:01] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: false, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: false, FPS drop logging: true, All weapons unlocked: true, All maps unlocked: true, Global stuck max time: 20.0s, Nav mesh visible: false, Search path visible: false, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false, Enemy path visible: false, Cover raycast visible: false, Tactical group: false, Cover infinite rays: true, Cover sector rays: true, Roguelike unlocked: false
+[15:49:01] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[15:49:01] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.50, music: 1.00
+[15:49:01] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true, revolver_aim_assist: true, unlock_notifications: true, combo_font_size: 140
+[15:49:01] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[15:49:01] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[15:49:01] [INFO] [CinemaEffects] Created effects layer at layer 99
+[15:49:01] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[15:49:01] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[15:49:01] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[15:49:01] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[15:49:01] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[15:49:01] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[15:49:01] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[15:49:01] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[15:49:01] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[15:49:01] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[15:49:01] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[15:49:01] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[15:49:01] [INFO] [GrenadeTimerHelper] Autoload ready
+[15:49:01] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[15:49:01] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[15:49:01] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[15:49:01] [INFO] [PowerFantasy]   Kill effect duration: 600ms
+[15:49:01] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[15:49:01] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[15:49:01] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[15:49:01] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[15:49:01] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[15:49:01] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[15:49:01] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[15:49:01] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[15:49:01] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[15:49:01] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[15:49:01] [INFO] [ProgressManager] ProgressManager ready, loaded 21 entries
+[15:49:01] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[15:49:01] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[15:49:01] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[15:49:01] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[15:49:01] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[15:49:01] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[15:49:01] [INFO] [SceneLoader] SceneLoader initialized
+[15:49:01] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[15:49:01] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[15:49:01] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[15:49:01] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[15:49:01] [INFO] [PersistManager] Restored kills_without_laser_sight: 246
+[15:49:01] [INFO] [PersistManager] Restored shots_fired_special_weapons: 336
+[15:49:01] [INFO] [PersistManager] Restored total_deaths: 52
+[15:49:01] [INFO] [PersistManager] Restored no_damage_levels_completed: 4
+[15:49:01] [INFO] [PersistManager] Restored levels_completed_rank_a_or_higher: 11
+[15:49:01] [INFO] [PersistManager] Restored levels_completed_rank_s: 0
+[15:49:01] [INFO] [PersistManager] Restored kills_through_wall: 10
+[15:49:01] [INFO] [PersistManager] Restored levels_completed_with_silenced_pistol: 1
+[15:49:01] [INFO] [GameManager] Weapon selected: sniper
+[15:49:01] [INFO] [PersistManager] Restored selected weapon: sniper
+[15:49:01] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[15:49:01] [INFO] [GrenadeManager] Grenade type changed from Flashbang to F-1 Grenade
+[15:49:01] [INFO] [PersistManager] Restored selected grenade type: 2
+[15:49:01] [INFO] [PersistManager] Restored unlocked active item type: 0
+[15:49:01] [INFO] [PersistManager] Restored unlocked active item type: 11
+[15:49:01] [INFO] [ActiveItemManager] Active item changed from None to Extended Magazine
+[15:49:01] [INFO] [PersistManager] Restored selected active item type: 10
+[15:49:01] [INFO] [PersistManager] Loudspeaker progress restored: level 1, levels_completed=0
+[15:49:01] [INFO] [PersistManager] State loaded successfully
+[15:49:01] [INFO] [PersistManager] PersistManager ready
+[15:49:01] [INFO] [UnlockManager] UnlockManager ready
+[15:49:01] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["makarov_pm", "revolver", "mini_uzi", "shotgun", "sniper", "m16", "silenced_pistol", "ak_gl"]
+[15:49:01] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, warm_lights: true, ai: true
+[15:49:01] [INFO] [LocalizationSettings] Loaded 2 translation(s)
+[15:49:01] [INFO] [LocalizationSettings] LocalizationSettings initialized — locale: en
+[15:49:01] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_condition
+[15:49:01] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_kill_condition
+[15:49:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:01] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[15:49:01] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[15:49:01] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[15:49:01] [ENEMY] [Enemy1] Death animation component initialized
+[15:49:01] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[15:49:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:01] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[15:49:01] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[15:49:01] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[15:49:01] [ENEMY] [Enemy2] Death animation component initialized
+[15:49:02] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[15:49:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:02] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[15:49:02] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[15:49:02] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[15:49:02] [ENEMY] [Enemy3] Death animation component initialized
+[15:49:02] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[15:49:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:02] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[15:49:02] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[15:49:02] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[15:49:02] [ENEMY] [Enemy4] Death animation component initialized
+[15:49:02] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[15:49:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:02] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[15:49:02] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[15:49:02] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[15:49:02] [ENEMY] [Enemy5] Death animation component initialized
+[15:49:02] [ENEMY] [Enemy5] [Gunslinger] Enemy glow applied
+[15:49:02] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:02] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[15:49:02] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[15:49:02] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[15:49:02] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[15:49:02] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[15:49:02] [INFO] [Player.Weapon] GameManager weapon selection: sniper (SniperRifle)
+[15:49:02] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[15:49:02] [INFO] [Player.Weapon] Equipped SniperRifle (ammo: 12/5)
+[15:49:02] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[15:49:02] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[15:49:02] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[15:49:02] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[15:49:02] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[15:49:02] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[15:49:02] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[15:49:02] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[15:49:02] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[15:49:02] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[15:49:02] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[15:49:02] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[15:49:02] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[15:49:02] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[15:49:02] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[15:49:02] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[15:49:02] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[15:49:02] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[15:49:02] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[15:49:02] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[15:49:02] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[15:49:02] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[15:49:02] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[15:49:02] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[15:49:02] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[15:49:02] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[15:49:02] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[15:49:02] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[15:49:02] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[15:49:02] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[15:49:02] [INFO] [Player.Jammer] JammerHUD initialized
+[15:49:02] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[15:49:02] [INFO] [Player] Ready! Ammo: 12/5, Grenades: 1/3, Health: 2/4
+[15:49:02] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[15:49:02] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[15:49:02] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[15:49:02] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[15:49:02] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[15:49:02] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[15:49:02] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[15:49:02] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[15:49:02] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[15:49:02] [INFO] [LabyrinthLevel] Setting up weapon: sniper
+[15:49:02] [INFO] [LabyrinthLevel] SniperRifle already equipped by C# Player - applying labyrinth ammo config
+[15:49:02] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for sniper
+[15:49:02] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): SniperRifle 12/72
+[15:49:02] [INFO] [GameManager] set_player() called with: <CharacterBody2D#87342188304> (class: CharacterBody2D)
+[15:49:02] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[15:49:02] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[15:49:02] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[15:49:02] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[15:49:02] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[15:49:02] [INFO] [ScoreManager] Level started with 5 enemies
+[15:49:02] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[15:49:02] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[15:49:02] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[15:49:02] [INFO] [ReplayManager] Replay data cleared
+[15:49:02] [INFO] [LabyrinthLevel] Previous replay data cleared
+[15:49:02] [INFO] [ReplayManager] Detected player weapon: Sniper Rifle (ASVK)
+[15:49:02] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[15:49:02] [INFO] [ReplayManager] Level: LabyrinthLevel
+[15:49:02] [INFO] [ReplayManager] Player: Player (valid: True)
+[15:49:02] [INFO] [ReplayManager] Enemies count: 5
+[15:49:02] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/asvk_topdown.png
+[15:49:02] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[15:49:02] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[15:49:02] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[15:49:02] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[15:49:02] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[15:49:02] [INFO] [LabyrinthLevel] Replay recording started successfully
+[15:49:02] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[15:49:02] [INFO] [CinemaEffects] Found player node: Player
+[15:49:02] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[15:49:02] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/RevolverLevel.tscn
+[15:49:02] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/RevolverLevel.tscn
+[15:49:02] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[15:49:02] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[15:49:02] [INFO] [UnlockManager] Restored saved unlock for weapon: ak_gl
+[15:49:02] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[15:49:02] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[15:49:02] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[15:49:02] [ENEMY] [Enemy1] Registered as sound listener
+[15:49:02] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[15:49:02] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[15:49:02] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[15:49:02] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[15:49:02] [ENEMY] [Enemy2] Registered as sound listener
+[15:49:02] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[15:49:02] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[15:49:02] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[15:49:02] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[15:49:02] [ENEMY] [Enemy3] Registered as sound listener
+[15:49:02] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[15:49:02] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[15:49:02] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[15:49:02] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[15:49:02] [ENEMY] [Enemy4] Registered as sound listener
+[15:49:02] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[15:49:02] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[15:49:02] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[15:49:02] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[15:49:02] [ENEMY] [Enemy5] Registered as sound listener
+[15:49:02] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 1, behavior: GUARD
+[15:49:02] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[15:49:02] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[15:49:02] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:49:02] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:49:02] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=315.0°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:49:02] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=281.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:49:02] [INFO] [Player] Detecting weapon pose (frame 3)...
+[15:49:02] [INFO] [Player] Detected weapon: ASVK Sniper Rifle (Sniper pose)
+[15:49:02] [INFO] [Player] Applied Sniper arm pose: Left=(28, 6), Right=(-3, 6)
+[15:49:02] [INFO] [PenultimateHit] Shader warmup complete in 1225 ms
+[15:49:02] [INFO] [LastChance] Shader warmup complete in 1224 ms
+[15:49:02] [INFO] [CinemaEffects] Cinema shader warmup complete in 1099 ms
+[15:49:02] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1091 ms
+[15:49:02] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[15:49:02] [INFO] [FlashbangPlayer] Shader warmup complete in 1087 ms
+[15:49:02] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[15:49:02] [INFO] [SceneLoader] ERROR: Invalid resource (falling back to sync): res://scenes/levels/RevolverLevel.tscn
+[15:49:02] [INFO] [SceneLoader] Using synchronous load fallback
+[15:49:03] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[15:49:03] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[15:49:03] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[15:49:03] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[15:49:03] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[15:49:03] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:49:03] [INFO] [SceneLoader] Sync fallback scene changed successfully: res://scenes/levels/RevolverLevel.tscn
+[15:49:03] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:TopEnemy1] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:TopEnemy1] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:TopEnemy1] BloodyFeetComponent ready on TopEnemy1
+[15:49:03] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[15:49:03] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:49:03] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[15:49:03] [INFO] [LastChance] Resetting all effects (scene change detected)
+[15:49:03] [INFO] [CinemaEffects] Scene changed to: RevolverLevel
+[15:49:03] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[15:49:03] [INFO] [BlackMetalEffectsManager] Scene changed to: RevolverLevel
+[15:49:03] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[15:49:03] [INFO] [PersistManager] Startup navigation complete — arrived at: res://scenes/levels/RevolverLevel.tscn
+[15:49:03] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:49:03] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RevolverLevel.tscn
+[15:49:03] [ENEMY] [TopEnemy1] Death animation component initialized
+[15:49:03] [ENEMY] [TopEnemy1] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:TopEnemy2] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:TopEnemy2] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:TopEnemy2] BloodyFeetComponent ready on TopEnemy2
+[15:49:03] [ENEMY] [TopEnemy2] Death animation component initialized
+[15:49:03] [ENEMY] [TopEnemy2] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:TopEnemy3] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:TopEnemy3] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:TopEnemy3] BloodyFeetComponent ready on TopEnemy3
+[15:49:03] [ENEMY] [TopEnemy3] Death animation component initialized
+[15:49:03] [ENEMY] [TopEnemy3] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy1] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy1] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy1] BloodyFeetComponent ready on BottomEnemy1
+[15:49:03] [ENEMY] [BottomEnemy1] Death animation component initialized
+[15:49:03] [ENEMY] [BottomEnemy1] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy2] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy2] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy2] BloodyFeetComponent ready on BottomEnemy2
+[15:49:03] [ENEMY] [BottomEnemy2] Death animation component initialized
+[15:49:03] [ENEMY] [BottomEnemy2] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy3] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy3] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy3] BloodyFeetComponent ready on BottomEnemy3
+[15:49:03] [ENEMY] [BottomEnemy3] Death animation component initialized
+[15:49:03] [ENEMY] [BottomEnemy3] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard1] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard1] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard1] BloodyFeetComponent ready on ReloadGuard1
+[15:49:03] [ENEMY] [ReloadGuard1] Death animation component initialized
+[15:49:03] [ENEMY] [ReloadGuard1] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard2] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard2] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard2] BloodyFeetComponent ready on ReloadGuard2
+[15:49:03] [ENEMY] [ReloadGuard2] Death animation component initialized
+[15:49:03] [ENEMY] [ReloadGuard2] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard3] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard3] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard3] BloodyFeetComponent ready on ReloadGuard3
+[15:49:03] [ENEMY] [ReloadGuard3] Death animation component initialized
+[15:49:03] [ENEMY] [ReloadGuard3] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard4] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard4] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard4] BloodyFeetComponent ready on ReloadGuard4
+[15:49:03] [ENEMY] [ReloadGuard4] Death animation component initialized
+[15:49:03] [ENEMY] [ReloadGuard4] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy1] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy1] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy1] BloodyFeetComponent ready on FinalEnemy1
+[15:49:03] [ENEMY] [FinalEnemy1] Death animation component initialized
+[15:49:03] [ENEMY] [FinalEnemy1] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy2] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy2] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy2] BloodyFeetComponent ready on FinalEnemy2
+[15:49:03] [ENEMY] [FinalEnemy2] Death animation component initialized
+[15:49:03] [ENEMY] [FinalEnemy2] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:ForceFieldEnemy] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:ForceFieldEnemy] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:ForceFieldEnemy] BloodyFeetComponent ready on ForceFieldEnemy
+[15:49:03] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[15:49:03] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[15:49:03] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[15:49:03] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[15:49:03] [ENEMY] [ForceFieldEnemy] Death animation component initialized
+[15:49:03] [ENEMY] [ForceFieldEnemy] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:ArmoredSkinEnemy] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:ArmoredSkinEnemy] Found EnemyModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:ArmoredSkinEnemy] BloodyFeetComponent ready on ArmoredSkinEnemy
+[15:49:03] [INFO] [EnemyArmoredSkin] Armor shader applied to 4 sprites
+[15:49:03] [ENEMY] [ArmoredSkinEnemy] Death animation component initialized
+[15:49:03] [ENEMY] [ArmoredSkinEnemy] [Gunslinger] Enemy glow applied
+[15:49:03] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:03] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[15:49:03] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[15:49:03] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[15:49:03] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[15:49:03] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[15:49:03] [INFO] [Player.Weapon] GameManager weapon selection: sniper (SniperRifle)
+[15:49:03] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[15:49:03] [INFO] [Player.Weapon] Equipped SniperRifle (ammo: 12/5)
+[15:49:03] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[15:49:03] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[15:49:03] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[15:49:03] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[15:49:03] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[15:49:03] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[15:49:03] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[15:49:03] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[15:49:03] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[15:49:03] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[15:49:03] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[15:49:03] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[15:49:03] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[15:49:03] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[15:49:03] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[15:49:03] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[15:49:03] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[15:49:03] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[15:49:03] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[15:49:03] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[15:49:03] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[15:49:03] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[15:49:03] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[15:49:03] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[15:49:03] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[15:49:03] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[15:49:03] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[15:49:03] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[15:49:03] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[15:49:03] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[15:49:03] [INFO] [Player.Jammer] JammerHUD initialized
+[15:49:03] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[15:49:03] [INFO] [Player] Ready! Ammo: 12/5, Grenades: 1/3, Health: 2/4
+[15:49:03] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[15:49:03] [INFO] [RevolverLevel] Found Environment/Enemies node with 14 children
+[15:49:03] [INFO] [RevolverLevel] Enemy tracking complete: 14 enemies registered
+[15:49:03] [INFO] [GameManager] set_player() called with: <CharacterBody2D#150743289485> (class: CharacterBody2D)
+[15:49:03] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[15:49:03] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[15:49:03] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[15:49:03] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[15:49:03] [INFO] [RevolverLevel] Camera2D limits set — top=64 bottom=1664 left=64 right=2064 — Issue #1682
+[15:49:03] [INFO] [ScoreManager] Level started with 14 enemies
+[15:49:03] [INFO] [RevolverLevel] ReplayManager found as C# autoload - verified OK
+[15:49:03] [INFO] [RevolverLevel] Starting replay recording - Player: Player, Enemies count: 14
+[15:49:03] [INFO] [ReplayManager] Replay data cleared
+[15:49:03] [INFO] [ReplayManager] Detected player weapon: Sniper Rifle (ASVK)
+[15:49:03] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[15:49:03] [INFO] [ReplayManager] Level: RevolverLevel
+[15:49:03] [INFO] [ReplayManager] Player: Player (valid: True)
+[15:49:03] [INFO] [ReplayManager] Enemies count: 14
+[15:49:03] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/asvk_topdown.png
+[15:49:03] [INFO] [ReplayManager]   Enemy 0: TopEnemy1
+[15:49:03] [INFO] [ReplayManager]   Enemy 1: TopEnemy2
+[15:49:03] [INFO] [ReplayManager]   Enemy 2: TopEnemy3
+[15:49:03] [INFO] [ReplayManager]   Enemy 3: BottomEnemy1
+[15:49:03] [INFO] [ReplayManager]   Enemy 4: BottomEnemy2
+[15:49:03] [INFO] [ReplayManager]   Enemy 5: BottomEnemy3
+[15:49:03] [INFO] [ReplayManager]   Enemy 6: ReloadGuard1
+[15:49:03] [INFO] [ReplayManager]   Enemy 7: ReloadGuard2
+[15:49:03] [INFO] [ReplayManager]   Enemy 8: ReloadGuard3
+[15:49:03] [INFO] [ReplayManager]   Enemy 9: ReloadGuard4
+[15:49:03] [INFO] [ReplayManager]   Enemy 10: FinalEnemy1
+[15:49:03] [INFO] [ReplayManager]   Enemy 11: FinalEnemy2
+[15:49:03] [INFO] [ReplayManager]   Enemy 12: ForceFieldEnemy
+[15:49:03] [INFO] [ReplayManager]   Enemy 13: ArmoredSkinEnemy
+[15:49:03] [INFO] [RevolverLevel] Replay recording started successfully
+[15:49:03] [INFO] [WeaponHintsComponent] Connected weapon signals for: sniper (node: SniperRifle)
+[15:49:03] [INFO] [WeaponHintsComponent] Hint added 'scope': [color=#ff4444][ПКМ][/color] Scope in
+[15:49:03] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: sniper
+[15:49:03] [INFO] [BloodyFeet:TopEnemy1] Blood detector created and attached to TopEnemy1
+[15:49:03] [INFO] [BloodyFeet:TopEnemy1] Snow surface detector created on TopEnemy1
+[15:49:03] [INFO] [CinemaEffects] Found player node: Player
+[15:49:03] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[15:49:03] [INFO] [SoundPropagation] Registered listener: TopEnemy1 (total: 1)
+[15:49:03] [ENEMY] [TopEnemy1] Registered as sound listener
+[15:49:03] [ENEMY] [TopEnemy1] Spawned at (620, 550), hp: 1, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:TopEnemy2] Blood detector created and attached to TopEnemy2
+[15:49:03] [INFO] [BloodyFeet:TopEnemy2] Snow surface detector created on TopEnemy2
+[15:49:03] [INFO] [SoundPropagation] Registered listener: TopEnemy2 (total: 2)
+[15:49:03] [ENEMY] [TopEnemy2] Registered as sound listener
+[15:49:03] [ENEMY] [TopEnemy2] Spawned at (740, 550), hp: 1, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:TopEnemy3] Blood detector created and attached to TopEnemy3
+[15:49:03] [INFO] [BloodyFeet:TopEnemy3] Snow surface detector created on TopEnemy3
+[15:49:03] [INFO] [SoundPropagation] Registered listener: TopEnemy3 (total: 3)
+[15:49:03] [ENEMY] [TopEnemy3] Registered as sound listener
+[15:49:03] [ENEMY] [TopEnemy3] Spawned at (860, 550), hp: 2, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy1] Blood detector created and attached to BottomEnemy1
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy1] Snow surface detector created on BottomEnemy1
+[15:49:03] [INFO] [SoundPropagation] Registered listener: BottomEnemy1 (total: 4)
+[15:49:03] [ENEMY] [BottomEnemy1] Registered as sound listener
+[15:49:03] [ENEMY] [BottomEnemy1] Spawned at (620, 1150), hp: 1, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy2] Blood detector created and attached to BottomEnemy2
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy2] Snow surface detector created on BottomEnemy2
+[15:49:03] [INFO] [SoundPropagation] Registered listener: BottomEnemy2 (total: 5)
+[15:49:03] [ENEMY] [BottomEnemy2] Registered as sound listener
+[15:49:03] [ENEMY] [BottomEnemy2] Spawned at (740, 1150), hp: 1, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy3] Blood detector created and attached to BottomEnemy3
+[15:49:03] [INFO] [BloodyFeet:BottomEnemy3] Snow surface detector created on BottomEnemy3
+[15:49:03] [INFO] [SoundPropagation] Registered listener: BottomEnemy3 (total: 6)
+[15:49:03] [ENEMY] [BottomEnemy3] Registered as sound listener
+[15:49:03] [ENEMY] [BottomEnemy3] Spawned at (860, 1150), hp: 2, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard1] Blood detector created and attached to ReloadGuard1
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard1] Snow surface detector created on ReloadGuard1
+[15:49:03] [INFO] [SoundPropagation] Registered listener: ReloadGuard1 (total: 7)
+[15:49:03] [ENEMY] [ReloadGuard1] Registered as sound listener
+[15:49:03] [ENEMY] [ReloadGuard1] Spawned at (1180, 500), hp: 1, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard2] Blood detector created and attached to ReloadGuard2
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard2] Snow surface detector created on ReloadGuard2
+[15:49:03] [INFO] [SoundPropagation] Registered listener: ReloadGuard2 (total: 8)
+[15:49:03] [ENEMY] [ReloadGuard2] Registered as sound listener
+[15:49:03] [ENEMY] [ReloadGuard2] Spawned at (1180, 600), hp: 1, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard3] Blood detector created and attached to ReloadGuard3
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard3] Snow surface detector created on ReloadGuard3
+[15:49:03] [INFO] [SoundPropagation] Registered listener: ReloadGuard3 (total: 9)
+[15:49:03] [ENEMY] [ReloadGuard3] Registered as sound listener
+[15:49:03] [ENEMY] [ReloadGuard3] Spawned at (1180, 1100), hp: 1, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard4] Blood detector created and attached to ReloadGuard4
+[15:49:03] [INFO] [BloodyFeet:ReloadGuard4] Snow surface detector created on ReloadGuard4
+[15:49:03] [INFO] [SoundPropagation] Registered listener: ReloadGuard4 (total: 10)
+[15:49:03] [ENEMY] [ReloadGuard4] Registered as sound listener
+[15:49:03] [ENEMY] [ReloadGuard4] Spawned at (1180, 1200), hp: 1, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy1] Blood detector created and attached to FinalEnemy1
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy1] Snow surface detector created on FinalEnemy1
+[15:49:03] [INFO] [SoundPropagation] Registered listener: FinalEnemy1 (total: 11)
+[15:49:03] [ENEMY] [FinalEnemy1] Registered as sound listener
+[15:49:03] [ENEMY] [FinalEnemy1] Spawned at (1850, 700), hp: 1, behavior: PATROL
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy2] Blood detector created and attached to FinalEnemy2
+[15:49:03] [INFO] [BloodyFeet:FinalEnemy2] Snow surface detector created on FinalEnemy2
+[15:49:03] [INFO] [SoundPropagation] Registered listener: FinalEnemy2 (total: 12)
+[15:49:03] [ENEMY] [FinalEnemy2] Registered as sound listener
+[15:49:03] [ENEMY] [FinalEnemy2] Spawned at (1850, 1000), hp: 1, behavior: PATROL
+[15:49:03] [INFO] [BloodyFeet:ForceFieldEnemy] Blood detector created and attached to ForceFieldEnemy
+[15:49:03] [INFO] [BloodyFeet:ForceFieldEnemy] Snow surface detector created on ForceFieldEnemy
+[15:49:03] [INFO] [SoundPropagation] Registered listener: ForceFieldEnemy (total: 13)
+[15:49:03] [ENEMY] [ForceFieldEnemy] Registered as sound listener
+[15:49:03] [ENEMY] [ForceFieldEnemy] Spawned at (1600, 850), hp: 1, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:ArmoredSkinEnemy] Blood detector created and attached to ArmoredSkinEnemy
+[15:49:03] [INFO] [BloodyFeet:ArmoredSkinEnemy] Snow surface detector created on ArmoredSkinEnemy
+[15:49:03] [INFO] [SoundPropagation] Registered listener: ArmoredSkinEnemy (total: 14)
+[15:49:03] [ENEMY] [ArmoredSkinEnemy] Registered as sound listener
+[15:49:03] [ENEMY] [ArmoredSkinEnemy] Spawned at (1700, 1050), hp: 2, behavior: GUARD
+[15:49:03] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[15:49:03] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[15:49:03] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 14) - skipping fallback
+[15:49:03] [INFO] [WeaponHintsComponent] Strikethrough setup 'scope': 1 lines
+[15:49:03] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=14
+[15:49:03] [ENEMY] [FinalEnemy1] Patrol points snapped to navmesh (Issue #1216)
+[15:49:03] [ENEMY] [TopEnemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=157.5°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [TopEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [TopEnemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [BottomEnemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [BottomEnemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [BottomEnemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [ReloadGuard1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [ReloadGuard2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [ReloadGuard3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [ReloadGuard4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=135.0°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [ForceFieldEnemy] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [ENEMY] [ArmoredSkinEnemy] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(200,850), corner_timer=0.00
+[15:49:03] [INFO] [Player] Detecting weapon pose (frame 3)...
+[15:49:03] [INFO] [Player] Detected weapon: ASVK Sniper Rifle (Sniper pose)
+[15:49:03] [INFO] [Player] Applied Sniper arm pose: Left=(28, 6), Right=(-3, 6)
+[15:49:03] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[15:49:03] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[15:49:03] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[15:49:03] [INFO] [LastChance] Found player: Player
+[15:49:03] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[15:49:03] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[15:49:03] [INFO] [LastChance] Connected to player Died signal (C#)
+[15:49:03] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[15:49:03] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 2019 ms
+[15:49:04] [WARN] [FPS] Drop detected: 25 fps (threshold: 30)
+[15:49:04] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=14
+[15:49:05] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=14
+[15:49:06] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=14
+[15:49:07] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=14
+[15:49:08] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=14
+[15:49:08] [ENEMY] [FinalEnemy1] PATROL corner check: angle -0.0°
+[15:49:08] [ENEMY] [FinalEnemy1] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-0.0°, current=3.1°, player=(200,850), corner_timer=0.30
+[15:49:09] [ENEMY] [FinalEnemy1] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=90.0°, current=6.7°, player=(200,850), corner_timer=-0.02
+[15:49:09] [ENEMY] [FinalEnemy1] PATROL corner check: angle -0.0°
+[15:49:09] [ENEMY] [FinalEnemy1] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-0.0°, current=12.6°, player=(200,850), corner_timer=0.30
+[15:49:09] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=14
+[15:49:10] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:49:10] [INFO] [PersistManager] Last level saved: res://scenes/levels/LabyrinthLevel.tscn
+[15:49:10] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/LabyrinthLevel.tscn
+[15:49:10] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=14
+[15:49:10] [INFO] [SceneLoader] Background load started successfully
+[15:49:10] [INFO] [SceneLoader] Background load complete: res://scenes/levels/LabyrinthLevel.tscn
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: ArmoredSkinEnemy (remaining: 13)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: ForceFieldEnemy (remaining: 12)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: FinalEnemy2 (remaining: 11)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: FinalEnemy1 (remaining: 10)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: ReloadGuard4 (remaining: 9)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: ReloadGuard3 (remaining: 8)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: ReloadGuard2 (remaining: 7)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: ReloadGuard1 (remaining: 6)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: BottomEnemy3 (remaining: 5)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: BottomEnemy2 (remaining: 4)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: BottomEnemy1 (remaining: 3)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: TopEnemy3 (remaining: 2)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: TopEnemy2 (remaining: 1)
+[15:49:10] [INFO] [SoundPropagation] Unregistered listener: TopEnemy1 (remaining: 0)
+[15:49:10] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:49:10] [INFO] [SceneLoader] Scene changed successfully
+[15:49:10] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[15:49:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:10] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[15:49:10] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[15:49:10] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[15:49:10] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[15:49:10] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:49:10] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[15:49:10] [INFO] [LastChance] Resetting all effects (scene change detected)
+[15:49:10] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[15:49:10] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[15:49:10] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[15:49:10] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[15:49:10] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:49:10] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/LabyrinthLevel.tscn
+[15:49:10] [ENEMY] [Enemy1] Death animation component initialized
+[15:49:10] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[15:49:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:10] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[15:49:10] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[15:49:10] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[15:49:10] [ENEMY] [Enemy2] Death animation component initialized
+[15:49:10] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[15:49:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:10] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[15:49:10] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[15:49:10] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[15:49:10] [ENEMY] [Enemy3] Death animation component initialized
+[15:49:10] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[15:49:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:10] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[15:49:10] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[15:49:10] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[15:49:10] [ENEMY] [Enemy4] Death animation component initialized
+[15:49:10] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[15:49:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:10] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[15:49:10] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[15:49:10] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[15:49:10] [ENEMY] [Enemy5] Death animation component initialized
+[15:49:10] [ENEMY] [Enemy5] [Gunslinger] Enemy glow applied
+[15:49:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:10] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[15:49:10] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[15:49:10] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[15:49:10] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[15:49:10] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[15:49:10] [INFO] [Player.Weapon] GameManager weapon selection: sniper (SniperRifle)
+[15:49:10] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[15:49:10] [INFO] [Player.Weapon] Equipped SniperRifle (ammo: 12/5)
+[15:49:10] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[15:49:10] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[15:49:10] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[15:49:10] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[15:49:10] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[15:49:10] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[15:49:10] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[15:49:10] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[15:49:10] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[15:49:10] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[15:49:10] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[15:49:10] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[15:49:10] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[15:49:10] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[15:49:10] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[15:49:10] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[15:49:10] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[15:49:10] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[15:49:10] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[15:49:10] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[15:49:10] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[15:49:10] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[15:49:10] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[15:49:10] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[15:49:10] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[15:49:10] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[15:49:10] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[15:49:10] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[15:49:10] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[15:49:10] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[15:49:10] [INFO] [Player.Jammer] JammerHUD initialized
+[15:49:10] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[15:49:10] [INFO] [Player] Ready! Ammo: 12/5, Grenades: 1/3, Health: 2/4
+[15:49:10] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[15:49:10] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[15:49:10] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[15:49:10] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[15:49:10] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[15:49:10] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[15:49:10] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[15:49:10] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[15:49:10] [INFO] [LabyrinthLevel] Setting up weapon: sniper
+[15:49:10] [INFO] [LabyrinthLevel] SniperRifle already equipped by C# Player - applying labyrinth ammo config
+[15:49:10] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for sniper
+[15:49:10] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): SniperRifle 12/72
+[15:49:10] [INFO] [GameManager] set_player() called with: <CharacterBody2D#230216963907> (class: CharacterBody2D)
+[15:49:10] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[15:49:10] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[15:49:10] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[15:49:10] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[15:49:10] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[15:49:10] [INFO] [ScoreManager] Level started with 5 enemies
+[15:49:10] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[15:49:11] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[15:49:11] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[15:49:11] [INFO] [ReplayManager] Replay data cleared
+[15:49:11] [INFO] [LabyrinthLevel] Previous replay data cleared
+[15:49:11] [INFO] [ReplayManager] Detected player weapon: Sniper Rifle (ASVK)
+[15:49:11] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[15:49:11] [INFO] [ReplayManager] Level: LabyrinthLevel
+[15:49:11] [INFO] [ReplayManager] Player: Player (valid: True)
+[15:49:11] [INFO] [ReplayManager] Enemies count: 5
+[15:49:11] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/asvk_topdown.png
+[15:49:11] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[15:49:11] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[15:49:11] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[15:49:11] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[15:49:11] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[15:49:11] [INFO] [LabyrinthLevel] Replay recording started successfully
+[15:49:11] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[15:49:11] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[15:49:11] [INFO] [CinemaEffects] Found player node: Player
+[15:49:11] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[15:49:11] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[15:49:11] [ENEMY] [Enemy1] Registered as sound listener
+[15:49:11] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[15:49:11] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[15:49:11] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[15:49:11] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[15:49:11] [ENEMY] [Enemy2] Registered as sound listener
+[15:49:11] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[15:49:11] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[15:49:11] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[15:49:11] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[15:49:11] [ENEMY] [Enemy3] Registered as sound listener
+[15:49:11] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[15:49:11] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[15:49:11] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[15:49:11] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[15:49:11] [ENEMY] [Enemy4] Registered as sound listener
+[15:49:11] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[15:49:11] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[15:49:11] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[15:49:11] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[15:49:11] [ENEMY] [Enemy5] Registered as sound listener
+[15:49:11] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 1, behavior: GUARD
+[15:49:11] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[15:49:11] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[15:49:11] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[15:49:11] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[15:49:11] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:49:11] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=45.0°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:49:11] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=315.0°, current=0.0°, player=(150,1000), corner_timer=0.00
+[15:49:11] [INFO] [Player] Detecting weapon pose (frame 3)...
+[15:49:11] [INFO] [Player] Detected weapon: ASVK Sniper Rifle (Sniper pose)
+[15:49:11] [INFO] [Player] Applied Sniper arm pose: Left=(28, 6), Right=(-3, 6)
+[15:49:11] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[15:49:11] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[15:49:11] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[15:49:11] [INFO] [LastChance] Found player: Player
+[15:49:11] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[15:49:11] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[15:49:11] [INFO] [LastChance] Connected to player Died signal (C#)
+[15:49:11] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[15:49:12] [WARN] [FPS] Drop detected: 22 fps (threshold: 30)
+[15:49:12] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[15:49:12] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[15:49:12] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[15:49:13] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[15:49:14] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[15:49:14] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-54.4°, player=(150,1000), corner_timer=-0.02
+[15:49:14] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[15:49:14] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(150,1000), corner_timer=0.30
+[15:49:14] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[15:49:14] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[15:49:14] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[15:49:15] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[15:49:16] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=5
+[15:49:16] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=174.9°, current=-85.8°, player=(150,1000), corner_timer=-0.02
+[15:49:16] [ENEMY] [Enemy3] PATROL corner check: angle -95.1°
+[15:49:16] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-95.1°, current=-85.6°, player=(150,1000), corner_timer=0.30
+[15:49:17] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=5
+[15:49:18] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=5
+[15:49:18] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:49:18] [INFO] [PersistManager] Last level saved: res://scenes/levels/BuildingLevel.tscn
+[15:49:18] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/BuildingLevel.tscn
+[15:49:19] [INFO] [SceneLoader] Background load started successfully
+[15:49:19] [INFO] [SceneLoader] Background load complete: res://scenes/levels/BuildingLevel.tscn
+[15:49:19] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[15:49:19] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[15:49:19] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[15:49:19] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[15:49:19] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[15:49:19] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:49:19] [INFO] [SceneLoader] Scene changed successfully
+[15:49:19] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[15:49:19] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[15:49:19] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:49:19] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[15:49:19] [INFO] [LastChance] Resetting all effects (scene change detected)
+[15:49:19] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[15:49:19] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[15:49:19] [INFO] [BlackMetalEffectsManager] Scene changed to: BuildingLevel
+[15:49:19] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[15:49:19] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:49:19] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/BuildingLevel.tscn
+[15:49:19] [ENEMY] [Enemy1] Death animation component initialized
+[15:49:19] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[15:49:19] [ENEMY] [Enemy2] Death animation component initialized
+[15:49:19] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[15:49:19] [ENEMY] [Enemy3] Death animation component initialized
+[15:49:19] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[15:49:19] [ENEMY] [Enemy4] Death animation component initialized
+[15:49:19] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[15:49:19] [ENEMY] [Grenadier] Death animation component initialized
+[15:49:19] [ENEMY] [Grenadier] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[15:49:19] [ENEMY] [Enemy6] Death animation component initialized
+[15:49:19] [ENEMY] [Enemy6] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[15:49:19] [ENEMY] [Enemy7] Death animation component initialized
+[15:49:19] [ENEMY] [Enemy7] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[15:49:19] [ENEMY] [Enemy8] Death animation component initialized
+[15:49:19] [ENEMY] [Enemy8] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[15:49:19] [ENEMY] [Enemy9] Death animation component initialized
+[15:49:19] [ENEMY] [Enemy9] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[15:49:19] [ENEMY] [Enemy10] Death animation component initialized
+[15:49:19] [ENEMY] [Enemy10] [Gunslinger] Enemy glow applied
+[15:49:19] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:19] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[15:49:19] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[15:49:19] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[15:49:19] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[15:49:19] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[15:49:19] [INFO] [Player.Weapon] GameManager weapon selection: sniper (SniperRifle)
+[15:49:19] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[15:49:19] [INFO] [Player.Weapon] Equipped SniperRifle (ammo: 12/5)
+[15:49:19] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[15:49:19] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[15:49:19] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[15:49:19] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[15:49:19] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[15:49:19] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[15:49:19] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[15:49:19] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[15:49:19] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[15:49:19] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[15:49:19] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[15:49:19] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[15:49:19] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[15:49:19] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[15:49:19] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[15:49:19] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[15:49:19] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[15:49:19] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[15:49:19] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[15:49:19] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[15:49:19] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[15:49:19] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[15:49:19] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[15:49:19] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[15:49:19] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[15:49:19] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[15:49:19] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[15:49:19] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[15:49:19] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[15:49:19] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[15:49:19] [INFO] [Player.Jammer] JammerHUD initialized
+[15:49:19] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[15:49:19] [INFO] [Player] Ready! Ammo: 12/5, Grenades: 1/3, Health: 2/4
+[15:49:19] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[15:49:19] [INFO] [WeaponHintsComponent] Connected weapon signals for: sniper (node: SniperRifle)
+[15:49:19] [INFO] [WeaponHintsComponent] Hint added 'scope': [color=#ff4444][ПКМ][/color] Scope in
+[15:49:19] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: sniper
+[15:49:19] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[15:49:19] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[15:49:19] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[15:49:19] [INFO] [CinemaEffects] Found player node: Player
+[15:49:19] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[15:49:19] [ENEMY] [Enemy1] Registered as sound listener
+[15:49:19] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 1, behavior: GUARD
+[15:49:19] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[15:49:19] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[15:49:19] [ENEMY] [Enemy2] Registered as sound listener
+[15:49:19] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 1, behavior: GUARD
+[15:49:19] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[15:49:19] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[15:49:19] [ENEMY] [Enemy3] Registered as sound listener
+[15:49:19] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 1, behavior: GUARD
+[15:49:19] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[15:49:19] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[15:49:19] [ENEMY] [Enemy4] Registered as sound listener
+[15:49:19] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 1, behavior: GUARD
+[15:49:19] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[15:49:19] [INFO] [BloodyFeet:Grenadier] Snow surface detector created on Grenadier
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[15:49:19] [ENEMY] [Grenadier] Registered as sound listener
+[15:49:19] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 1, behavior: GUARD
+[15:49:19] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[15:49:19] [INFO] [BloodyFeet:Enemy6] Snow surface detector created on Enemy6
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[15:49:19] [ENEMY] [Enemy6] Registered as sound listener
+[15:49:19] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[15:49:19] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[15:49:19] [INFO] [BloodyFeet:Enemy7] Snow surface detector created on Enemy7
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[15:49:19] [ENEMY] [Enemy7] Registered as sound listener
+[15:49:19] [ENEMY] [Enemy7] Spawned at (1700, 870), hp: 1, behavior: PATROL
+[15:49:19] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[15:49:19] [INFO] [BloodyFeet:Enemy8] Snow surface detector created on Enemy8
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[15:49:19] [ENEMY] [Enemy8] Registered as sound listener
+[15:49:19] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[15:49:19] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[15:49:19] [INFO] [BloodyFeet:Enemy9] Snow surface detector created on Enemy9
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[15:49:19] [ENEMY] [Enemy9] Registered as sound listener
+[15:49:19] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[15:49:19] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[15:49:19] [INFO] [BloodyFeet:Enemy10] Snow surface detector created on Enemy10
+[15:49:19] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[15:49:19] [ENEMY] [Enemy10] Registered as sound listener
+[15:49:19] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 1, behavior: PATROL
+[15:49:19] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[15:49:19] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[15:49:19] [INFO] [WeaponHintsComponent] Strikethrough setup 'scope': 1 lines
+[15:49:19] [INFO] [LevelInitFallback] ConfigureBuildingCameraLimits: limits set — left=64 top=64 right=2464 bottom=2064 — Issue #1684
+[15:49:19] [INFO] [LevelInitFallback] GDScript _ready() did NOT execute - performing C# fallback initialization
+[15:49:19] [INFO] [LevelInitFallback] Полигон loaded (C# fallback) - Tactical Combat Arena
+[15:49:19] [INFO] [LevelInitFallback] Found Environment/Enemies node with 10 children
+[15:49:19] [INFO] [LevelInitFallback] Child 'Enemy1': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Child 'Enemy2': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Child 'Enemy3': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Child 'Enemy4': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Child 'Grenadier': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Child 'Enemy6': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Child 'Enemy7': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Child 'Enemy8': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Child 'Enemy9': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Child 'Enemy10': has_died_signal=True
+[15:49:19] [INFO] [LevelInitFallback] Enemy tracking complete: 10 enemies registered
+[15:49:19] [INFO] [LevelInitFallback] Realistic visibility component added to player (night mode)
+[15:49:19] [INFO] [GameManager] set_player() called with: <CharacterBody2D#301671125358> (class: CharacterBody2D)
+[15:49:19] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[15:49:19] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[15:49:19] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[15:49:19] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[15:49:19] [INFO] [LevelInitFallback] HUD ammo refreshed (fallback initial weapon setup): SniperRifle 12/72
+[15:49:19] [INFO] [LevelInitFallback] Re-applied auto-reload magazine reduction after fallback ammo config for SniperRifle
+[15:49:19] [INFO] [LevelInitFallback] HUD ammo refreshed (post fallback level ammo config): SniperRifle 12/72
+[15:49:19] [INFO] [LevelInitFallback] HUD ammo refreshed (post fallback debug UI setup): SniperRifle 12/72
+[15:49:19] [INFO] [ScoreManager] Level started with 10 enemies
+[15:49:19] [INFO] [LevelInitFallback] ScoreManager initialized with 10 enemies
+[15:49:19] [INFO] [LevelInitFallback] Exit zone created at position (120, 1250)
+[15:49:19] [INFO] [ReplayManager] Replay data cleared
+[15:49:19] [INFO] [ReplayManager] Detected player weapon: Sniper Rifle (ASVK)
+[15:49:19] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[15:49:19] [INFO] [ReplayManager] Level: BuildingLevel
+[15:49:19] [INFO] [ReplayManager] Player: Player (valid: True)
+[15:49:19] [INFO] [ReplayManager] Enemies count: 10
+[15:49:19] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/asvk_topdown.png
+[15:49:19] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[15:49:19] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[15:49:19] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[15:49:19] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[15:49:19] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[15:49:19] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[15:49:19] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[15:49:19] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[15:49:19] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[15:49:19] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[15:49:19] [INFO] [LevelInitFallback] Replay recording started with 10 enemies
+[15:49:19] [INFO] [LevelInitFallback] Weapon hints component already exists - skipping fallback setup
+[15:49:19] [INFO] [LevelInitFallback] GDScript properties synced
+[15:49:19] [INFO] [LevelInitFallback] Warm ceiling lights placed in all rooms (C# fallback)
+[15:49:19] [INFO] [LevelInitFallback] Baking navigation mesh (C# fallback)...
+[15:49:19] [INFO] [LevelInitFallback] Navigation mesh baked successfully (C# fallback) — poly_count=97, vertex_count=138
+[15:49:19] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[15:49:19] [ENEMY] [Enemy7] Patrol points snapped to navmesh (Issue #1216)
+[15:49:19] [ENEMY] [Enemy10] Patrol points snapped to navmesh (Issue #1216)
+[15:49:19] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[15:49:19] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[15:49:19] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[15:49:19] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[15:49:19] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[15:49:19] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[15:49:19] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=11.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[15:49:19] [INFO] [Player] Detecting weapon pose (frame 3)...
+[15:49:19] [INFO] [Player] Detected weapon: ASVK Sniper Rifle (Sniper pose)
+[15:49:19] [INFO] [Player] Applied Sniper arm pose: Left=(28, 6), Right=(-3, 6)
+[15:49:19] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[15:49:19] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[15:49:19] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[15:49:19] [INFO] [LastChance] Found player: Player
+[15:49:19] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[15:49:19] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[15:49:19] [INFO] [LastChance] Connected to player Died signal (C#)
+[15:49:19] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[15:49:20] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[15:49:20] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[15:49:21] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=90.0°, current=0.0°, player=(450,1250), corner_timer=0.30
+[15:49:21] [ENEMY] [Enemy10] ROT_CHANGE: none -> P4:velocity, state=IDLE, target=0.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[15:49:21] [ENEMY] [Enemy10] PATROL corner check: angle 90.0°
+[15:49:21] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=0.0°, player=(450,1250), corner_timer=0.30
+[15:49:21] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=54.4°, player=(450,1250), corner_timer=-0.02
+[15:49:21] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[15:49:21] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=51.6°, player=(450,1250), corner_timer=0.30
+[15:49:21] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[15:49:21] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=54.4°, player=(450,1250), corner_timer=-0.02
+[15:49:21] [ENEMY] [Enemy10] PATROL corner check: angle -90.0°
+[15:49:21] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=51.6°, player=(450,1250), corner_timer=0.30
+[15:49:22] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[15:49:23] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[15:49:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=84.3°, player=(450,1250), corner_timer=-0.02
+[15:49:23] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[15:49:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=84.1°, player=(450,1250), corner_timer=0.30
+[15:49:23] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=-93.8°, player=(450,1250), corner_timer=-0.02
+[15:49:23] [ENEMY] [Enemy10] PATROL corner check: angle 90.0°
+[15:49:23] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=-99.7°, player=(450,1250), corner_timer=0.30
+[15:49:23] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=180.0°, current=80.5°, player=(450,1250), corner_timer=-0.02
+[15:49:23] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[15:49:23] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=80.3°, player=(450,1250), corner_timer=0.30
+[15:49:23] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P1:visible, state=IDLE, target=-161.7°, current=-117.5°, player=(450,1250), corner_timer=0.25
+[15:49:23] [ENEMY] [Enemy10] State: IDLE -> COMBAT
+[15:49:23] [ENEMY] [Enemy10] Found cover at (1310.302, 1424) (distance: 133.4, player at (450, 1250))
+[15:49:24] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[15:49:25] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=10
+[15:49:26] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=10
+[15:49:27] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=10
+[15:49:27] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:49:27] [INFO] [PersistManager] Last level saved: res://scenes/levels/RailwayStationLevel.tscn
+[15:49:27] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/RailwayStationLevel.tscn
+[15:49:27] [INFO] [SceneLoader] Background load started successfully
+[15:49:27] [INFO] [SceneLoader] Background load complete: res://scenes/levels/RailwayStationLevel.tscn
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Enemy10 (remaining: 9)
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Enemy9 (remaining: 8)
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Enemy8 (remaining: 7)
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Enemy7 (remaining: 6)
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Enemy6 (remaining: 5)
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Grenadier (remaining: 4)
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[15:49:27] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[15:49:27] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:49:27] [INFO] [SceneLoader] Scene changed successfully
+[15:49:27] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[15:49:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:27] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Footprint scene loaded
+[15:49:27] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[15:49:27] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] BloodyFeetComponent ready on NearTracks_MachineGunnerLeft
+[15:49:27] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[15:49:27] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[15:49:27] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[15:49:27] [INFO] [LastChance] Resetting all effects (scene change detected)
+[15:49:27] [INFO] [CinemaEffects] Scene changed to: RailwayStationLevel
+[15:49:27] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[15:49:27] [INFO] [BlackMetalEffectsManager] Scene changed to: RailwayStationLevel
+[15:49:27] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[15:49:27] [INFO] [PersistManager] State saved to user://game_state.cfg
+[15:49:27] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RailwayStationLevel.tscn
+[15:49:27] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation component initialized
+[15:49:27] [ENEMY] [NearTracks_MachineGunnerLeft] [Gunslinger] Enemy glow applied
+[15:49:27] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:27] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Footprint scene loaded
+[15:49:27] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[15:49:27] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] BloodyFeetComponent ready on NearTracks_MachineGunnerRight
+[15:49:27] [ENEMY] [NearTracks_MachineGunnerRight] Death animation component initialized
+[15:49:28] [ENEMY] [NearTracks_MachineGunnerRight] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] BloodyFeetComponent ready on FarTracks_MachineGunnerLeft
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation component initialized
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerLeft] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] BloodyFeetComponent ready on FarTracks_MachineGunnerRight
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerRight] Death animation component initialized
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerRight] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] BloodyFeetComponent ready on CentralWalkway_ForceFieldLeft
+[15:49:28] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[15:49:28] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[15:49:28] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[15:49:28] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[15:49:28] [ENEMY] [CentralWalkway_ForceFieldLeft] Death animation component initialized
+[15:49:28] [ENEMY] [CentralWalkway_ForceFieldLeft] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] BloodyFeetComponent ready on CentralWalkway_ForceFieldRight
+[15:49:28] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[15:49:28] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[15:49:28] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[15:49:28] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[15:49:28] [ENEMY] [CentralWalkway_ForceFieldRight] Death animation component initialized
+[15:49:28] [ENEMY] [CentralWalkway_ForceFieldRight] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator1] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator1] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator1] BloodyFeetComponent ready on Exit_DroneOperator1
+[15:49:28] [ENEMY] [Exit_DroneOperator1] Death animation component initialized
+[15:49:28] [INFO] [DroneOperator] VR headset visual created
+[15:49:28] [INFO] [DroneOperator] Tablet visual created
+[15:49:28] [INFO] [DroneOperator] Setup complete
+[15:49:28] [ENEMY] [Exit_DroneOperator1] Found cover at (721.5328, 2040) (distance: 940.2, player at (2000, 3100))
+[15:49:28] [ENEMY] [Exit_DroneOperator1] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator2] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator2] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator2] BloodyFeetComponent ready on Exit_DroneOperator2
+[15:49:28] [ENEMY] [Exit_DroneOperator2] Death animation component initialized
+[15:49:28] [INFO] [DroneOperator] VR headset visual created
+[15:49:28] [INFO] [DroneOperator] Tablet visual created
+[15:49:28] [INFO] [DroneOperator] Setup complete
+[15:49:28] [ENEMY] [Exit_DroneOperator2] Found cover at (1602.407, 2040) (distance: 940.0, player at (2000, 3100))
+[15:49:28] [ENEMY] [Exit_DroneOperator2] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator3] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator3] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator3] BloodyFeetComponent ready on Exit_DroneOperator3
+[15:49:28] [ENEMY] [Exit_DroneOperator3] Death animation component initialized
+[15:49:28] [INFO] [DroneOperator] VR headset visual created
+[15:49:28] [INFO] [DroneOperator] Tablet visual created
+[15:49:28] [INFO] [DroneOperator] Setup complete
+[15:49:28] [ENEMY] [Exit_DroneOperator3] Found cover at (2440, 2040) (distance: 941.9, player at (2000, 3100))
+[15:49:28] [ENEMY] [Exit_DroneOperator3] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator4] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator4] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator4] BloodyFeetComponent ready on Exit_DroneOperator4
+[15:49:28] [ENEMY] [Exit_DroneOperator4] Death animation component initialized
+[15:49:28] [INFO] [DroneOperator] VR headset visual created
+[15:49:28] [INFO] [DroneOperator] Tablet visual created
+[15:49:28] [INFO] [DroneOperator] Setup complete
+[15:49:28] [ENEMY] [Exit_DroneOperator4] Found cover at (2440, 2040) (distance: 1274.0, player at (2000, 3100))
+[15:49:28] [ENEMY] [Exit_DroneOperator4] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] BloodyFeetComponent ready on Spawn_GasMaskEnemy
+[15:49:28] [ENEMY] [Spawn_GasMaskEnemy] Death animation component initialized
+[15:49:28] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[15:49:28] [ENEMY] [Spawn_GasMaskEnemy] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft1] BloodyFeetComponent ready on Platform_TeleporterLeft1
+[15:49:28] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft1
+[15:49:28] [ENEMY] [Platform_TeleporterLeft1] Death animation component initialized
+[15:49:28] [ENEMY] [Platform_TeleporterLeft1] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft2] BloodyFeetComponent ready on Platform_TeleporterLeft2
+[15:49:28] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft2
+[15:49:28] [ENEMY] [Platform_TeleporterLeft2] Death animation component initialized
+[15:49:28] [ENEMY] [Platform_TeleporterLeft2] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft3] BloodyFeetComponent ready on Platform_TeleporterLeft3
+[15:49:28] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft3
+[15:49:28] [ENEMY] [Platform_TeleporterLeft3] Death animation component initialized
+[15:49:28] [ENEMY] [Platform_TeleporterLeft3] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight1] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight1] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight1] BloodyFeetComponent ready on Platform_TeleporterRight1
+[15:49:28] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight1
+[15:49:28] [ENEMY] [Platform_TeleporterRight1] Death animation component initialized
+[15:49:28] [ENEMY] [Platform_TeleporterRight1] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight2] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight2] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight2] BloodyFeetComponent ready on Platform_TeleporterRight2
+[15:49:28] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight2
+[15:49:28] [ENEMY] [Platform_TeleporterRight2] Death animation component initialized
+[15:49:28] [ENEMY] [Platform_TeleporterRight2] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight3] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight3] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight3] BloodyFeetComponent ready on Platform_TeleporterRight3
+[15:49:28] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight3
+[15:49:28] [ENEMY] [Platform_TeleporterRight3] Death animation component initialized
+[15:49:28] [ENEMY] [Platform_TeleporterRight3] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Platform_ShieldRight] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Platform_ShieldRight] Found EnemyModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Platform_ShieldRight] BloodyFeetComponent ready on Platform_ShieldRight
+[15:49:28] [INFO] [EnemyShield] SWAT riot shield visual created with collision area (top-down view)
+[15:49:28] [INFO] [EnemyShield] Setup complete (shield_hp=20, stun=1.0s)
+[15:49:28] [ENEMY] [Platform_ShieldRight] Death animation component initialized
+[15:49:28] [ENEMY] [Platform_ShieldRight] [Gunslinger] Enemy glow applied
+[15:49:28] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[15:49:28] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[15:49:28] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[15:49:28] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[15:49:28] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[15:49:28] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[15:49:28] [INFO] [Player.Weapon] GameManager weapon selection: sniper (SniperRifle)
+[15:49:28] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[15:49:28] [INFO] [Player.Weapon] Equipped SniperRifle (ammo: 12/5)
+[15:49:28] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[15:49:28] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[15:49:28] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[15:49:28] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[15:49:28] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[15:49:28] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[15:49:28] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[15:49:28] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[15:49:28] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[15:49:28] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[15:49:28] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[15:49:28] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[15:49:28] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[15:49:28] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[15:49:28] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[15:49:28] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[15:49:28] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[15:49:28] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[15:49:28] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[15:49:28] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[15:49:28] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[15:49:28] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[15:49:28] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[15:49:28] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[15:49:28] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[15:49:28] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[15:49:28] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[15:49:28] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[15:49:28] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[15:49:28] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[15:49:28] [INFO] [Player.Jammer] JammerHUD initialized
+[15:49:28] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[15:49:28] [INFO] [Player] Ready! Ammo: 12/5, Grenades: 1/3, Health: 2/4
+[15:49:28] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[15:49:28] [INFO] [RailwayStationLevel] Found Environment/Enemies node with 18 children
+[15:49:28] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerRight': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerRight': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldLeft': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldRight': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator1': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator2': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator3': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator4': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Spawn_GasMaskEnemy': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft1': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft2': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft3': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight1': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight2': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight3': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Child 'Platform_ShieldRight': script=true, has_died_signal=true
+[15:49:28] [INFO] [RailwayStationLevel] Enemy tracking complete: 18 enemies registered
+[15:49:28] [INFO] [RailwayStationLevel] Setting up weapon: sniper
+[15:49:28] [INFO] [RailwayStationLevel] SniperRifle already equipped by C# Player - skipping GDScript weapon swap
+[15:49:28] [INFO] [GameManager] set_player() called with: <CharacterBody2D#437046483053> (class: CharacterBody2D)
+[15:49:28] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[15:49:28] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[15:49:28] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[15:49:28] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[15:49:28] [INFO] [ScoreManager] Level started with 18 enemies
+[15:49:28] [INFO] [RailwayStationLevel] ReplayManager found as C# autoload
+[15:49:28] [INFO] [ReplayManager] Replay data cleared
+[15:49:28] [INFO] [ReplayManager] Detected player weapon: Sniper Rifle (ASVK)
+[15:49:28] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[15:49:28] [INFO] [ReplayManager] Level: RailwayStationLevel
+[15:49:28] [INFO] [ReplayManager] Player: Player (valid: True)
+[15:49:28] [INFO] [ReplayManager] Enemies count: 18
+[15:49:28] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/asvk_topdown.png
+[15:49:28] [INFO] [ReplayManager]   Enemy 0: NearTracks_MachineGunnerLeft
+[15:49:28] [INFO] [ReplayManager]   Enemy 1: NearTracks_MachineGunnerRight
+[15:49:28] [INFO] [ReplayManager]   Enemy 2: FarTracks_MachineGunnerLeft
+[15:49:28] [INFO] [ReplayManager]   Enemy 3: FarTracks_MachineGunnerRight
+[15:49:28] [INFO] [ReplayManager]   Enemy 4: CentralWalkway_ForceFieldLeft
+[15:49:28] [INFO] [ReplayManager]   Enemy 5: CentralWalkway_ForceFieldRight
+[15:49:28] [INFO] [ReplayManager]   Enemy 6: Exit_DroneOperator1
+[15:49:28] [INFO] [ReplayManager]   Enemy 7: Exit_DroneOperator2
+[15:49:28] [INFO] [ReplayManager]   Enemy 8: Exit_DroneOperator3
+[15:49:28] [INFO] [ReplayManager]   Enemy 9: Exit_DroneOperator4
+[15:49:28] [INFO] [ReplayManager]   Enemy 10: Spawn_GasMaskEnemy
+[15:49:28] [INFO] [ReplayManager]   Enemy 11: Platform_TeleporterLeft1
+[15:49:28] [INFO] [ReplayManager]   Enemy 12: Platform_TeleporterLeft2
+[15:49:28] [INFO] [ReplayManager]   Enemy 13: Platform_TeleporterLeft3
+[15:49:28] [INFO] [ReplayManager]   Enemy 14: Platform_TeleporterRight1
+[15:49:28] [INFO] [ReplayManager]   Enemy 15: Platform_TeleporterRight2
+[15:49:28] [INFO] [ReplayManager]   Enemy 16: Platform_TeleporterRight3
+[15:49:28] [INFO] [ReplayManager]   Enemy 17: Platform_ShieldRight
+[15:49:28] [INFO] [WeaponHintsComponent] Connected weapon signals for: sniper (node: SniperRifle)
+[15:49:28] [INFO] [WeaponHintsComponent] Hint added 'scope': [color=#ff4444][ПКМ][/color] Scope in
+[15:49:28] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: sniper
+[15:49:28] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 18) - skipping fallback
+[15:49:28] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Blood detector created and attached to NearTracks_MachineGunnerLeft
+[15:49:28] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Snow surface detector created on NearTracks_MachineGunnerLeft
+[15:49:28] [INFO] [CinemaEffects] Found player node: Player
+[15:49:28] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[15:49:28] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerLeft (total: 1)
+[15:49:28] [ENEMY] [NearTracks_MachineGunnerLeft] Registered as sound listener
+[15:49:28] [ENEMY] [NearTracks_MachineGunnerLeft] Spawned at (300, 2670), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Blood detector created and attached to NearTracks_MachineGunnerRight
+[15:49:28] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Snow surface detector created on NearTracks_MachineGunnerRight
+[15:49:28] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerRight (total: 2)
+[15:49:28] [ENEMY] [NearTracks_MachineGunnerRight] Registered as sound listener
+[15:49:28] [ENEMY] [NearTracks_MachineGunnerRight] Spawned at (3700, 2670), hp: 2, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Blood detector created and attached to FarTracks_MachineGunnerLeft
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Snow surface detector created on FarTracks_MachineGunnerLeft
+[15:49:28] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerLeft (total: 3)
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerLeft] Registered as sound listener
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerLeft] Spawned at (300, 1890), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Blood detector created and attached to FarTracks_MachineGunnerRight
+[15:49:28] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Snow surface detector created on FarTracks_MachineGunnerRight
+[15:49:28] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerRight (total: 4)
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerRight] Registered as sound listener
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerRight] Spawned at (3700, 1890), hp: 2, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Blood detector created and attached to CentralWalkway_ForceFieldLeft
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Snow surface detector created on CentralWalkway_ForceFieldLeft
+[15:49:28] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldLeft (total: 5)
+[15:49:28] [ENEMY] [CentralWalkway_ForceFieldLeft] Registered as sound listener
+[15:49:28] [ENEMY] [CentralWalkway_ForceFieldLeft] Spawned at (1700, 2300), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Blood detector created and attached to CentralWalkway_ForceFieldRight
+[15:49:28] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Snow surface detector created on CentralWalkway_ForceFieldRight
+[15:49:28] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldRight (total: 6)
+[15:49:28] [ENEMY] [CentralWalkway_ForceFieldRight] Registered as sound listener
+[15:49:28] [ENEMY] [CentralWalkway_ForceFieldRight] Spawned at (2300, 2300), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator1] Blood detector created and attached to Exit_DroneOperator1
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator1] Snow surface detector created on Exit_DroneOperator1
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator1 (total: 7)
+[15:49:28] [ENEMY] [Exit_DroneOperator1] Registered as sound listener
+[15:49:28] [ENEMY] [Exit_DroneOperator1] Spawned at (700, 1100), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator2] Blood detector created and attached to Exit_DroneOperator2
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator2] Snow surface detector created on Exit_DroneOperator2
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator2 (total: 8)
+[15:49:28] [ENEMY] [Exit_DroneOperator2] Registered as sound listener
+[15:49:28] [ENEMY] [Exit_DroneOperator2] Spawned at (1600, 1100), hp: 2, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator3] Blood detector created and attached to Exit_DroneOperator3
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator3] Snow surface detector created on Exit_DroneOperator3
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator3 (total: 9)
+[15:49:28] [ENEMY] [Exit_DroneOperator3] Registered as sound listener
+[15:49:28] [ENEMY] [Exit_DroneOperator3] Spawned at (2500, 1100), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator4] Blood detector created and attached to Exit_DroneOperator4
+[15:49:28] [INFO] [BloodyFeet:Exit_DroneOperator4] Snow surface detector created on Exit_DroneOperator4
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator4 (total: 10)
+[15:49:28] [ENEMY] [Exit_DroneOperator4] Registered as sound listener
+[15:49:28] [ENEMY] [Exit_DroneOperator4] Spawned at (3300, 1100), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Blood detector created and attached to Spawn_GasMaskEnemy
+[15:49:28] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Snow surface detector created on Spawn_GasMaskEnemy
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Spawn_GasMaskEnemy (total: 11)
+[15:49:28] [ENEMY] [Spawn_GasMaskEnemy] Registered as sound listener
+[15:49:28] [ENEMY] [Spawn_GasMaskEnemy] Spawned at (900, 3075), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Blood detector created and attached to Platform_TeleporterLeft1
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Snow surface detector created on Platform_TeleporterLeft1
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft1 (total: 12)
+[15:49:28] [ENEMY] [Platform_TeleporterLeft1] Registered as sound listener
+[15:49:28] [ENEMY] [Platform_TeleporterLeft1] Spawned at (200, 3500), hp: 2, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Blood detector created and attached to Platform_TeleporterLeft2
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Snow surface detector created on Platform_TeleporterLeft2
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft2 (total: 13)
+[15:49:28] [ENEMY] [Platform_TeleporterLeft2] Registered as sound listener
+[15:49:28] [ENEMY] [Platform_TeleporterLeft2] Spawned at (400, 3500), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Blood detector created and attached to Platform_TeleporterLeft3
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Snow surface detector created on Platform_TeleporterLeft3
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft3 (total: 14)
+[15:49:28] [ENEMY] [Platform_TeleporterLeft3] Registered as sound listener
+[15:49:28] [ENEMY] [Platform_TeleporterLeft3] Spawned at (600, 3500), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight1] Blood detector created and attached to Platform_TeleporterRight1
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight1] Snow surface detector created on Platform_TeleporterRight1
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight1 (total: 15)
+[15:49:28] [ENEMY] [Platform_TeleporterRight1] Registered as sound listener
+[15:49:28] [ENEMY] [Platform_TeleporterRight1] Spawned at (3400, 3500), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight2] Blood detector created and attached to Platform_TeleporterRight2
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight2] Snow surface detector created on Platform_TeleporterRight2
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight2 (total: 16)
+[15:49:28] [ENEMY] [Platform_TeleporterRight2] Registered as sound listener
+[15:49:28] [ENEMY] [Platform_TeleporterRight2] Spawned at (3600, 3500), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight3] Blood detector created and attached to Platform_TeleporterRight3
+[15:49:28] [INFO] [BloodyFeet:Platform_TeleporterRight3] Snow surface detector created on Platform_TeleporterRight3
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight3 (total: 17)
+[15:49:28] [ENEMY] [Platform_TeleporterRight3] Registered as sound listener
+[15:49:28] [ENEMY] [Platform_TeleporterRight3] Spawned at (3800, 3500), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Platform_ShieldRight] Blood detector created and attached to Platform_ShieldRight
+[15:49:28] [INFO] [BloodyFeet:Platform_ShieldRight] Snow surface detector created on Platform_ShieldRight
+[15:49:28] [INFO] [SoundPropagation] Registered listener: Platform_ShieldRight (total: 18)
+[15:49:28] [ENEMY] [Platform_ShieldRight] Registered as sound listener
+[15:49:28] [ENEMY] [Platform_ShieldRight] Spawned at (3600, 3650), hp: 1, behavior: GUARD
+[15:49:28] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[15:49:28] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[15:49:28] [INFO] [WeaponHintsComponent] Strikethrough setup 'scope': 1 lines
+[15:49:28] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=18
+[15:49:28] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[15:49:28] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=0.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=0.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[15:49:28] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[15:49:28] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[15:49:28] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[15:49:28] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=-90.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [INFO] [Player] Detecting weapon pose (frame 3)...
+[15:49:28] [INFO] [Player] Detected weapon: ASVK Sniper Rifle (Sniper pose)
+[15:49:28] [INFO] [Player] Applied Sniper arm pose: Left=(28, 6), Right=(-3, 6)
+[15:49:28] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P5:idle_scan -> P1:visible, state=IDLE, target=2.0°, current=5.7°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [Spawn_GasMaskEnemy] State: IDLE -> COMBAT
+[15:49:28] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (761.3854, 3378.52) (distance: 346.5, player at (2000, 3100))
+[15:49:28] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[15:49:28] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[15:49:28] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[15:49:28] [INFO] [LastChance] Found player: Player
+[15:49:28] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[15:49:28] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[15:49:28] [INFO] [LastChance] Connected to player Died signal (C#)
+[15:49:28] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[15:49:28] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1025.458, 3052.123), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:28] [ENEMY] [NearTracks_MachineGunnerLeft] Heard gunshot at (1025.458, 3052.123), intensity=0.00, distance=820
+[15:49:28] [ENEMY] [Platform_TeleporterLeft2] Heard gunshot at (1025.458, 3052.123), intensity=0.00, distance=769
+[15:49:28] [ENEMY] [Platform_TeleporterLeft3] Heard gunshot at (1025.458, 3052.123), intensity=0.01, distance=618
+[15:49:28] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[15:49:28] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: none -> P2:combat_state, state=COMBAT, target=-14.0°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-15.9°, current=77.3°, player=(2000,3100), corner_timer=0.00
+[15:49:28] [ENEMY] [Platform_TeleporterLeft3] Found cover at (724.6032, 3494.945) (distance: 124.7, player at (2000, 3100))
+[15:49:29] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: none -> P2:combat_state, state=COMBAT, target=14.2°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:49:29] [INFO] [Drone] _ready started
+[15:49:29] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[15:49:29] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[15:49:29] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[15:49:29] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[15:49:29] [INFO] [Drone] Initialized by operator: Exit_DroneOperator1
+[15:49:29] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[15:49:29] [INFO] [DroneOperator] Connected to drone.died signal
+[15:49:29] [INFO] [DroneOperator] Drone deployed at (700, 1084)
+[15:49:29] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[15:49:29] [INFO] [Drone] _ready started
+[15:49:29] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[15:49:29] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[15:49:29] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[15:49:29] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[15:49:29] [INFO] [Drone] Initialized by operator: Exit_DroneOperator2
+[15:49:29] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[15:49:29] [INFO] [DroneOperator] Connected to drone.died signal
+[15:49:29] [INFO] [DroneOperator] Drone deployed at (1600, 1060)
+[15:49:29] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[15:49:29] [INFO] [Drone] _ready started
+[15:49:29] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[15:49:29] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[15:49:29] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[15:49:29] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[15:49:29] [INFO] [Drone] Initialized by operator: Exit_DroneOperator3
+[15:49:29] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[15:49:29] [INFO] [DroneOperator] Connected to drone.died signal
+[15:49:29] [INFO] [DroneOperator] Drone deployed at (2500, 1084)
+[15:49:29] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[15:49:29] [INFO] [Drone] _ready started
+[15:49:29] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[15:49:29] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[15:49:29] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[15:49:29] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[15:49:29] [INFO] [Drone] Initialized by operator: Exit_DroneOperator4
+[15:49:29] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[15:49:29] [INFO] [DroneOperator] Connected to drone.died signal
+[15:49:29] [INFO] [DroneOperator] Drone deployed at (3300, 1084)
+[15:49:29] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[15:49:29] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1043.755, 3067.692), source=NEUTRAL (null), range=900, listeners=18
+[15:49:29] [ENEMY] [NearTracks_MachineGunnerLeft] Heard CASING_KICK at (1043.755, 3067.692), intensity=0.00, dist=843
+[15:49:29] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1043.755, 3067.692), intensity=1.00, dist=32
+[15:49:29] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (1043.755, 3067.692), intensity=0.00, dist=775
+[15:49:29] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1043.755, 3067.692), intensity=0.01, dist=582
+[15:49:29] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=14, self=0
+[15:49:29] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[15:49:29] [INFO] [GrenadeBase] Grenade created at (1121.343, 3056.834) (frozen)
+[15:49:29] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[15:49:29] [INFO] [GrenadeBase] LEGACY throw_grenade() called! Direction: (0.990067, 0.140594), Speed: 1352.8 (unfrozen)
+[15:49:29] [INFO] [GrenadeBase] NOTE: Using DRAG-BASED system. If velocity-based is expected, ensure grenade has throw_grenade_velocity_based() method.
+[15:49:29] [INFO] [GasMaskGrenade] Chemical grenade thrown at (2000, 3100) (remaining: 3)
+[15:49:29] [INFO] [GrenadeBase] Collision detected with Spawn_GasMaskEnemy (type: CharacterBody2D)
+[15:49:29] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1174.612, 3059.451), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:29] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=16, self=1
+[15:49:29] [ENEMY] [Platform_TeleporterLeft3] State: COMBAT -> PURSUING
+[15:49:29] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=18
+[15:49:29] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1185.59, 3077.22), source=NEUTRAL (null), range=900, listeners=18
+[15:49:29] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1185.59, 3077.22), intensity=1.00, dist=40
+[15:49:29] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (1185.59, 3077.22), intensity=0.00, dist=892
+[15:49:29] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1185.59, 3077.22), intensity=0.01, dist=574
+[15:49:29] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=15, self=0
+[15:49:29] [WARN] [FPS] Drop detected: 15 fps (threshold: 30)
+[15:49:29] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:29] [INFO] [ScoreManager] Damage taken: 1 (total: 1)
+[15:49:29] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.99974453, 0.022602439), lethal=False (C#)
+[15:49:29] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:29] [INFO] [BloodDecal] Blood puddle created at (2059, 3101.356) (added to group)
+[15:49:29] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 1.0
+[15:49:29] [INFO] [PenultimateHit] Triggering penultimate hit effect (HP: 1.0)
+[15:49:29] [INFO] [PenultimateHit] Starting penultimate hit effect:
+[15:49:29] [INFO] [PenultimateHit]   - Time scale: 0.10
+[15:49:29] [INFO] [PenultimateHit]   - Saturation boost: 2.00 (3.0x)
+[15:49:29] [INFO] [PenultimateHit]   - Contrast boost: 1.00 (2.0x)
+[15:49:29] [INFO] [PenultimateHit]   - Duration: 3.0 real seconds
+[15:49:29] [INFO] [PenultimateHit] Applied shader parameters: saturation=2.00, contrast=1.00
+[15:49:29] [INFO] [PenultimateHit] Applying saturation to 22 enemies
+[15:49:29] [INFO] [PenultimateHit] Applied 4.0x saturation to 6 player sprites
+[15:49:29] [INFO] [LastChance] Player health updated (C# Damaged): 1.0
+[15:49:30] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1323.766, 3066.778), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:30] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=16, self=1
+[15:49:30] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1299.733, 3077.911), source=NEUTRAL (null), range=900, listeners=18
+[15:49:30] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1299.733, 3077.911), intensity=0.00, dist=875
+[15:49:30] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1299.733, 3077.911), intensity=1.00, dist=27
+[15:49:30] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1299.733, 3077.911), intensity=0.01, dist=667
+[15:49:30] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=15, self=0
+[15:49:30] [INFO] [ReplayManager] Recording frame 120 (1,4s): player_valid=True, enemies=18
+[15:49:31] [INFO] [Player] Invincibility mode: ON
+[15:49:31] [INFO] [GameManager] Invincibility mode toggled: ON
+[15:49:31] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1356.261, 3068.372), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:31] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=16, self=1
+[15:49:31] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1338.806, 3083.239), source=NEUTRAL (null), range=900, listeners=18
+[15:49:31] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1338.806, 3083.239), intensity=0.00, dist=863
+[15:49:31] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1338.806, 3083.239), intensity=1.00, dist=24
+[15:49:31] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1338.806, 3083.239), intensity=0.01, dist=698
+[15:49:31] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=15, self=0
+[15:49:31] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[15:49:31] [INFO] [ReplayManager] Recording frame 180 (1,5s): player_valid=True, enemies=18
+[15:49:32] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1388.757, 3069.965), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:32] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard gunshot at (1388.757, 3069.965), intensity=0.00, distance=830
+[15:49:32] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[15:49:32] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=69.4°, current=56.2°, player=(2000,3100), corner_timer=0.00
+[15:49:32] [ENEMY] [CentralWalkway_ForceFieldLeft] Found cover at (1758.679, 2656.264) (distance: 361.1, player at (2000, 3100))
+[15:49:32] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1369.645, 3084.06), source=NEUTRAL (null), range=900, listeners=18
+[15:49:32] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1369.645, 3084.06), intensity=0.00, dist=850
+[15:49:32] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1369.645, 3084.06), intensity=1.00, dist=25
+[15:49:32] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1369.645, 3084.06), intensity=0.00, dist=724
+[15:49:32] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=15, self=0
+[15:49:32] [INFO] [ReplayManager] Recording frame 240 (1,6s): player_valid=True, enemies=18
+[15:49:32] [INFO] [ScoreManager] Damage taken: 1 (total: 2)
+[15:49:32] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:32] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.9999823, 0.0059648976), lethal=False (C#)
+[15:49:32] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:32] [INFO] [BloodDecal] Blood puddle created at (2059, 3100.358) (added to group)
+[15:49:32] [INFO] [PenultimateHit] Effect duration expired after 3.01 real seconds
+[15:49:32] [INFO] [PenultimateHit] Ending penultimate hit effect
+[15:49:32] [INFO] [PenultimateHit] Starting visual effects fade-out over 400ms
+[15:49:32] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1418.849, 3066.22), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:32] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[15:49:32] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1403.197, 3083.016), source=NEUTRAL (null), range=900, listeners=18
+[15:49:32] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1403.197, 3083.016), intensity=0.00, dist=807
+[15:49:32] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1403.197, 3083.016), intensity=1.00, dist=33
+[15:49:32] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1403.197, 3083.016), intensity=0.00, dist=754
+[15:49:32] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=15, self=0
+[15:49:33] [INFO] [ImpactEffects] [ImpactEffects] water_body group empty on scene 'RailwayStationLevel' — blood-in-water check unavailable (Issue #1578)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2087.116, 3169.139) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2127.233, 3171.25) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2121.625, 3162.376) (added to group)
+[15:49:33] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[15:49:33] [INFO] [GrenadeBase] Grenade created at (1459.158, 3052.239) (frozen)
+[15:49:33] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[15:49:33] [INFO] [GrenadeBase] LEGACY throw_grenade() called! Direction: (0.999975, -0.007037), Speed: 1085.9 (unfrozen)
+[15:49:33] [INFO] [GrenadeBase] NOTE: Using DRAG-BASED system. If velocity-based is expected, ensure grenade has throw_grenade_velocity_based() method.
+[15:49:33] [INFO] [GasMaskGrenade] Chemical grenade thrown at (2000, 3100) (remaining: 2)
+[15:49:33] [INFO] [GrenadeBase] Collision detected with Spawn_GasMaskEnemy (type: CharacterBody2D)
+[15:49:33] [INFO] [GrenadeBase] Collision detected with PlatformBench2 (type: StaticBody2D)
+[15:49:33] [INFO] [ChemicalGasGrenade] Hit obstacle 'PlatformBench2' — detonating on contact
+[15:49:33] [INFO] [ChemicalGasGrenade] Gas released at (1498.841, 3077.207)!
+[15:49:33] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(1498.841, 3077.207), source=NEUTRAL (@RigidBody2D@8272), range=1469, listeners=18
+[15:49:33] [ENEMY] [CentralWalkway_ForceFieldRight] Heard EXPLOSION at (1498.841, 3077.207), intensity=0.00, distance=1116
+[15:49:33] [ENEMY] [Platform_TeleporterLeft1] Heard EXPLOSION at (1498.841, 3077.207), intensity=0.00, distance=1366
+[15:49:33] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=11, self=0
+[15:49:33] [INFO] [ChemicalGasGrenade] Spawning cloud with 5.62s grow-in matching sound
+[15:49:33] [INFO] [ChemicalCloud] _ready() at (1498.841, 3077.207)
+[15:49:33] [INFO] [ChemicalCloud] Particle system created
+[15:49:33] [INFO] [ChemicalCloud] Cloud spawned at (1498.841, 3077.207), radius=600, duration=20s
+[15:49:33] [INFO] [ChemicalGasGrenade] Chemical cloud spawned at (1498.841, 3077.207) (radius=600, duration=20s, grow_in=5.62s)
+[15:49:33] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: none -> P2:combat_state, state=COMBAT, target=110.6°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[15:49:33] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-12.5°, current=-22.5°, player=(2000,3100), corner_timer=0.00
+[15:49:33] [ENEMY] [Platform_TeleporterLeft1] Found cover at (723.9988, 3413.163) (distance: 531.1, player at (2000, 3100))
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2122.352, 3182.41) (added to group)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2145.777, 3211.797) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2124.553, 3162.245) (added to group)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2084.738, 3153.996) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2097.505, 3136.859) (added to group)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2168.924, 3251.325) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2104.497, 3130.712) (added to group)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [PenultimateHit] Visual effects fade-out complete
+[15:49:33] [INFO] [PenultimateHit] Restored original colors to 5 player sprites
+[15:49:33] [INFO] [PenultimateHit] Called player RefreshHealthVisual (C#)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2129.397, 3158.68) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2107.624, 3197.912) (added to group)
+[15:49:33] [ENEMY] [CentralWalkway_ForceFieldLeft] State: COMBAT -> PURSUING
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ScoreManager] Damage taken: 1 (total: 3)
+[15:49:33] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:33] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.99739957, 0.07207074), lethal=False (C#)
+[15:49:33] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2059, 3104.335) (added to group)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2126.396, 3199.909) (added to group)
+[15:49:33] [INFO] [GrenadeBase] Collision detected with StationBuilding (type: StaticBody2D)
+[15:49:33] [INFO] [ChemicalGasGrenade] Hit obstacle 'StationBuilding' — detonating on contact
+[15:49:33] [INFO] [ChemicalGasGrenade] Gas released at (2972.789, 3340.842)!
+[15:49:33] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(2972.789, 3340.842), source=NEUTRAL (ChemicalGasGrenade), range=1469, listeners=18
+[15:49:33] [ENEMY] [NearTracks_MachineGunnerRight] Heard EXPLOSION at (2972.789, 3340.842), intensity=0.00, distance=989
+[15:49:33] [ENEMY] [Platform_TeleporterRight1] Heard EXPLOSION at (2972.789, 3340.842), intensity=0.01, distance=456
+[15:49:33] [ENEMY] [Platform_TeleporterRight2] Heard EXPLOSION at (2972.789, 3340.842), intensity=0.01, distance=647
+[15:49:33] [ENEMY] [Platform_TeleporterRight3] Heard EXPLOSION at (2972.789, 3340.842), intensity=0.00, distance=842
+[15:49:33] [ENEMY] [Platform_ShieldRight] Heard EXPLOSION at (2972.789, 3340.842), intensity=0.01, distance=699
+[15:49:33] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=12, self=0
+[15:49:33] [INFO] [ChemicalGasGrenade] Spawning cloud with 5.62s grow-in matching sound
+[15:49:33] [INFO] [ChemicalCloud] _ready() at (2972.789, 3340.842)
+[15:49:33] [INFO] [ChemicalCloud] Particle system created
+[15:49:33] [INFO] [ChemicalCloud] Cloud spawned at (2972.789, 3340.842), radius=600, duration=20s
+[15:49:33] [INFO] [ChemicalGasGrenade] Chemical cloud spawned at (2972.789, 3340.842) (radius=600, duration=20s, grow_in=5.62s)
+[15:49:33] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=165.8°, current=-180.0°, player=(2000,3100), corner_timer=0.00
+[15:49:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:33] [ENEMY] [FarTracks_MachineGunnerRight] Heard gunshot at (3700, 2670), intensity=0.00, distance=780
+[15:49:33] [INFO] [SoundPropagation] Sound result: notified=10, out_of_range=7, self=1
+[15:49:33] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=499
+[15:49:33] [ENEMY] [FarTracks_MachineGunnerRight] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=144.6°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[15:49:33] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-164.1°, current=-101.3°, player=(2000,3100), corner_timer=0.00
+[15:49:33] [ENEMY] [Platform_TeleporterRight1] Found cover at (3275.396, 3494.945) (distance: 124.7, player at (2000, 3100))
+[15:49:33] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-166.0°, current=-33.8°, player=(2000,3100), corner_timer=0.00
+[15:49:33] [ENEMY] [Platform_TeleporterRight2] Found cover at (3269.906, 3427.39) (distance: 338.0, player at (2000, 3100))
+[15:49:33] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-167.5°, current=78.7°, player=(2000,3100), corner_timer=0.00
+[15:49:33] [ENEMY] [Platform_TeleporterRight3] Found cover at (3263.501, 3593.948) (distance: 544.7, player at (2000, 3100))
+[15:49:33] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P5:idle_scan -> P2:shield_delayed, state=COMBAT, target=-161.0°, current=-145.0°, player=(2000,3100), corner_timer=0.00
+[15:49:33] [ENEMY] [Platform_ShieldRight] Found cover at (3274.059, 3590.884) (distance: 331.3, player at (2000, 3100))
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1535.837, 3029.472), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:33] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=16, self=1
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [WARN] [FPS] Drop detected: 28 fps (threshold: 30)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2174.34, 3170.632) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2125.339, 3195.401) (added to group)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ScoreManager] Damage taken: 1 (total: 4)
+[15:49:33] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:33] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.99562055, 0.09348671), lethal=False (C#)
+[15:49:33] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2059, 3105.634) (added to group)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:33] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=498
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ReplayManager] Recording frame 300 (2,3s): player_valid=True, enemies=18
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2174.162, 3190.032) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2181.221, 3214.196) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2146.203, 3217.029) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2187.499, 3179.509) (added to group)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [ENEMY] [Platform_TeleporterLeft1] State: COMBAT -> PURSUING
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2136.118, 3193.017) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2217.235, 3162.033) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2103.366, 3141.222) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2076.598, 3139.894) (added to group)
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2057.105, 3116.398) (added to group)
+[15:49:33] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=497
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [ENEMY] [Platform_TeleporterLeft3] FLANKING started: target=(1858.895, 2958.26), side=right, pos=(736.6976, 3435.454)
+[15:49:33] [ENEMY] [Platform_TeleporterLeft3] State: PURSUING -> FLANKING
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [Teleporter] Teleported from (736.6976, 3435.454) to (1858.895, 2958.26)
+[15:49:33] [ENEMY] [Platform_TeleporterLeft3] State: FLANKING -> COMBAT
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [ENEMY] [Platform_TeleporterLeft3] Found cover at (1742.342, 2943.569) (distance: 117.5, player at (2000, 3100))
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2053.669, 3134.104) (added to group)
+[15:49:33] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:33] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:33] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=496
+[15:49:33] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=45.1°, current=-0.2°, player=(2000,3100), corner_timer=0.00
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:33] [INFO] [ScoreManager] Damage taken: 1 (total: 5)
+[15:49:33] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:33] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.99285275, 0.1193457), lethal=False (C#)
+[15:49:33] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:33] [INFO] [BloodDecal] Blood puddle created at (2059, 3107.212) (added to group)
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:33] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1535.837, 3029.472), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2078.482, 3156.932) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2065.547, 3161.347) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2116.257, 3130.923) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2072.256, 3181.517) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2099.856, 3192.741) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2047.755, 3139.895) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2065.745, 3137.52) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2061.908, 3132.157) (added to group)
+[15:49:34] [ENEMY] [Platform_TeleporterRight1] State: COMBAT -> PURSUING
+[15:49:34] [ENEMY] [Platform_TeleporterRight2] State: COMBAT -> PURSUING
+[15:49:34] [ENEMY] [Platform_TeleporterRight3] State: COMBAT -> PURSUING
+[15:49:34] [ENEMY] [Platform_ShieldRight] State: COMBAT -> PURSUING
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=495
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2114.282, 3205.871) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2153.855, 3250.19) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2132.553, 3238.497) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2153.547, 3268.074) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2151.402, 3244.307) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2159.336, 3193.663) (added to group)
+[15:49:34] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[15:49:34] [INFO] [GrenadeBase] Grenade created at (1535.837, 3029.472) (frozen)
+[15:49:34] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[15:49:34] [INFO] [GrenadeBase] LEGACY throw_grenade() called! Direction: (0.972548, 0.232704), Speed: 939.0 (unfrozen)
+[15:49:34] [INFO] [GrenadeBase] NOTE: Using DRAG-BASED system. If velocity-based is expected, ensure grenade has throw_grenade_velocity_based() method.
+[15:49:34] [INFO] [GasMaskGrenade] Chemical grenade thrown at (2000, 3100) (remaining: 1)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [GrenadeBase] Collision detected with Spawn_GasMaskEnemy (type: CharacterBody2D)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 6)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.99475306, 0.10230514), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2059, 3106.171) (added to group)
+[15:49:34] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=494
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2188.856, 3167.536) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2170.967, 3294.598) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2107.88, 3137.089) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2074.125, 3125.789) (added to group)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1858.895, 2958.26), source=ENEMY (Platform_TeleporterLeft3), range=840, listeners=18
+[15:49:34] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=493
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 7)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.70283985, 0.7113481), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2153.775, 3203.246) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2095.57, 3158.483) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2074.523, 3154.165) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2142.384, 3137.106) (added to group)
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 8)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.99236405, 0.12334359), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2059, 3107.458) (added to group)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2098.814, 3203.945) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2106.13, 3228.512) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2099.596, 3156.526) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2122.265, 3187.847) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2037.356, 3135.035) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2050.039, 3120.287) (added to group)
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 9)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.7106561, 0.70353955), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:34] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:34] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=492
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2153.755, 3167.273) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2176.287, 3297.941) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2088.465, 3181.688) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2084.929, 3156.292) (added to group)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 10)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.7016998, 0.7124728), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=491
+[15:49:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1535.837, 3029.472), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:34] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [WARN] [FPS] Drop detected: 10 fps (threshold: 30)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2096.58, 3207.506) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2086.722, 3174.105) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2026.697, 3214.168) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2067.911, 3220.438) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2049.58, 3222.95) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2046.844, 3127.271) (added to group)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ReplayManager] Recording frame 360 (3,3s): player_valid=True, enemies=18
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 11)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.70801723, 0.70619524), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=490
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2078.28, 3144.522) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2112.516, 3199.079) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2136.084, 3242.085) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2124.099, 3175.211) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2180.149, 3216.715) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2052.428, 3179.021) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2035.615, 3225.194) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2076.152, 3189.975) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2041.813, 3143.401) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2038.544, 3149.334) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2043.682, 3150.199) (added to group)
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 12)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.993031, 0.11785327), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2059, 3107.121) (added to group)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 13)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.7100301, 0.7041714), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2199, 3163.07) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2126.459, 3286.504) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2101.953, 3208.536) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2056.026, 3232.734) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2075.969, 3281.373) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2139.317, 3223.076) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2119.937, 3276.536) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2148.385, 3271.881) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2170.497, 3163.472) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2094.496, 3159.109) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2114.312, 3170.257) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2082.335, 3152.313) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2069.813, 3173.128) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2032.295, 3215.438) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2072.362, 3189.544) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2060.681, 3143.93) (added to group)
+[15:49:34] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=489
+[15:49:34] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1858.895, 2958.26), source=ENEMY (Platform_TeleporterLeft3), range=840, listeners=18
+[15:49:34] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 14)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.9928753, 0.11915844), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2059, 3107.201) (added to group)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [ScoreManager] Damage taken: 1 (total: 15)
+[15:49:34] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:34] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.69032, 0.72350425), lethal=False (C#)
+[15:49:34] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:34] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2111.686, 3167.289) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2136.545, 3202.271) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2172.738, 3239.77) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2130.698, 3218.3) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2085.777, 3239.111) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2085.882, 3209.625) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2085.761, 3205.396) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2105.081, 3204.968) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2065.064, 3168.201) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2056.854, 3194.783) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2092.566, 3201.348) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2055.455, 3181.323) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2042.036, 3189.996) (added to group)
+[15:49:34] [INFO] [BloodDecal] Blood puddle created at (2071.454, 3144.025) (added to group)
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:35] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:35] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=488
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ScoreManager] Damage taken: 1 (total: 16)
+[15:49:35] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:35] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.99393463, 0.10997258), lethal=False (C#)
+[15:49:35] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2059, 3106.639) (added to group)
+[15:49:35] [ENEMY] [CentralWalkway_ForceFieldLeft] PURSUING corner check: angle -118.2°
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ScoreManager] Damage taken: 1 (total: 17)
+[15:49:35] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:35] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.70115703, 0.7130069), lethal=False (C#)
+[15:49:35] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2118.648, 3264.995) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2140.982, 3272.377) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2162.565, 3272.563) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2111.037, 3207.631) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2063.518, 3257.906) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2081.832, 3232.967) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2064.079, 3182.473) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2111.419, 3182.204) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2044.992, 3167.67) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2088.369, 3184.778) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2047.565, 3150.632) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2042.82, 3110.559) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2059.897, 3127.607) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2022.831, 3170.022) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2049.128, 3176.22) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2040.323, 3126.34) (added to group)
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=487
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ScoreManager] Damage taken: 1 (total: 18)
+[15:49:35] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:35] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.7346231, 0.6784755), lethal=False (C#)
+[15:49:35] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1535.837, 3029.472), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[15:49:35] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2162.122, 3287.604) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2118.876, 3287.867) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2031.927, 3270.073) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2147.212, 3293.03) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2133.024, 3280.574) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2173.303, 3264.597) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2065.708, 3320.481) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2069.304, 3231.254) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2074.838, 3226.201) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2092.302, 3242.178) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2080.113, 3127.251) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2060.449, 3117.281) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2074.706, 3119.072) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2065.557, 3147.989) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2087.231, 3197.336) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2060.702, 3116.471) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2077.611, 3157.981) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2050.909, 3210.836) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2070.273, 3178.631) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2082.265, 3167.208) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2051.973, 3106.938) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2048.332, 3200.514) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2029.032, 3202.073) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2052.923, 3166.056) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2019.793, 3174.481) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2089.701, 3166.581) (added to group)
+[15:49:35] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[15:49:35] [INFO] [GrenadeBase] Grenade created at (1535.837, 3029.472) (frozen)
+[15:49:35] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[15:49:35] [INFO] [GrenadeBase] LEGACY throw_grenade() called! Direction: (0.990285, 0.139051), Speed: 939.0 (unfrozen)
+[15:49:35] [INFO] [GrenadeBase] NOTE: Using DRAG-BASED system. If velocity-based is expected, ensure grenade has throw_grenade_velocity_based() method.
+[15:49:35] [INFO] [GasMaskGrenade] Chemical grenade thrown at (2000, 3100) (remaining: 0)
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [GrenadeBase] Collision detected with Spawn_GasMaskEnemy (type: CharacterBody2D)
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ScoreManager] Damage taken: 1 (total: 19)
+[15:49:35] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:35] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.9877686, 0.15592694), lethal=False (C#)
+[15:49:35] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2059, 3109.471) (added to group)
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=486
+[15:49:35] [ENEMY] [Platform_TeleporterLeft1] FLANKING started: target=(1864.826, 2952.596), side=right, pos=(361.2144, 3463.965)
+[15:49:35] [ENEMY] [Platform_TeleporterLeft1] State: PURSUING -> FLANKING
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ScoreManager] Damage taken: 1 (total: 20)
+[15:49:35] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:35] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.70110583, 0.7130573), lethal=False (C#)
+[15:49:35] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1588.2 > max 1468.6
+[15:49:35] [ENEMY] [Platform_TeleporterLeft1] FLANKING corner check: angle -130.3°
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1583.2 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2047.955, 3306.519) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2033.529, 3261.093) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2047.43, 3250.493) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2102.646, 3166.211) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2143.317, 3174.814) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2134.059, 3173.355) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2102.942, 3258.082) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2078.075, 3201.334) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2112.505, 3259.308) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2065.916, 3261.236) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2072.375, 3161.604) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2097.255, 3186.577) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2049.924, 3227.597) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2086.094, 3249.021) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2046.664, 3172.666) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2048.471, 3170.594) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2088.202, 3169.65) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2027.584, 3194.972) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2041.129, 3152.29) (added to group)
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1578.3 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1573.3 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1568.4 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ScoreManager] Damage taken: 1 (total: 21)
+[15:49:35] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:35] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.9875506, 0.15730184), lethal=False (C#)
+[15:49:35] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2059, 3109.557) (added to group)
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1563.4 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1558.5 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ScoreManager] Damage taken: 1 (total: 22)
+[15:49:35] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:35] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.71902263, 0.69498676), lethal=False (C#)
+[15:49:35] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:35] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=485
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1553.5 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1548.6 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1543.6 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2159.394, 3265.554) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2076.597, 3284.589) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2194.585, 3244.201) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2112.774, 3200.163) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2218.119, 3203.881) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2157.853, 3312.174) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2067.851, 3245.863) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2138.088, 3280.698) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2159.833, 3286.481) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2098.069, 3133.471) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2107.837, 3163.678) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2111.457, 3217.105) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2116.397, 3129.791) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2040.329, 3278.723) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2091.852, 3243.264) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2074.127, 3331.296) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2069.524, 3142.248) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2090.617, 3175.834) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2070.731, 3126.65) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2019.726, 3187.53) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2026.673, 3168.661) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2108.372, 3167.029) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2049.821, 3166.172) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2022.737, 3170.046) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2058.618, 3183.254) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2045.786, 3105.317) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2039.863, 3129.502) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2029.251, 3159.134) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2039.526, 3176.029) (added to group)
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1538.7 > max 1468.6
+[15:49:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1858.895, 2958.26), source=ENEMY (Platform_TeleporterLeft3), range=840, listeners=18
+[15:49:35] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=-11.6°, current=-11.7°, player=(2000,3100), corner_timer=0.13
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [GrenadeBase] Collision detected with StationBuilding (type: StaticBody2D)
+[15:49:35] [INFO] [ChemicalGasGrenade] Hit obstacle 'StationBuilding' — detonating on contact
+[15:49:35] [INFO] [ChemicalGasGrenade] Gas released at (2751.909, 3340.891)!
+[15:49:35] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(2751.909, 3340.891), source=NEUTRAL (ChemicalGasGrenade), range=1469, listeners=18
+[15:49:35] [INFO] [SoundPropagation] Sound result: notified=9, out_of_range=9, self=0
+[15:49:35] [INFO] [ChemicalGasGrenade] Spawning cloud with 5.62s grow-in matching sound
+[15:49:35] [INFO] [ChemicalCloud] _ready() at (2751.909, 3340.891)
+[15:49:35] [INFO] [ChemicalCloud] Particle system created
+[15:49:35] [INFO] [ChemicalCloud] Cloud spawned at (2751.909, 3340.891), radius=600, duration=20s
+[15:49:35] [INFO] [ChemicalGasGrenade] Chemical cloud spawned at (2751.909, 3340.891) (radius=600, duration=20s, grow_in=5.62s)
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [ScoreManager] Damage taken: 1 (total: 23)
+[15:49:35] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:35] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.70085704, 0.7133018), lethal=False (C#)
+[15:49:35] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:35] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:35] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=484
+[15:49:35] [ENEMY] [Platform_TeleporterLeft1] State: FLANKING -> COMBAT
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [ENEMY] [Platform_TeleporterLeft1] Found cover at (726.8481, 3458.385) (distance: 304.6, player at (2000, 3100))
+[15:49:35] [ENEMY] [Platform_TeleporterRight1] FLANKING started: target=(2141.108, 2958.261), side=left, pos=(3263.301, 3435.454)
+[15:49:35] [ENEMY] [Platform_TeleporterRight1] State: PURSUING -> FLANKING
+[15:49:35] [ENEMY] [Platform_TeleporterRight2] FLANKING started: target=(2055.01, 3292.288), side=right, pos=(3439.604, 3459.903)
+[15:49:35] [ENEMY] [Platform_TeleporterRight2] State: PURSUING -> FLANKING
+[15:49:35] [ENEMY] [Platform_TeleporterRight3] FLANKING started: target=(2060.059, 3290.775), side=right, pos=(3638.605, 3464.134)
+[15:49:35] [ENEMY] [Platform_TeleporterRight3] State: PURSUING -> FLANKING
+[15:49:35] [ENEMY] [Platform_ShieldRight] FLANKING started: target=(2038.28, 3296.306), side=right, pos=(3523.087, 3623.558)
+[15:49:35] [ENEMY] [Platform_ShieldRight] State: PURSUING -> FLANKING
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [Teleporter] Teleported from (3263.301, 3435.454) to (2141.108, 2958.261)
+[15:49:35] [ENEMY] [Platform_TeleporterRight1] State: FLANKING -> COMBAT
+[15:49:35] [INFO] [Teleporter] Teleported from (3439.604, 3459.903) to (2055.01, 3292.288)
+[15:49:35] [ENEMY] [Platform_TeleporterRight2] State: FLANKING -> COMBAT
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1588.0 > max 1468.6
+[15:49:35] [ENEMY] [Platform_TeleporterRight3] FLANKING corner check: angle 108.4°
+[15:49:35] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle 134.9°
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2113.47, 3180.165) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2165.666, 3246.699) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2125.067, 3228.463) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2123.682, 3156.751) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2047.776, 3294.581) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2081.894, 3306.719) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2090.033, 3221.641) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2080.634, 3246.177) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2079.481, 3219.741) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2107.015, 3224.835) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2171.132, 3197.139) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2155.412, 3201.526) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2132.67, 3185.876) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2066.499, 3343.01) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2081.784, 3244.27) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2172.127, 3249.129) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2109.569, 3247.44) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2155.467, 3225.029) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2111.939, 3276.671) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2046.579, 3211.791) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2083.233, 3212.107) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2123.276, 3267.737) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2059.293, 3185.999) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2035.967, 3246.123) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2053.46, 3151.748) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2069.385, 3162.681) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2063.812, 3157.842) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2046.469, 3170.622) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2023.75, 3202.865) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2034.161, 3211.058) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2049.861, 3134.667) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2029.048, 3150.966) (added to group)
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [INFO] [BloodyFeet:Platform_TeleporterRight2] Stepped in blood! 12 footprints to spawn, color: (0.5, 0.02, 0.02, 0.9)
+[15:49:35] [ENEMY] [Platform_TeleporterRight1] Found cover at (2188.818, 3074.36) (distance: 125.5, player at (2000, 3100))
+[15:49:35] [ENEMY] [Platform_TeleporterRight2] Found cover at (2093.255, 3700.802) (distance: 410.3, player at (2000, 3100))
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1582.8 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1577.6 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1572.4 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [ScoreManager] Damage taken: 1 (total: 24)
+[15:49:35] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:35] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.703794, 0.7104042), lethal=False (C#)
+[15:49:35] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1567.2 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1562.0 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=483
+[15:49:35] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=134.9°, current=168.3°, player=(2000,3100), corner_timer=0.00
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1556.8 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [ReplayManager] Recording frame 420 (4,3s): player_valid=True, enemies=18
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1551.6 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:35] [INFO] [Teleporter] Rejected teleport: distance 1546.4 > max 1468.6
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:35] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:35] [WARN] [FPS] Drop detected: 9 fps (threshold: 30)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2207.785, 3166.844) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2111.248, 3237.092) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2128.105, 3167.477) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2132.961, 3296.293) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2161.667, 3301.861) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2150.454, 3349.866) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2036.106, 3252.952) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2176.603, 3234.49) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2100.276, 3138.744) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2059.101, 3129.164) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2130.621, 3230.577) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2046.955, 3229.405) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2055.714, 3241.908) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2070.362, 3278.418) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2101.851, 3169.759) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2071.633, 3262.61) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2062.638, 3164.115) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2037.815, 3219.823) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2051.053, 3144.198) (added to group)
+[15:49:35] [INFO] [BloodDecal] Blood puddle created at (2101.589, 3173.793) (added to group)
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1541.1 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1535.9 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 25)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.6939152, 0.7200568), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1530.7 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1525.5 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1520.3 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=482
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1858.895, 2958.26), source=ENEMY (Platform_TeleporterLeft3), range=840, listeners=18
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:36] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-106.0°, current=-140.0°, player=(2000,3100), corner_timer=0.00
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1515.1 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410.001, 3101.891) (distance: 145.2, player at (2000, 3100))
+[15:49:36] [ENEMY] [Spawn_GasMaskEnemy] State: COMBAT -> SEEKING_COVER
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1509.9 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1547.029, 3057.638), source=NEUTRAL (null), range=900, listeners=18
+[15:49:36] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1547.029, 3057.638), intensity=0.01, dist=584
+[15:49:36] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1547.029, 3057.638), intensity=1.00, dist=33
+[15:49:36] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1547.029, 3057.638), intensity=0.02, dist=327
+[15:49:36] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (1547.029, 3057.638), intensity=0.01, dist=602
+[15:49:36] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (1547.029, 3057.638), intensity=0.01, dist=560
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=13, self=0
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1504.7 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2082.783, 3264.365) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2105.76, 3256.176) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2152.592, 3275.075) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2088.125, 3191.839) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2114.262, 3193.379) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2101.043, 3279.515) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2167.219, 3220.882) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2136.664, 3139.612) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2078.004, 3189.931) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2088.976, 3138.269) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2091.827, 3124.645) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2074.915, 3155.914) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2131.043, 3189.085) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2144.876, 3199.045) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2108.631, 3191.143) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2049.38, 3207.489) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2089.375, 3204.97) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2038.882, 3263.01) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2079.913, 3183.73) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2101.002, 3286.113) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2067.378, 3173.292) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2040.833, 3142.662) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2039.392, 3173.776) (added to group)
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1499.5 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 26)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.7077178, 0.7064953), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1494.3 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1489.1 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1483.9 > max 1468.6
+[15:49:36] [ENEMY] [Platform_TeleporterRight3] FLANKING corner check: angle 108.4°
+[15:49:36] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle 134.9°
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1478.7 > max 1468.6
+[15:49:36] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.9° (interval=1.5s)
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:36] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=481
+[15:49:36] [INFO] [Teleporter] Rejected teleport: distance 1473.5 > max 1468.6
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(551.8795, 3384.102), source=ENEMY (Platform_TeleporterLeft1), range=840, listeners=18
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[15:49:36] [INFO] [Teleporter] Teleported from (3522.229, 3425.36) to (2060.059, 3290.775)
+[15:49:36] [ENEMY] [Platform_TeleporterRight3] State: FLANKING -> COMBAT
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [BloodyFeet:Platform_TeleporterRight3] Stepped in blood! 12 footprints to spawn, color: (0.5, 0.02, 0.02, 0.9)
+[15:49:36] [ENEMY] [Platform_TeleporterRight3] Found cover at (2166.723, 3691.694) (distance: 419.8, player at (2000, 3100))
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2141.476, 3249.063) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2210.571, 3192.4) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2148.898, 3289.635) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2098.646, 3262.848) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2123.821, 3151.293) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2128.773, 3222.6) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2139.73, 3201.772) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2101.361, 3247.09) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2121.317, 3236.206) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2093.906, 3214.796) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2040.741, 3285.064) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2158.067, 3223.12) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2123.41, 3331.883) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2075.731, 3204.154) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2063.314, 3188.126) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2061.274, 3234.326) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2035.484, 3267.265) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2053.255, 3168.543) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2063.192, 3232.48) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2043.89, 3228.024) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2086.125, 3166.111) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2023.118, 3190.517) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2049.75, 3162.479) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2048.329, 3138.933) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2083.643, 3193.076) (added to group)
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 27)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.6751103, 0.7377169), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2141.108, 2958.261), source=ENEMY (Platform_TeleporterRight1), range=840, listeners=18
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2054.995, 3292.293), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: P2:combat_state -> P1:visible, state=COMBAT, target=-119.7°, current=-147.8°, player=(2000,3100), corner_timer=0.27
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 28)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.7075052, 0.7067082), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 29)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.2781359, -0.9605418), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=480
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 30)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.73330206, 0.6799031), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2106.688, 3319.626) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2113.787, 3295.766) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2174.971, 3288.463) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2097.92, 3301.238) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2135.864, 3340.375) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2127.394, 3285.463) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2158.508, 3229.615) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2038.417, 3222.482) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2076.349, 3260.142) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2040.584, 3275.231) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2066.651, 3256.388) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2064.126, 3173.26) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2062.282, 3217.819) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2035.114, 3181.006) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2064.081, 3188.189) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2038.041, 3164.907) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2022.455, 3171.738) (added to group)
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1858.895, 2958.26), source=ENEMY (Platform_TeleporterLeft3), range=840, listeners=18
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 31)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.70702976, 0.70718384), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 32)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.2811221, -0.95967203), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=479
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(604.6204, 3387.151), source=NEUTRAL (null), range=900, listeners=18
+[15:49:36] [ENEMY] [NearTracks_MachineGunnerLeft] Heard CASING_KICK at (604.6204, 3387.151), intensity=0.00, dist=779
+[15:49:36] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (604.6204, 3387.151), intensity=0.00, dist=884
+[15:49:36] [ENEMY] [Platform_TeleporterLeft1] Heard CASING_KICK at (604.6204, 3387.151), intensity=1.00, dist=37
+[15:49:36] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (604.6204, 3387.151), intensity=0.05, dist=225
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=14, self=0
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 33)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.7349752, 0.678094), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle 134.9°
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2070.636, 3335.431) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2062.249, 3331.17) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2071.152, 3285.956) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2112.265, 3220.228) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2148.481, 3266.957) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2073.849, 3174.013) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2102.059, 3213.255) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2099.129, 3180.988) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2082.777, 3175.103) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2041.345, 3190.356) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2030.685, 3186.52) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2068.407, 3156.464) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2036.465, 3170.764) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2073.129, 3153.42) (added to group)
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 34)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.70778745, 0.7064254), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 35)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.26978654, -0.9629202), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410, 3100.319) (distance: 6.1, player at (2000, 3100))
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 36)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.7482584, 0.6634075), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:36] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=478
+[15:49:36] [ENEMY] [Platform_TeleporterLeft3] Found cover at (1742.342, 2943.569) (distance: 117.5, player at (2000, 3100))
+[15:49:36] [ENEMY] [Platform_TeleporterLeft3] State: COMBAT -> SEEKING_COVER
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2100.407, 3275.448), source=ENEMY (Platform_TeleporterRight3), range=840, listeners=18
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2055.133, 3289.497) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2037.526, 3263.156) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2166.047, 3332.657) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2055.691, 3260.115) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2064.798, 3259.842) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2079.806, 3205.939) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2070.369, 3224.642) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2072.854, 3211.712) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2058.123, 3241.288) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2103, 3250.798) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2084.578, 3196.125) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2059.41, 3228.162) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2042.081, 3168.921) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2028.781, 3208.39) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2041.604, 3152.25) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2069.529, 3220.477) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2017.713, 3163.602) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1943.834, 3215.989) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1962.481, 3177.596) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1902.886, 3207.078) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1951.184, 3175.417) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1914.19, 3187.921) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1925.911, 3186.58) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1941.173, 3199.484) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1931.597, 3209.391) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1993.752, 3047.91) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1969.129, 3038.724) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2004.56, 3022.045) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2028.326, 3209.475) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2052.694, 3172.735) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2038.056, 3184.57) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (1974.275, 3144.22) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2004.47, 3069.644) (added to group)
+[15:49:36] [INFO] [BloodDecal] Blood puddle created at (2021.547, 3153.981) (added to group)
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 37)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.70835304, 0.7058583), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 38)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.27577633, -0.9612218), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(698.4198, 3355.35), source=ENEMY (Platform_TeleporterLeft1), range=840, listeners=18
+[15:49:36] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:36] [INFO] [ScoreManager] Damage taken: 1 (total: 39)
+[15:49:36] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:36] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.49385965, -0.8695417), lethal=False (C#)
+[15:49:36] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:36] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2141.108, 2958.261), source=ENEMY (Platform_TeleporterRight1), range=840, listeners=18
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2054.604, 3292.438), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=477
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2049.625, 3317.776) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2077.685, 3286.965) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2128.591, 3284.837) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2097.588, 3265.601) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2042.485, 3208.023) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2049.542, 3272.847) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2047.729, 3318.964) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2155.215, 3226.331) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1958.69, 3244.917) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1934.596, 3240.706) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1957.033, 3293.453) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1889.856, 3198.549) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1902.802, 3191.368) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1920.484, 3198.471) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2001.529, 3074.237) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1969.88, 3069.502) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1995.472, 3072.546) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1947.578, 3062.881) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1973.625, 3080.722) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2139.437, 3247.395) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2069.491, 3183.686) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2060.719, 3184.036) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2093.758, 3199.047) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2088.042, 3226.667) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1920.431, 3202.743) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1947.775, 3145.446) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1944.547, 3215.196) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1972.721, 3177.375) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1963.88, 3026.486) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2009.035, 3053.626) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2076.192, 3213.2) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1934.046, 3154.1) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2006.245, 3057.375) (added to group)
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 40)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.708963, 0.70524573), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 41)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.27482656, -0.96149385), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410, 3100.319) (distance: 6.1, player at (2000, 3100))
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [BloodyFeet:Player] Stepped in blood! 12 footprints to spawn, color: (0.5, 0.02, 0.02, 0.9)
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 42)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.98238677, -0.18685888), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2059, 3088.588) (added to group)
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 43)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.4905068, -0.8714374), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(717.5015, 3370.628), source=NEUTRAL (null), range=900, listeners=18
+[15:49:37] [ENEMY] [NearTracks_MachineGunnerLeft] Heard CASING_KICK at (717.5015, 3370.628), intensity=0.00, dist=816
+[15:49:37] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (717.5015, 3370.628), intensity=0.00, dist=749
+[15:49:37] [ENEMY] [Platform_TeleporterLeft1] Heard CASING_KICK at (717.5015, 3370.628), intensity=1.00, dist=37
+[15:49:37] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (717.5015, 3370.628), intensity=0.02, dist=328
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=14, self=0
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle 134.9°
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 44)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.7548646, 0.65588075), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=476
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1790.363, 2937.347), source=ENEMY (Platform_TeleporterLeft3), range=840, listeners=18
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 45)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.98082757, -0.19487771), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2059, 3088.079) (added to group)
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 46)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.69743496, 0.7166481), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 47)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.27663907, -0.9609739), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2067.155, 3308.379) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2118.931, 3331.663) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2073.658, 3233.043) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2148.232, 3305.523) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1896.967, 3297.632) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2003.115, 3053.519) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2022.827, 2989.178) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1935.187, 3056.977) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1933.952, 3042.306) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1863.362, 3043.417) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2164.94, 3337.113) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2196.607, 3292.68) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2050.935, 3255.91) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1956.041, 3266.152) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1922.018, 3208.572) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1895.291, 3216.98) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1955.342, 3269.99) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2016.076, 3074.406) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1933.836, 3032.291) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1929.387, 3043.529) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1997.389, 2999.098) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2011.943, 3053.319) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1900.336, 3056.284) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1968.416, 3046.371) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2103.612, 3168.644) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2040.674, 3208.548) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1912.093, 3150.147) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1963.781, 3221.951) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1941.151, 3040.231) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1961.103, 3069.868) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1940.025, 3020.86) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1959.413, 3043.677) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1978.599, 3040.615) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2057.179, 3190.095) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2078.514, 3177.196) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2093.069, 3161.89) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2061.826, 3240.513) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1971.097, 3033.531) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1959.572, 3073.604) (added to group)
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 48)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.4945247, -0.8691636), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [ReplayManager] Recording frame 480 (5,3s): player_valid=True, enemies=18
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 49)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.769738, 0.63835996), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2100.686, 3275.344), source=ENEMY (Platform_TeleporterRight3), range=840, listeners=18
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 50)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.98183596, -0.1897319), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2059, 3088.406) (added to group)
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:37] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=475
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P1:visible -> P4:velocity, state=SEEKING_COVER, target=164.2°, current=45.4°, player=(2000,3100), corner_timer=0.00
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 51)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.6965138, 0.7175435), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 52)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.29477707, -0.9555661), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410, 3100.319) (distance: 6.1, player at (2000, 3100))
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] Found cover at (1741.503, 2949.831) (distance: 11.1, player at (2000, 3100))
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(798.7219, 3310.533), source=ENEMY (Platform_TeleporterLeft1), range=840, listeners=18
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] State: SEEKING_COVER -> IN_COVER
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [WARN] [FPS] Drop detected: 5 fps (threshold: 30)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1967.098, 3054.934) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1951.392, 3099.058) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2042.491, 3325.472) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1831.36, 3273.465) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1962.754, 3278.753) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1832.171, 3247.269) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1934.25, 3261.588) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2008.07, 3095.559) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1936.952, 3002.082) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1953.978, 3023.24) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1996.217, 3047.96) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1978.888, 2971.997) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2070.974, 3276.91) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2079.439, 3212.822) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2058.155, 3269.633) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2109.325, 3283.681) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2112.359, 3261.927) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2146.766, 3247.713) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2092.039, 3320.396) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2134.631, 3279.61) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1961.334, 3241.814) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1942.669, 3210.525) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1894.571, 3220.982) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1956.55, 3277.107) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1914.687, 3186.365) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1920.473, 3295.89) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1942.205, 3215.316) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1961.98, 3068.048) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1979.688, 3003.865) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2108.146, 3215.599) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2050.422, 3213.851) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1964.46, 3219.458) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1970.9, 3212.648) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1943.722, 3157.86) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1955.407, 3225.6) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1974.481, 3007.002) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1964.208, 3071.282) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1959.764, 3013.654) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1963.288, 3060.977) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2002.579, 3046.025) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1980.809, 3022.893) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1998.261, 3071.882) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1956.804, 3058.075) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1981.659, 3056.73) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1980.257, 3065.455) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1956.02, 3025.39) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1916.49, 3066.38) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1955.151, 3030.723) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1947.366, 3187.317) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1948.568, 3173.939) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2047.362, 3092.473) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1983.375, 3043.188) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2039.753, 3166.981) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2038.242, 3096.302) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2063.074, 3123.815) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1998.496, 3032.143) (added to group)
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 53)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.49429837, -0.8692923), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] State: IN_COVER -> PURSUING
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P4:velocity -> P2:combat_state, state=PURSUING, target=30.8°, current=63.0°, player=(2000,3100), corner_timer=0.00
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] PURSUING: close/visible unhittable target, attempting FLANKING before pursuit cover
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] FLANKING started: target=(2002.201, 2899.97), side=right, pos=(1738.814, 2944.573)
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] State: PURSUING -> FLANKING
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2141.108, 2958.261), source=ENEMY (Platform_TeleporterRight1), range=840, listeners=18
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2054.328, 3292.541), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] FLANKING corner check: angle 103.5°
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 54)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.98223513, -0.18765451), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2059, 3088.537) (added to group)
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 55)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.6959248, 0.7181147), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 56)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.22725433, -0.97383547), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=474
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:37] [ENEMY] [CentralWalkway_ForceFieldLeft] PURSUING corner check: angle -138.7°
+[15:49:37] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1791.711, 2962.704), source=NEUTRAL (null), range=900, listeners=18
+[15:49:37] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1791.711, 2962.704), intensity=0.01, dist=467
+[15:49:37] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (1791.711, 2962.704), intensity=0.00, dist=835
+[15:49:37] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1791.711, 2962.704), intensity=0.02, dist=400
+[15:49:37] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1791.711, 2962.704), intensity=1.00, dist=30
+[15:49:37] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (1791.711, 2962.704), intensity=0.02, dist=349
+[15:49:37] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (1791.711, 2962.704), intensity=0.01, dist=422
+[15:49:37] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (1791.711, 2962.704), intensity=0.01, dist=440
+[15:49:37] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=11, self=0
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [ScoreManager] Damage taken: 1 (total: 57)
+[15:49:37] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:37] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.4930364, -0.8700087), lethal=False (C#)
+[15:49:37] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:37] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle 134.9°
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:37] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1899.125, 3245.014) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2135.3, 3349.43) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2079.394, 3278.975) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2172.599, 3291.536) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1885.233, 3222.445) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1848.857, 3283.246) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1964.515, 3281.821) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1996.778, 3034.931) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1869.956, 3033.928) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1993.016, 3008.94) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1965.712, 3078.963) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2115.347, 3250.309) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2090.337, 3336.085) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2075.856, 3276.091) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1888.169, 3216.123) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1899.17, 3188.345) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1958.714, 3069.841) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1986.183, 3059.4) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1880.807, 3040.473) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1917.992, 3098.978) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1946.574, 3061.214) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1953.528, 3019.104) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1929.63, 3070.672) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1854.546, 3062.84) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1884.66, 3057.562) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1940.234, 3160.421) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1919.741, 3173.493) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1948.709, 3186.344) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1970.335, 3028.865) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1953.672, 3058.369) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2006.559, 3074.921) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1987.416, 3057.485) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1962.424, 3064.973) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2011.934, 3057.148) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1970.417, 3077.825) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2072.078, 3128.24) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2051.04, 3113.563) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1956.788, 3064.845) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1955.477, 3071.414) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1910.724, 3067.122) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1983.303, 3007.14) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2027.963, 3175.108) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2039.575, 3173.767) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2078.168, 3164.54) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2055.479, 3126.529) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2069.639, 3073.705) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1937.055, 3174.251) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1904.146, 3158.781) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1955.079, 3075.016) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1984.852, 3059.771) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1962.18, 3055.963) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1977.568, 3063.434) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1948.185, 3034.701) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1981.723, 3037.594) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1982.798, 3010.705) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2009.87, 3019.306) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2039.726, 3132.587) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2044.668, 3138.408) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2055.099, 3161.3) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1970.303, 3043.95) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1903.147, 3281.98) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1998.813, 3103.359) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1900.355, 3060.362) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1935.599, 3036.508) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2164.252, 3279.559) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2122.538, 3300.728) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2121.102, 3251.312) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1854.713, 3318.663) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1850.865, 3245.612) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1941.265, 3259.585) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1950.239, 3304.168) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1877.664, 3232.732) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1939.748, 3073.042) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1976.082, 3007.134) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1910.818, 3014.44) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1919.527, 3117.885) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1872.9, 3266.809) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1938.918, 3205.924) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1958.521, 3263.043) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1945.438, 3032.628) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2062.254, 3118.419) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2149.553, 3187.77) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1946.362, 3083.509) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1943.542, 3103.293) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1933.509, 3088.871) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2044.944, 3197.558) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2088.522, 3178.627) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2075.633, 3224.355) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2065.42, 3190.969) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2056.216, 3214.318) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2077.013, 3125.959) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2065.775, 3129.035) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2072.756, 3127.14) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1905.156, 3237.81) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1909.241, 3273.462) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1899.459, 3199.51) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1977.316, 3063.769) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1993.137, 3062.586) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1981.179, 3047.263) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1994.001, 3064.669) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1966.776, 3062.804) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1947.958, 3066.877) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1943.693, 3044.037) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2061.212, 3226.836) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2047.824, 3137.002) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2047.44, 3211.078) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2088.344, 3127.903) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2063.195, 3138.694) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1955.386, 3183.479) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1936.718, 3208.461) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1932.281, 3060.167) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2005.046, 3035.462) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2001.608, 3059.512) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1983.571, 3067.887) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2006.457, 3031.788) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2004.747, 3052.273) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1982.27, 3073.012) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1965.527, 3082.497) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1952.396, 3179.431) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1964.07, 3085.084) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1865.226, 3271.298) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1936.927, 3328.618) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1930.037, 3326.767) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1994.092, 3010.721) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1909.271, 3020.64) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1900.004, 3310.515) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1910.908, 3206.432) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1911.743, 3295.527) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1889.728, 3256.509) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1886.871, 3285.815) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2010.703, 3078.536) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2009.317, 3032.492) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1971.388, 2982.403) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1995.066, 3037.302) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2092.297, 3128.652) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2200.641, 3172.154) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2086.636, 3181.395) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2175.521, 3207.636) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1927.45, 3055.157) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1955.775, 3021.114) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1982.076, 2986.453) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1983.535, 3058.271) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1918.085, 3028.304) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2167.131, 3229.381) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2061.493, 3244.86) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2088.799, 3274.713) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2101.015, 3132.757) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1864.613, 3236.289) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1915.069, 3209.927) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1925.446, 3227.448) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1963.602, 3272.265) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1920.824, 3265.231) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1906.638, 3070.121) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1943.008, 3039.337) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1936.378, 3035.784) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2033.724, 3199.901) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2056.923, 3224.655) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2093.724, 3145.618) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2087.709, 3154.44) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2094.049, 3142.417) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1949.594, 3275.178) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1917.752, 3231.354) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1925.712, 3283.783) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1932.111, 3196.215) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1971.212, 3229.629) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1983.627, 3064.853) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1950.932, 3039.678) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1981.441, 3030.399) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1974.644, 3043.743) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2065.406, 3141.098) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2047.313, 3100.097) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2059.752, 3124.174) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1947.008, 3161.993) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1939.615, 3179.544) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1976.332, 3036.961) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2002.221, 3035.512) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1966.977, 3074.031) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1976.107, 3068.661) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1921.62, 3053.578) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1975.249, 3041.155) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1922.272, 3063.703) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2158.728, 3186.844) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2122.312, 3213.545) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2097.038, 3169.458) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2100.574, 3210.361) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1923.472, 3252.417) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1939.154, 3103.899) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1940.94, 2983.498) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1895.249, 3043.822) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1950.37, 3067.18) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2113.805, 3256.381) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2070.307, 3199.009) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2118.838, 3180.677) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2085.093, 3126.459) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1918.296, 3220.246) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1945.037, 3088.695) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2071.667, 3135.637) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2062.551, 3132.983) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (2077.963, 3150.664) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1959.598, 3202.43) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1950.526, 3234.172) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1961.027, 3030.752) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1964.134, 3029.77) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1932.333, 3067.441) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1920.714, 3056.631) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1959.863, 3021.528) (added to group)
+[15:49:37] [INFO] [BloodDecal] Blood puddle created at (1921.428, 3040.752) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1879.842, 3315.864) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1860.466, 3315.689) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1910.947, 3032.599) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2115.317, 3146.758) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1856.131, 3095.997) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1988.235, 3067.867) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2139.877, 3242.544) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2096.342, 3329.197) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1912.868, 3306.692) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1833.053, 3276.992) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1871.533, 3268.525) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1930.465, 3052.375) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1906.28, 3066.989) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1884.185, 3065.34) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1957.908, 3054.485) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2069.793, 3284.075) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2149.925, 3164.24) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2097.165, 3163.421) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1872.136, 3246.492) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1863.033, 3263.778) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1928.276, 3088.732) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1970.395, 3074.208) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1931.655, 3036.965) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1906.461, 3062.184) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2034.401, 3004.737) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1961.696, 3089.442) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1978.012, 3048.804) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1975.384, 3020.429) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1905.654, 3073.037) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2102.014, 3249.818) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2119.507, 3179.242) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2206.906, 3248.506) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2149.027, 3181.596) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1912.294, 3297.013) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1835.068, 3244.165) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1950.155, 3290.681) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1937.127, 3049.883) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1982.096, 2976.954) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1917.979, 3233.015) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2022.255, 3036.023) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1928.611, 3096.083) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1879.56, 3073.132) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1894.022, 3124.809) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2047.391, 3302.102) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2186.751, 3262.499) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2139.737, 3344.251) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1915.763, 3267.3) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2014.218, 3084.203) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1991.349, 3055.888) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1939.217, 2988.838) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1987.729, 3004.553) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2107.595, 3195.133) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1957.286, 3263.643) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1849.647, 3229.888) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1985.87, 3038.714) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1972.179, 3072.201) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1993.521, 3051.102) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1979.048, 3037.471) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1929.763, 3063.31) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1982.463, 3055.959) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1966.606, 2990.861) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1972.229, 3011.545) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1992.973, 3058.434) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2131.169, 3133.453) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1936.312, 3241.919) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1881.138, 3268.791) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1838.022, 3273.115) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2017.511, 3031.747) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1890.283, 3009.854) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1945.403, 3070.848) (added to group)
+[15:49:38] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410, 3100.319) (distance: 6.1, player at (2000, 3100))
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(821.8254, 3325.874), source=NEUTRAL (null), range=900, listeners=18
+[15:49:38] [ENEMY] [NearTracks_MachineGunnerLeft] Heard CASING_KICK at (821.8254, 3325.874), intensity=0.00, dist=838
+[15:49:38] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (821.8254, 3325.874), intensity=0.01, dist=636
+[15:49:38] [ENEMY] [Platform_TeleporterLeft1] Heard CASING_KICK at (821.8254, 3325.874), intensity=1.00, dist=41
+[15:49:38] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (821.8254, 3325.874), intensity=0.01, dist=439
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=14, self=0
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2141.108, 2958.261), source=ENEMY (Platform_TeleporterRight1), range=840, listeners=18
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2054.24, 3292.573), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2100.864, 3275.279), source=ENEMY (Platform_TeleporterRight3), range=840, listeners=18
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1990.559, 3003.884) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1924.744, 3096.927) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2214.903, 3242.399) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2123.505, 3202.636) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1943.518, 3294.371) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1855.525, 3283.633) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1970.551, 3033.113) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1906.071, 3020.281) (added to group)
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 58)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.7016991, 0.71247345), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 59)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.25898132, -0.96588236), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:38] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=473
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(869.9725, 3291.983), source=ENEMY (Platform_TeleporterLeft1), range=840, listeners=18
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 60)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.5210544, -0.85352355), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=35.8°, current=30.2°, player=(2000,3100), corner_timer=0.10
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1831.505, 3340.22) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1881.601, 3301.694) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1965.267, 3023.616) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1962.021, 3054.764) (added to group)
+[15:49:38] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410, 3100.319) (distance: 6.1, player at (2000, 3100))
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 61)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.74972004, 0.6617552), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 62)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.28553468, -0.9583684), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 63)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.5012365, -0.8653104), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=472
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [ENEMY] [Platform_TeleporterLeft3] FLANKING corner check: angle 60.2°
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [ReplayManager] Recording frame 540 (6,3s): player_valid=True, enemies=18
+[15:49:38] [ENEMY] [Platform_TeleporterLeft3] State: FLANKING -> COMBAT
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 64)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.70365983, 0.7105371), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 65)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.25860798, -0.9659824), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [ENEMY] [CentralWalkway_ForceFieldLeft] PURSUING corner check: angle -16.4°
+[15:49:38] [ENEMY] [Platform_TeleporterLeft3] Found cover at (1742.362, 2943.434) (distance: 86.3, player at (2000, 3100))
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle 134.9°
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 66)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.5357726, -0.8443623), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(922.2402, 3300.485), source=NEUTRAL (null), range=900, listeners=18
+[15:49:38] [ENEMY] [NearTracks_MachineGunnerLeft] Heard CASING_KICK at (922.2402, 3300.485), intensity=0.00, dist=886
+[15:49:38] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (922.2402, 3300.485), intensity=0.01, dist=533
+[15:49:38] [ENEMY] [Platform_TeleporterLeft1] Heard CASING_KICK at (922.2402, 3300.485), intensity=1.00, dist=39
+[15:49:38] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (922.2402, 3300.485), intensity=0.01, dist=539
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=14, self=0
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=471
+[15:49:38] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410, 3100.319) (distance: 6.1, player at (2000, 3100))
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2141.108, 2958.261), source=ENEMY (Platform_TeleporterRight1), range=840, listeners=18
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2053.984, 3292.668), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=13, self=1
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.118, 3275.185), source=ENEMY (Platform_TeleporterRight3), range=840, listeners=18
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1947.103, 3150.703) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1927.666, 3209.392) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1963, 3142.809) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1936.722, 3182.708) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1948.173, 3203.275) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1946.55, 3177.381) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1946.446, 3172.792) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1979.928, 3025.267) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1994.292, 3051.731) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1945.536, 3063.016) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1958.77, 3066.033) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1961.289, 3067.589) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1986.864, 3027.929) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1929.699, 3073.318) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1976.06, 3078.233) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1986.139, 3041.546) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1976.423, 3039.448) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (1941.948, 3129.771) (added to group)
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2004.342, 3038.732) (added to group)
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 67)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.67753536, 0.73549026), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 68)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.21233013, -0.977198), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:38] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:38] [INFO] [ScoreManager] Damage taken: 1 (total: 69)
+[15:49:38] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:38] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.986128, -0.16598685), lethal=False (C#)
+[15:49:38] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:38] [INFO] [BloodDecal] Blood puddle created at (2059, 3089.901) (added to group)
+[15:49:38] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(980.3904, 3273.223), source=ENEMY (Platform_TeleporterLeft1), range=840, listeners=18
+[15:49:38] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 70)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.48052055, -0.8769834), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:39] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:39] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=470
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -166.6° (interval=1.5s)
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 71)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.671034, 0.7414266), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 72)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.26998645, -0.96286416), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1968.425, 3232.822) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1934.124, 3235.326) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1929.769, 3196.972) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1920.006, 3207.81) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1981.522, 3023.817) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1938.232, 3111.514) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1925.024, 3096.008) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1879.728, 3059.087) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1938.118, 3079.149) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1908.165, 3189.224) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1950.005, 3077.638) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2004.136, 3069.269) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1964.093, 3086.088) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1922.926, 3057.298) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1960.05, 3046.203) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1988.67, 3066.156) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1951.264, 3083.295) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1941.861, 3068.024) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1966.16, 3141.995) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1942.316, 3142.333) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1970.236, 3079.264) (added to group)
+[15:49:39] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410, 3100.319) (distance: 6.1, player at (2000, 3100))
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 73)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.5301654, -0.8478943), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(998.0706, 3288.501), source=NEUTRAL (null), range=900, listeners=18
+[15:49:39] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (998.0706, 3288.501), intensity=0.01, dist=459
+[15:49:39] [ENEMY] [Platform_TeleporterLeft1] Heard CASING_KICK at (998.0706, 3288.501), intensity=1.00, dist=38
+[15:49:39] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (998.0706, 3288.501), intensity=0.01, dist=611
+[15:49:39] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=15, self=0
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=469
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [ENEMY] [CentralWalkway_ForceFieldLeft] PURSUING corner check: angle -5.5°
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 74)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.6827359, 0.73066527), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 75)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.28688407, -0.9579653), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle -45.1°
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1941.067, 3265.419) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1875.522, 3276.914) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1957.771, 3064.409) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1956.927, 3084.938) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1999.704, 3028.74) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1982.583, 3058.266) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1955.536, 3075.855) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1955.411, 3078.751) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1941.405, 3048.555) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1954.666, 3098.76) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1954.951, 3202.765) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1947.869, 3208.392) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1935.908, 3249.625) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1917.861, 3176.05) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1860.789, 3204.392) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1916.653, 3182.087) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1872.076, 3253.063) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1926.98, 3217.418) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1901.999, 3268.075) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1925.969, 3204.779) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1960.428, 3034.533) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2006.773, 3044.321) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1934.271, 3060.415) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1978.139, 3084.073) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1994.854, 3029.766) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1941.397, 3067.016) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1989.119, 3067.04) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1994.159, 3025.274) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1925.676, 3154.707) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1963.773, 3198.567) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1976.562, 3177.325) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1914.539, 3182.807) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1983.803, 3069.082) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1992.003, 3066.337) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1989.616, 3021.056) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1967.984, 3070.194) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1984.892, 3052.448) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1934.227, 3022.459) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1970.553, 3061.093) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1926.284, 3074.828) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1912.682, 3078.531) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1980.562, 3078.282) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1981.6, 3064.161) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1979.08, 3065.212) (added to group)
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 76)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.4768235, -0.87899905), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1841.556, 2919.093), source=ENEMY (Platform_TeleporterLeft3), range=840, listeners=18
+[15:49:39] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2141.108, 2958.261), source=ENEMY (Platform_TeleporterRight1), range=840, listeners=18
+[15:49:39] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2053.741, 3292.758), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:39] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.359, 3275.095), source=ENEMY (Platform_TeleporterRight3), range=840, listeners=18
+[15:49:39] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=468
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 77)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.6561434, 0.7546363), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 78)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.25080916, -0.96803653), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410, 3100.319) (distance: 6.1, player at (2000, 3100))
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 79)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.6538416, 0.75663143), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1054.002, 3260.717), source=ENEMY (Platform_TeleporterLeft1), range=840, listeners=18
+[15:49:39] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 80)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.5399926, -0.8416698), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1934.841, 3284.511) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1781.058, 3312.876) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1974.862, 3029.217) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1904.862, 3055.798) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1886.367, 3002.452) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1951.326, 3100.604) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1932.125, 3070.976) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1948.033, 3108.011) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1896.227, 3129.865) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1930.714, 3294.363) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1795.356, 3254.564) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1930.111, 3072.243) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1917.403, 3058.529) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1878.016, 3075.77) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1933.149, 3116.508) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1968.353, 3050) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1967.201, 3047.045) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1951.701, 3009.978) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1886.287, 3012.816) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1952.531, 3263.817) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1966.48, 3225.343) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1952.432, 3246.895) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1893.365, 3208.328) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1997.562, 3013.076) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2013.724, 2983.992) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1960.806, 3002.397) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1962.147, 3071.281) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1933.13, 3007.215) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1951.236, 3071.326) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1902.212, 3082.019) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1948.838, 3093.388) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1952.86, 3147.753) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1937.707, 3187.64) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1956.833, 3189.24) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1967.808, 3045.2) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1983.151, 3060.994) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2007.661, 3012.214) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2088.712, 3122.609) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2085.514, 3067.058) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1989.255, 3031.93) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1998.829, 3069.039) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1931.932, 3053.059) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1996.209, 3046.981) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1964, 3084.951) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1949.457, 3058.275) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1940.561, 3084.636) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1952.308, 3177.244) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1962.408, 3162.81) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1932.123, 3155.503) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1931.462, 3156.804) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1944.111, 3157.391) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1949.015, 3158.205) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1913.233, 3200.621) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1952.349, 3212.679) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1949.617, 3026.005) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1954.107, 3042.394) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1977.378, 3068.341) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2008.31, 3075.627) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1989.887, 3044.968) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1933.01, 3031.263) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1970.471, 3080.871) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1968.15, 3082.163) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1918.201, 3148.833) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1921.708, 3151.913) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1971.104, 3055.75) (added to group)
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [GrenadeBase] Collision detected with WallRight (type: StaticBody2D)
+[15:49:39] [INFO] [ChemicalGasGrenade] Hit obstacle 'WallRight' — detonating on contact
+[15:49:39] [INFO] [ChemicalGasGrenade] Gas released at (3925.944, 3391.352)!
+[15:49:39] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(3925.944, 3391.352), source=NEUTRAL (@RigidBody2D@8628), range=1469, listeners=18
+[15:49:39] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=16, self=0
+[15:49:39] [INFO] [ChemicalGasGrenade] Spawning cloud with 5.62s grow-in matching sound
+[15:49:39] [INFO] [ChemicalCloud] _ready() at (3925.944, 3391.352)
+[15:49:39] [INFO] [ChemicalCloud] Particle system created
+[15:49:39] [INFO] [ChemicalCloud] Cloud spawned at (3925.944, 3391.352), radius=600, duration=20s
+[15:49:39] [INFO] [ChemicalGasGrenade] Chemical cloud spawned at (3925.944, 3391.352) (radius=600, duration=20s, grow_in=5.62s)
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 81)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.65513253, 0.75551397), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 82)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.301864, -0.9533511), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:39] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:39] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=467
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 83)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.65948087, 0.7517214), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 84)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.5247999, -0.8512257), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:39] [WARN] [FPS] Drop detected: 5 fps (threshold: 30)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1922.056, 3305.198) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1986.392, 3100.954) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1934.667, 3047.688) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1974.113, 2989.025) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1882.058, 3122.324) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1917.281, 3145.504) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1922.812, 3265.764) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1849.544, 3244.189) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1833.285, 3275.937) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1898.747, 3053.999) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1916.103, 3056.411) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1963.568, 3094.506) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1940.575, 3080.463) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1981.809, 3070.51) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1919.839, 3076.347) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1983.466, 3079.974) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1911.71, 3057.208) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1913.894, 3121.544) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1872.058, 3007.078) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1970.507, 3231.336) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1968.38, 3216.534) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1925.351, 3225.518) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1930.874, 3231.888) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1903.904, 3220.043) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2005.845, 3056.795) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2008.63, 3053.943) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1974.908, 3053.56) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1927.75, 3028.957) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1943.14, 3023.397) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2110.186, 3138.706) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2150.1, 3175.955) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1953.47, 3080.024) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1970.018, 3032.81) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1984.423, 3051.047) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1935.493, 2992.96) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1955.743, 3202.87) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1964.497, 3210.213) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1975.598, 3065.487) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2017.797, 2988.205) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1991.264, 3056.062) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1946.405, 3074.615) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1968.427, 3052.732) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1946.966, 3089.053) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1942.371, 3031.765) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1946.079, 3081.79) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1956.958, 3137.459) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1951.733, 3229.811) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1948.259, 3184.512) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1980.261, 3071.098) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1976.107, 3010.133) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2002.737, 3074.948) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1933.752, 3050.119) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1938.616, 3063.002) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1993.39, 3058.357) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (1961.757, 3184.86) (added to group)
+[15:49:39] [INFO] [BloodDecal] Blood puddle created at (2000.815, 3050.202) (added to group)
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410, 3100.319) (distance: 6.1, player at (2000, 3100))
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [ENEMY] [CentralWalkway_ForceFieldLeft] PURSUING corner check: angle -175.4°
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:39] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle -45.1°
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 85)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.6981928, 0.7159099), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 86)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.26715377, -0.963654), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (502px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 87)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.6597681, 0.75146925), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:39] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=466
+[15:49:39] [INFO] [ChemicalCloud] Moving original enemy from (1414.334, 3096.022) to (1490.078, 3009.125) (offset=(-75.47687, -87.12904))
+[15:49:39] [INFO] [IllusionEffect] Spawned at (1414.334, 3096.022), offset=(75.47687, 87.12904), duration=20s
+[15:49:39] [INFO] [IllusionEffect] Spawned at (1429.254, 3180.112), offset=(160.826, 84.08904), duration=20s
+[15:49:39] [INFO] [IllusionEffect] Spawned at (1335.895, 3078.583), offset=(47.26281, 162.367), duration=20s
+[15:49:39] [INFO] [ChemicalCloud] Moving original enemy from (1841.556, 2919.093) to (1724.647, 2913.51) (offset=(-81.22581, 84.2683))
+[15:49:39] [INFO] [IllusionEffect] Spawned at (1841.556, 2919.093), offset=(81.22581, -84.2683), duration=20s
+[15:49:39] [INFO] [IllusionEffect] Spawned at (1878.596, 2983.353), offset=(153.9714, -69.79381), duration=20s
+[15:49:39] [INFO] [IllusionEffect] Spawned at (1881.611, 2863.463), offset=(65.76803, -151.0529), duration=20s
+[15:49:39] [INFO] [ChemicalCloud] Moving original enemy from (1054.002, 3260.717) to (984.0486, 3181.323) (offset=(-55.66732, -89.98936))
+[15:49:39] [INFO] [IllusionEffect] Spawned at (1054.002, 3260.717), offset=(55.66732, 89.98936), duration=20s
+[15:49:39] [INFO] [IllusionEffect] Spawned at (1118.475, 3250.957), offset=(120.8646, 91.1661), duration=20s
+[15:49:39] [INFO] [IllusionEffect] Spawned at (1012.033, 3332.46), offset=(2.275089, 153.6895), duration=20s
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (2053.522, 3292.839) — cluster needs 3 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (2101.556, 3275.022) — cluster needs 3 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (1814.713, 2505.933) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (2141.108, 2958.261) — cluster needs 3 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (2300, 2300) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (444.6447, 3541.29) — cluster needs 3 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (300, 2670) — cluster needs 3 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (300, 1890) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (3252.763, 3354.614) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (1677.642, 1207.044) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (1600, 1100) — cluster needs 3 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (789.7931, 1216.372) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (700, 1124.023) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (2586.281, 1221.857) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (2500, 1124.023) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (3700, 2670) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (3700, 1890) — cluster needs 3 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (3378.432, 1230.358) — cluster needs 3 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Skipping enemy at (3300, 1124.023) — cluster needs 4 copies, only 1 slots remain
+[15:49:39] [INFO] [ChemicalCloud] Spawned 9 illusion copies for 22 enemies (total: 9/10)
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:39] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:39] [INFO] [IllusionEffect] Destroyed at (1118.475, 3250.957) (time_remaining=20.0s)
+[15:49:39] [INFO] [ScoreManager] Damage taken: 1 (total: 88)
+[15:49:39] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:39] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.45579064, -0.89008707), lethal=False (C#)
+[15:49:39] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P1:visible -> P4:velocity, state=SEEKING_COVER, target=136.2°, current=4.7°, player=(2000,3100), corner_timer=0.00
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2141.108, 2958.261), source=ENEMY (Platform_TeleporterRight1), range=840, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2053.511, 3292.843), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:40] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: P2:shield_delayed -> P1:shield_delayed, state=FLANKING, target=-166.6°, current=-167.0°, player=(2000,3100), corner_timer=0.25
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1927.811, 3314.833) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1871.04, 3035.107) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1913.952, 3062.192) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1874.279, 3283.336) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1948.151, 3241.095) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1848.785, 3326.444) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1840.547, 3325.704) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1903.334, 3224.58) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1950.696, 3308.036) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1927.007, 3072.081) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1940.347, 3059.513) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1962.156, 3067.776) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1911.125, 2999.924) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2186.167, 3242.016) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2180.179, 3170.07) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2113.77, 3166.34) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2104.063, 3128.681) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1954.504, 2992.011) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1926.783, 3082.645) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1914.458, 3230.811) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1939.637, 3238.491) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1925.315, 3301.458) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1977.58, 2982.359) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1962.003, 3039.039) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1907.306, 3066.236) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1917.874, 3077.616) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1938.88, 3064.605) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1981.516, 3021.233) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1922.946, 3005.113) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1957.158, 3092.163) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1970.483, 3245.092) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1908.061, 3226.44) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1969.971, 3032.3) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1951.505, 3065.443) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2006.61, 2978.126) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1950.4, 3044.776) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2007.054, 3061.199) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1916.312, 3051.68) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1988.937, 3063.678) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1938.772, 3070.34) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1953.868, 3007.935) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1926.012, 3055.549) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1945.202, 3154.629) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1957.587, 3167.112) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1934.096, 3162.464) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1970.51, 3231.322) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1981.943, 3200.434) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1897.061, 3207.262) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1974.654, 3155.409) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1970.408, 3064.11) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2011.563, 3067.4) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2012.436, 3045.778) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2000.921, 3065.994) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2066.065, 3152.908) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2066.99, 3153.385) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2065.986, 3204.164) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2067.899, 3206.15) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2040.531, 3240.622) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1937.842, 3039.775) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1993.604, 3074.296) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1960.446, 3065.175) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1924.528, 3071.364) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1951.49, 3055.612) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1930.729, 3078.967) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1932.864, 3063.316) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1961.143, 3155.863) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2056.208, 3153.866) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2041.622, 3142.433) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2030.72, 3178.203) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2047.764, 3180.719) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2013.556, 3165.75) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1981.866, 3071.512) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1959.707, 3040.065) (added to group)
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.587, 3275.01), source=ENEMY (Platform_TeleporterRight3), range=840, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 89)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.7285381, 0.6850053), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 90)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.28793693, -0.9576494), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: P4:velocity -> P1:visible, state=SEEKING_COVER, target=7.8°, current=28.3°, player=(2000,3100), corner_timer=0.00
+[15:49:40] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P1:visible -> P2:combat_state, state=COMBAT, target=34.1°, current=31.3°, player=(2000,3100), corner_timer=0.27
+[15:49:40] [ENEMY] [Platform_TeleporterLeft3] State: COMBAT -> PURSUING
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(984.0486, 3181.323), source=ENEMY (Platform_TeleporterLeft1), range=840, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[15:49:40] [ENEMY] [Platform_TeleporterLeft3] PURSUING: close/visible unhittable target, attempting FLANKING before pursuit cover
+[15:49:40] [ENEMY] [Platform_TeleporterLeft3] FLANKING started: target=(1819.841, 3187.304), side=left, pos=(1724.647, 2913.51)
+[15:49:40] [ENEMY] [Platform_TeleporterLeft3] State: PURSUING -> FLANKING
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 91)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.55593926, -0.8312229), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:40] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=465
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1903.244, 3334.635) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1929.362, 3074.236) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2140.732, 3234.445) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1983.989, 3091.185) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1905.794, 3333.436) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1933.516, 3320.87) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1943.051, 3077.355) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1905.786, 3061.399) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1917.985, 3110.268) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1958.197, 3090.274) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1921.996, 3110.627) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1913.182, 3039.497) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1930.71, 3332.046) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1911.9, 3256.411) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1895.924, 3292.794) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1964.616, 3296.617) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1878.014, 3249.093) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1923.807, 3229.063) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1849.096, 3272.331) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1987.831, 3038.168) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1911.547, 3042.677) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1979.657, 3058.734) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2006.78, 3043.372) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2003.897, 3034.208) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1946.06, 3078.913) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1917.518, 3066.961) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1963.661, 3042.729) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1947.715, 3317.313) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1980.565, 3067.151) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1991.04, 3030.367) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1989.395, 3017.6) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1986.831, 3054.092) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1966.308, 3030.349) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2048.578, 3291.048) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2048.106, 3252.984) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2108.813, 3201.324) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1944.98, 3036.552) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1941.523, 3102.969) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1977.796, 3021.673) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1909.059, 3177.995) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1940.692, 3214.279) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1976.044, 3171.816) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1955.797, 3008.135) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1982.215, 3034.222) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1976.152, 3073.877) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1972.435, 3004.235) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1967.274, 3064.715) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1958.202, 3031.912) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2026.528, 3167.813) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2068.833, 3178.677) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2051.053, 3231.449) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2033.815, 3244.118) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1895.131, 3072.509) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1991.753, 3014.81) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1926.91, 3037.002) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1933.177, 3081.479) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1924.682, 3078.679) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1955.85, 3088.844) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1971.687, 3179.223) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1969.23, 3135.783) (added to group)
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 92)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.70468277, 0.70952255), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 93)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.2083458, -0.97805524), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [IllusionEffect] Destroyed at (1353.418, 3173.647) (time_remaining=19.8s)
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 94)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.54230046, -0.8401846), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ReplayManager] Recording frame 600 (7,3s): player_valid=True, enemies=18
+[15:49:40] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=464
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2141.108, 2958.261), source=ENEMY (Platform_TeleporterRight1), range=840, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2053.365, 3292.898), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [ENEMY] [CentralWalkway_ForceFieldLeft] PURSUING corner check: angle -3.6°
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle 92.6°
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1920.501, 3079.363) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1984.833, 3007.563) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1989.069, 3031.551) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1848.854, 3039.02) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1842.755, 3071.405) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1933.751, 3283.96) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1934.225, 3272.164) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1941.06, 3095.45) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1893.169, 3020.492) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2032.562, 3025.172) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1936.678, 3081.561) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2088.436, 3331.808) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2107.618, 3249.19) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2070.681, 3328.862) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2080.263, 3234.173) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1949.516, 3097.358) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1949.379, 3088.107) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1883.989, 3082.482) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1934.29, 3089.243) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1964.498, 3218.51) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1937.688, 3246.498) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1926.734, 3233.874) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1928.78, 3204.365) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1926.6, 3278.22) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1909.933, 3018.75) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1958.951, 3088.165) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2000.144, 3007.263) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2044.227, 3235.231) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2062.696, 3271.904) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1947.768, 3000.151) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1984.864, 3040.167) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1888.304, 3045.129) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1966.113, 3152.645) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1991.869, 3046.528) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1946.251, 3032.699) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2001.64, 3060.833) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2073.2, 3188.579) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2035.656, 3162.646) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2033.658, 3172.804) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2038.952, 3182.384) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1952.568, 3070.462) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1944.306, 3076.242) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1945.995, 3048.44) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1972.739, 3064.043) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1964.071, 3075.7) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1944.93, 3046.343) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1985.251, 3072.385) (added to group)
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 95)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.6757076, 0.73716986), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 96)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.27947176, -0.960154), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [ENEMY] [Platform_TeleporterRight1] Found cover at (2188.818, 3074.36) (distance: 125.5, player at (2000, 3100))
+[15:49:40] [ENEMY] [Platform_TeleporterRight1] State: COMBAT -> SEEKING_COVER
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(984.0486, 3181.323), source=ENEMY (Platform_TeleporterLeft1), range=840, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2114.243, 2944.703), source=NEUTRAL (null), range=900, listeners=18
+[15:49:40] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2114.243, 2944.703), intensity=0.01, dist=530
+[15:49:40] [ENEMY] [CentralWalkway_ForceFieldRight] Heard CASING_KICK at (2114.243, 2944.703), intensity=0.01, dist=671
+[15:49:40] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (2114.243, 2944.703), intensity=0.00, dist=714
+[15:49:40] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (2114.243, 2944.703), intensity=0.02, dist=367
+[15:49:40] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (2114.243, 2944.703), intensity=1.00, dist=34
+[15:49:40] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2114.243, 2944.703), intensity=0.02, dist=354
+[15:49:40] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2114.243, 2944.703), intensity=0.02, dist=330
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=11, self=0
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 97)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.52852815, -0.8489158), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410.002, 3097.061) (distance: 7.3, player at (2000, 3100))
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:40] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=463
+[15:49:40] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P2:combat_state -> P1:visible, state=FLANKING, target=24.3°, current=36.8°, player=(2000,3100), corner_timer=0.00
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [ENEMY] [Platform_TeleporterLeft3] State: FLANKING -> COMBAT
+[15:49:40] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.803, 3274.93), source=ENEMY (Platform_TeleporterRight3), range=840, listeners=18
+[15:49:40] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:40] [ENEMY] [Platform_TeleporterLeft3] Found cover at (1741.834, 2947.345) (distance: 52.3, player at (2000, 3100))
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 98)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.75338006, 0.6575854), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 99)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.23852946, -0.9711353), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1808.022, 3297.555) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1820.734, 3319.758) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2037.885, 3015.401) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2152.614, 3327.931) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1968.576, 3079.317) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1809.352, 3271.853) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1932.669, 3293.622) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1851.293, 3325.49) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1882.22, 3282.171) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1893.276, 3306.275) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1971.642, 3000.839) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1991.941, 3053.021) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1917.953, 3084.085) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1930.585, 3086.091) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2023.302, 3015.973) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2089.273, 3272.261) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2055.398, 3338.785) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1946.066, 3056.291) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1926.813, 3092.283) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1918.875, 2991.508) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1945.419, 2995.804) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1929.534, 3219.475) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1935.869, 3275.205) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1929.655, 3204.392) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1897.337, 3206.58) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1975.2, 3231.839) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1959.35, 3041.075) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2012.981, 3017.949) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1946.586, 3067.2) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1976.284, 3051.913) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1959.094, 3058.578) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1924.343, 3042.643) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2053.153, 3273.555) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2080.083, 3219.111) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2051.106, 3254.848) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2095.879, 3179.347) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2091.89, 3228.03) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2080.296, 3219.721) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2084.047, 3248.602) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1893.256, 3037.883) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1932.471, 3033.928) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1941.781, 3076.948) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1956.944, 2990.693) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1998.355, 3030.799) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1933.39, 3069.647) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1881.932, 3040.411) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1929.886, 3184.223) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1959.87, 3223.037) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1946.809, 3175.351) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1969.717, 3180.686) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1950.489, 3045.918) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1995.602, 3068.774) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1942.231, 3041.748) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2004.075, 3069.948) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1999.331, 3061.293) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1951.827, 3060.668) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (1882.992, 3070.224) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2007.756, 3070.486) (added to group)
+[15:49:40] [INFO] [BloodDecal] Blood puddle created at (2014.444, 3046.933) (added to group)
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:40] [INFO] [ScoreManager] Damage taken: 1 (total: 100)
+[15:49:40] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:40] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.4903675, -0.8715158), lethal=False (C#)
+[15:49:40] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:40] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=462
+[15:49:41] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410.002, 3097.061) (distance: 7.3, player at (2000, 3100))
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [ScoreManager] Damage taken: 1 (total: 101)
+[15:49:41] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:41] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.87146616, 0.49045566), lethal=False (C#)
+[15:49:41] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:41] [INFO] [ScoreManager] Damage taken: 1 (total: 102)
+[15:49:41] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:41] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.3302612, -0.9438896), lethal=False (C#)
+[15:49:41] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1865.287, 3335.445) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1870.587, 3026.231) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1931.483, 3329.736) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1882.572, 3347.122) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1877.849, 3232.694) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1809.574, 3276.85) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1930.329, 3235.732) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1889.027, 3238.183) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1937.912, 3074.381) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1931.517, 3067.214) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1869.382, 3020.23) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2027.692, 3265.092) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2063.922, 3332.331) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2035.433, 3309.43) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1933.715, 2985.586) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1912.702, 3062.776) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1926.016, 3226.937) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1948.824, 3235.016) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1876.451, 3198.821) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1858.87, 3215.888) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1951.203, 3231.118) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1893.521, 3194.729) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1918.977, 3014.698) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1935.2, 3023.165) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1955.767, 2986.797) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2002.934, 3070.413) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1892.984, 3082.165) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1977.956, 3053.658) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1911.538, 3094.544) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1920.776, 3059.943) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1979.711, 3070.716) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1955.682, 3165.526) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1929.554, 3196.646) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1976, 3192.805) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1942.299, 3153.589) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1948.103, 3169.252) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1966.502, 3180.657) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1944.539, 3224.872) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1962.44, 3040.302) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1980.557, 3042.383) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1981.358, 3076.434) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1965.638, 3061.732) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1957.393, 3056.06) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1984.474, 3168.789) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1990.201, 3039.838) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1990.188, 3043.192) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1971.558, 3145.03) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1974.072, 3063.887) (added to group)
+[15:49:41] [INFO] [ScoreManager] Damage taken: 1 (total: 103)
+[15:49:41] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:41] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.5514145, -0.8342314), lethal=False (C#)
+[15:49:41] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2173.542, 3037.191), source=ENEMY (Platform_TeleporterRight1), range=840, listeners=18
+[15:49:41] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2053.155, 3292.975), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:41] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [ENEMY] [Platform_ShieldRight] FLANKING corner check: angle -118.7°
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [ENEMY] [Platform_TeleporterRight2] Found cover at (2087.189, 3701.325) (distance: 409.8, player at (2000, 3100))
+[15:49:41] [ENEMY] [Platform_TeleporterRight2] State: COMBAT -> SEEKING_COVER
+[15:49:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2101.941, 3274.879), source=ENEMY (Platform_TeleporterRight3), range=840, listeners=18
+[15:49:41] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(3700, 2670), source=ENEMY (NearTracks_MachineGunnerRight), range=2400, listeners=18
+[15:49:41] [INFO] [SoundPropagation] Sound result: notified=11, out_of_range=6, self=1
+[15:49:41] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=461
+[15:49:41] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2070.232, 3274.781), source=NEUTRAL (null), range=900, listeners=18
+[15:49:41] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2070.232, 3274.781), intensity=0.00, dist=781
+[15:49:41] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (2070.232, 3274.781), intensity=0.01, dist=679
+[15:49:41] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (2070.232, 3274.781), intensity=0.02, dist=400
+[15:49:41] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (2070.232, 3274.781), intensity=0.04, dist=243
+[15:49:41] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2070.232, 3274.781), intensity=1.00, dist=28
+[15:49:41] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2070.232, 3274.781), intensity=1.00, dist=32
+[15:49:41] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=12, self=0
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [ScoreManager] Damage taken: 1 (total: 104)
+[15:49:41] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:41] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.9450977, 0.326788), lethal=False (C#)
+[15:49:41] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:41] [INFO] [ScoreManager] Damage taken: 1 (total: 105)
+[15:49:41] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:41] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.23868152, -0.9710979), lethal=False (C#)
+[15:49:41] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:41] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410.002, 3097.061) (distance: 7.3, player at (2000, 3100))
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(984.0486, 3181.323), source=ENEMY (Platform_TeleporterLeft1), range=840, listeners=18
+[15:49:41] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[15:49:41] [ENEMY] [Platform_TeleporterRight3] Found cover at (2164.613, 3692.027) (distance: 421.8, player at (2000, 3100))
+[15:49:41] [ENEMY] [Platform_TeleporterRight3] State: COMBAT -> SEEKING_COVER
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [ScoreManager] Damage taken: 1 (total: 106)
+[15:49:41] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:41] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.49649197, -0.86804134), lethal=False (C#)
+[15:49:41] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1940.679, 3349.058) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1954.059, 3063.951) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1937.616, 3076.169) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2018.131, 3024.962) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2218.208, 3307.08) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1897.945, 3110.444) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1913.177, 3257.416) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1879.515, 3262.588) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1801.002, 3267.373) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1882.782, 3041.148) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1923.701, 3033.055) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1927.659, 3002.794) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1870.344, 3066.164) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1950.904, 3077.855) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1934.105, 3105.535) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1865.346, 3264.138) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1889.09, 3217.907) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1916.865, 3298.898) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1885.868, 3207.99) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1904.411, 3175.672) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2012.075, 3025.146) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1998.076, 3063.793) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1936.548, 3013.498) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1981.456, 3049.222) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1965.892, 3040.207) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1933.826, 3114.432) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1961.971, 3089.852) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1925.821, 3062.588) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1966.524, 3198.801) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1925.12, 3158.521) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1957.054, 3140.091) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1962.034, 3191.418) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1980.647, 3195.488) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2012.5, 3024.777) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2004.163, 3069.324) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1980.303, 3015.254) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1941.094, 3065.007) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1991.738, 3026.174) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1935.039, 3062.293) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1983.791, 3045.77) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1986.421, 3072.054) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1951.58, 3061.355) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1942.081, 3235.191) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1956.863, 3221.996) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1973.936, 3175.266) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1950.596, 3152.639) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2007.642, 3027.801) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1978.954, 3076.621) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1956.025, 3056.18) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1987.481, 3064.283) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1968.528, 3074.656) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1987.371, 3072.965) (added to group)
+[15:49:41] [ENEMY] [Platform_TeleporterRight1] Found cover at (2189.208, 3079.024) (distance: 10.4, player at (2000, 3100))
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [ENEMY] [Platform_TeleporterRight1] State: SEEKING_COVER -> IN_COVER
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (1410.002, 3097.061) (distance: 7.3, player at (2000, 3100))
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [ScoreManager] Damage taken: 1 (total: 107)
+[15:49:41] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:41] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.11369694, -0.99351555), lethal=False (C#)
+[15:49:41] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:41] [ENEMY] [NearTracks_MachineGunnerRight] [#1033] MG corridor suppression: fired at passage (2000, 3100), ammo=460
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[15:49:41] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(2125.513, 3241.196), source=NEUTRAL (null), range=900, listeners=18
+[15:49:41] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (2125.513, 3241.196), intensity=0.00, dist=768
+[15:49:41] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (2125.513, 3241.196), intensity=0.00, dist=725
+[15:49:41] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (2125.513, 3241.196), intensity=0.01, dist=424
+[15:49:41] [ENEMY] [Platform_TeleporterRight1] Heard CASING_KICK at (2125.513, 3241.196), intensity=0.08, dist=178
+[15:49:41] [ENEMY] [Platform_TeleporterRight2] Heard CASING_KICK at (2125.513, 3241.196), intensity=0.13, dist=139
+[15:49:41] [ENEMY] [Platform_TeleporterRight3] Heard CASING_KICK at (2125.513, 3241.196), intensity=1.00, dist=34
+[15:49:41] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=12, self=0
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [ScoreManager] Damage taken: 1 (total: 108)
+[15:49:41] [INFO] [Player] Hit blocked by invincibility mode (C#)
+[15:49:41] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(-0.50651145, -0.8622332), lethal=False (C#)
+[15:49:41] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[15:49:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1768.415, 3012.479), source=ENEMY (Platform_TeleporterLeft3), range=840, listeners=18
+[15:49:41] [INFO] [SoundPropagation] Sound result: notified=6, out_of_range=11, self=1
+[15:49:41] [ENEMY] [Platform_TeleporterRight1] State: IN_COVER -> PURSUING
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: P1:visible -> P2:combat_state, state=PURSUING, target=172.7°, current=165.0°, player=(2000,3100), corner_timer=0.00
+[15:49:41] [ENEMY] [Platform_TeleporterRight1] PURSUING: close/visible unhittable target, attempting FLANKING before pursuit cover
+[15:49:41] [ENEMY] [Platform_TeleporterRight1] FLANKING started: target=(2121.29, 3259.038), side=right, pos=(2190.953, 3075.447)
+[15:49:41] [ENEMY] [Platform_TeleporterRight1] State: PURSUING -> FLANKING
+[15:49:41] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(2004.516, 3320.309), source=ENEMY (Platform_TeleporterRight2), range=840, listeners=18
+[15:49:41] [INFO] [SoundPropagation] Sound result: notified=5, out_of_range=12, self=1
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1002px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (790px), no illusions spawned
+[15:49:41] [INFO] [ChemicalCloud] Player not in range (1948px), no illusions spawned
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1883.757, 3274.065) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2004.168, 3010.682) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2002.139, 3068.852) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1930.759, 2990.85) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1959.738, 3012.129) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1928.41, 3043.241) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1907.524, 3144.397) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1902.606, 3314.767) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1896.83, 3252.293) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1989.204, 3062.273) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1981.125, 3085.933) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1938.623, 3008.799) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1980.586, 3073.226) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1991.92, 3000.367) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1926.337, 3012.315) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1963.254, 3066.641) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2045.473, 3017.721) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1874.75, 3016.437) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1955.141, 3073.873) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1980.976, 2988.801) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1884.524, 3087.195) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1969.756, 2993.18) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1929.911, 3070.136) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1965.785, 3060.369) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1950.007, 3280.879) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1919.921, 3195.88) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1864.1, 3286.973) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1905.961, 3227.972) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1985.547, 3023.981) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1981.481, 2993.765) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2008.188, 3072.476) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1938.101, 3010.51) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1921.398, 3040.429) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1932.962, 3109.046) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1947.211, 3021.844) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1975.21, 3050.771) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1891.585, 3195.387) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1941.572, 3265.105) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1948.817, 3194.915) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1928.299, 3164.008) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1939.707, 3046.271) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2009.691, 3046.203) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1978.444, 3029.157) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1916.936, 3024.465) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1916.856, 3069.649) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1980.187, 3054.144) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1935.654, 3087.47) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1969.183, 3061.122) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1937.88, 3163.111) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1963.372, 3163.323) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1953.512, 3186.328) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1931.431, 3185.315) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1949.364, 3180.837) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1932.723, 3128.716) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1928.495, 3220.729) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1922.124, 3145.238) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1931.903, 3070.955) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1989.998, 3047.546) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1965.421, 3046.466) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1941.173, 3046.84) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1984.148, 3047.519) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1966.576, 3057.609) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1943.767, 3032.234) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1917.225, 3116.452) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1979.831, 3065.652) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1845.349, 3282.074) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1874.565, 3222.896) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1924.572, 3275.941) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1909.851, 3295.681) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1987.613, 2997.754) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1939.328, 3111.991) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1919.389, 3057.592) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1969.658, 2985.863) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1981.772, 3082.154) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1836.099, 3244.703) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1896.916, 3238.824) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1902.403, 3261.17) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1852.659, 3247.638) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2025.38, 3054.665) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1989.102, 3013.812) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1997.833, 2987.384) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1892.136, 3030.398) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1981.635, 3023.976) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1946.633, 3023.552) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1889.165, 3020.271) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1902.834, 3266.943) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1884.558, 3267.307) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1912.685, 3179.904) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2018.348, 3016.876) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1993.768, 2995.511) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1979.614, 3012.951) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1988.817, 3022.224) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1985.985, 3022.998) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1962.968, 3084.856) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1912.766, 3213.734) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1938.842, 3162.297) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1913.333, 3164.27) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1924.398, 3162.449) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1919.109, 3146.278) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2009.717, 3052.93) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1971.658, 3068.039) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1964.922, 3075.127) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (2015.6, 3042.254) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1971.611, 3053.938) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1965.137, 3053.713) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1966.186, 3027.267) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1949.876, 3021.781) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1956.708, 3022.605) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1968.628, 3012.056) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1976.607, 3048.889) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1999.773, 3073.791) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1994.183, 3063.741) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1970.212, 3034.975) (added to group)
+[15:49:41] [INFO] [BloodDecal] Blood puddle created at (1978.738, 3038.983) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1822.616, 3300.473) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1911.034, 3059.366) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1897.038, 3020.9) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1943.3, 3007.212) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1956.988, 3075.872) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1899.388, 3029.619) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1897.203, 3071.966) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1918.156, 3276.139) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1830.856, 3265.991) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1994.57, 3098.665) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1917.657, 3051.298) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1977.665, 3020.763) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1878.9, 3014.979) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1950.318, 3090.302) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1884.659, 3070.077) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1978.555, 3045.583) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1930.151, 3009.454) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1878.107, 3297.757) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1887.212, 3279.936) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1897.511, 3209.965) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1972.319, 3034.661) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1996.222, 3032.859) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1962.864, 2998.619) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1949.945, 3044.385) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1853.354, 3191.933) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1880.238, 3139.963) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1959.778, 3032.76) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1956.665, 3030.802) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1969.844, 2998.825) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2027.599, 3015.638) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2002.762, 3050.98) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1958.289, 3053.524) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1923.784, 3036.194) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1931.246, 3082.472) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1968.69, 3054.512) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1921.449, 3056.732) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1793.966, 3272.051) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1889.201, 3088.079) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1995.855, 3039.49) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1897.1, 3000.74) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1934.93, 3011.971) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1904.626, 3005.451) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1875.618, 3079.672) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1844.103, 3046.103) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1874.248, 3075.931) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1901.416, 3262.517) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1892.26, 3230.702) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2027.598, 2995.249) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1903.533, 3029.249) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1952.661, 3058.283) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1979.335, 2976.382) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1886.239, 3055.447) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1891.934, 3089.538) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1991.191, 3076.719) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2028.793, 3030.909) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1911.791, 3015.286) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1941.902, 3100.413) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1940.656, 3072.229) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1937.738, 3041.141) (added to group)
+[15:49:42] [INFO] [ReplayManager] Recording frame 660 (8,3s): player_valid=True, enemies=18
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1895.67, 3007.731) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1860.368, 3088.078) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1936.353, 3027.499) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1952.566, 3020.622) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1822.634, 3204.579) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1787.248, 3235.534) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2010.987, 2979.866) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1989.78, 3076.577) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1997.416, 3054.677) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1965.757, 3047.125) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1895.057, 3112.112) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1889.586, 3094.285) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1962.304, 3087.26) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2041.747, 3039.025) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1935.416, 3050.406) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2013.97, 3069.102) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1960.332, 3093.212) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1894.013, 3081.055) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1907.388, 2993.883) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1815.224, 3231.494) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1885.161, 3213.493) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1897.23, 3238.042) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1973.09, 3103.486) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1897.046, 3142.797) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2033.139, 3039.098) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2062.246, 2979.756) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2059.031, 2984.382) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1944.028, 3005.438) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1970.585, 3040.845) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (2048.475, 3083.934) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1964.521, 2984.11) (added to group)
+[15:49:42] [INFO] [BloodDecal] Blood puddle created at (1869.333, 3112.944) (added to group)
+[15:49:43] [INFO] [ReplayManager] Recording frame 720 (9,3s): player_valid=True, enemies=18
+[15:49:44] [INFO] [ReplayManager] Recording frame 780 (10,3s): player_valid=True, enemies=18
+[15:49:44] [INFO] ------------------------------------------------------------
+[15:49:44] [INFO] GAME LOG ENDED: 2026-05-03T15:49:44
+[15:49:44] [INFO] ============================================================

--- a/docs/case-studies/issue-1931/artifacts/game_log_20260503_160550.txt
+++ b/docs/case-studies/issue-1931/artifacts/game_log_20260503_160550.txt
@@ -1,0 +1,1669 @@
+[16:05:50] [INFO] ============================================================
+[16:05:50] [INFO] GAME LOG STARTED
+[16:05:50] [INFO] ============================================================
+[16:05:50] [INFO] Timestamp: 2026-05-03T16:05:50
+[16:05:50] [INFO] Log file: I:/Загрузки/godot exe/звУк/game_log_20260503_160550.txt
+[16:05:50] [INFO] Executable: I:/Загрузки/godot exe/звУк/Godot-Top-Down-Template.exe
+[16:05:50] [INFO] OS: Windows
+[16:05:50] [INFO] Debug build: false
+[16:05:50] [INFO] Engine version: 4.3-stable (official)
+[16:05:50] [INFO] Project: Godot Top-Down Template
+[16:05:50] [INFO] Build branch: issue-1931-00bcd7d31ef5
+[16:05:50] [INFO] Build commit: 40bfff67adf4e9627c0eb5d92ec3cc689eaded28
+[16:05:50] [INFO] Build date: 2026-05-03T12:54:11Z
+[16:05:50] [INFO] ------------------------------------------------------------
+[16:05:50] [INFO] [GameManager] GameManager ready
+[16:05:50] [INFO] [ScoreManager] ScoreManager ready
+[16:05:50] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[16:05:50] [INFO] [SoundPropagation] SoundPropagation autoload initialized
+[16:05:50] [INFO] [DifficultyManager] Loaded difficulty: Gunslinger (value: 5)
+[16:05:50] [INFO] [ImpactEffects] Scenes loaded: DustEffect, BloodEffect, SparksEffect, BloodDecal, WaterBloodDiffusion
+[16:05:50] [INFO] [ImpactEffects] ImpactEffectsManager ready - FULL VERSION with blood effects enabled
+[16:05:50] [INFO] [ImpactEffects] Explosion light pool initialized: 12 lights pre-created
+[16:05:50] [INFO] [ImpactEffects] Dust effect pool initialized: 16 effects pre-created
+[16:05:50] [INFO] [ImpactEffects] Starting particle shader warmup (Issue #343 fix)...
+[16:05:50] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[16:05:50] [INFO] [PenultimateHit] Saturation shader loaded successfully
+[16:05:50] [INFO] [PenultimateHit] Starting shader warmup (Issue #343 fix)...
+[16:05:50] [INFO] [PenultimateHit] PenultimateHitEffectsManager ready - Configuration:
+[16:05:50] [INFO] [PenultimateHit]   Time scale: 0.10 (10x slowdown)
+[16:05:50] [INFO] [PenultimateHit]   Saturation boost: 2.0 (3.0x)
+[16:05:50] [INFO] [PenultimateHit]   Contrast boost: 1.0 (2.0x)
+[16:05:50] [INFO] [PenultimateHit]   Effect duration: 3.0 real seconds
+[16:05:50] [INFO] [LastChance] Resetting all effects (scene change detected)
+[16:05:50] [INFO] [LastChance] Last chance shader loaded successfully
+[16:05:50] [INFO] [LastChance] Starting shader warmup (Issue #343 fix)...
+[16:05:50] [INFO] [LastChance] LastChanceEffectsManager ready - Configuration:
+[16:05:50] [INFO] [LastChance]   Freeze duration: 6.0 real seconds
+[16:05:50] [INFO] [LastChance]   Sepia intensity: 0.70
+[16:05:50] [INFO] [LastChance]   Brightness: 0.60
+[16:05:50] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FlashbangGrenade.tscn
+[16:05:50] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/FragGrenade.tscn
+[16:05:50] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DefensiveGrenade.tscn
+[16:05:50] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/AggressionGasGrenade.tscn
+[16:05:50] [INFO] [GrenadeManager] Loaded grenade scene: res://scenes/projectiles/DroneGrenade.tscn
+[16:05:50] [INFO] [ExperimentalSettings] ExperimentalSettings initialized - FOV: true, Complex grenades: false, AI prediction: true, Debug: false, Invincibility: true, Realistic visibility: false, Replay: false, Logging: true, Enemy flashlight blinding: false, FPS counter: false, FPS drop logging: true, All weapons unlocked: true, All maps unlocked: true, Global stuck max time: 20.0s, Nav mesh visible: false, Search path visible: false, Passage waypoints visible: false, Passage waypoints: false, Sound visualizer: false, Enemy path visible: false, Cover raycast visible: false, Tactical group: false, Cover infinite rays: true, Cover sector rays: true, Roguelike unlocked: false
+[16:05:50] [INFO] [NavMeshMonitor] NavMeshMonitor ready
+[16:05:50] [INFO] [SoundSettings] SoundSettings initialized - effects: 0.50, music: 1.00
+[16:05:50] [INFO] [GameplaySettings] GameplaySettings initialized - blood_amount: 1.00, wall_hit_particles: true, revolver_aim_assist: true, unlock_notifications: true, combo_font_size: 140
+[16:05:50] [INFO] [CinemaEffects] CinemaEffectsManager initializing (v5.3 - overlay approach with simplified death circle)...
+[16:05:50] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[16:05:50] [INFO] [CinemaEffects] Created effects layer at layer 99
+[16:05:50] [INFO] [CinemaEffects] Cinema shader loaded successfully (v5.0 - no screen_texture)
+[16:05:50] [INFO] [CinemaEffects] Starting cinema shader warmup (Issue #343 fix)...
+[16:05:50] [INFO] [CinemaEffects] Cinema film effect initialized (v5.3) - Configuration:
+[16:05:50] [INFO] [CinemaEffects]   Approach: Overlay-based (no screen_texture)
+[16:05:50] [INFO] [CinemaEffects]   Grain intensity: 0.15
+[16:05:50] [INFO] [CinemaEffects]   Warm tint: 0.12 intensity
+[16:05:50] [INFO] [CinemaEffects]   Sunny effect: 0.08 intensity
+[16:05:50] [INFO] [CinemaEffects]   Vignette: 0.25 intensity
+[16:05:50] [INFO] [CinemaEffects]   Film defects: 1.5% probability
+[16:05:50] [INFO] [CinemaEffects]   White specks: 0.70 intensity, 4.0% probability
+[16:05:50] [INFO] [CinemaEffects]   Death effects: cigarette burn + expanding spots + end of reel circle (160px, blinks 2x)
+[16:05:50] [INFO] [CinemaEffects] Enabling effect after 1 frame(s)...
+[16:05:50] [INFO] [GrenadeTimerHelper] Autoload ready
+[16:05:50] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[16:05:50] [INFO] [PowerFantasy] Saturation shader loaded successfully
+[16:05:50] [INFO] [PowerFantasy] PowerFantasyEffectsManager ready - Configuration:
+[16:05:50] [INFO] [PowerFantasy]   Kill effect duration: 600ms
+[16:05:50] [INFO] [PowerFantasy]   Grenade effect duration: 2000ms (2.0s)
+[16:05:50] [INFO] [BlackMetalEffectsManager] BlackMetalEffectsManager initializing...
+[16:05:50] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[16:05:50] [INFO] [BlackMetalEffectsManager] Black Metal shader loaded (B&W+red, hint_screen_texture approach)
+[16:05:50] [INFO] [BlackMetalEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[16:05:50] [INFO] [BlackMetalEffectsManager] Black Metal filter DISABLED
+[16:05:50] [INFO] [BlackMetalLightningEffectsManager] BlackMetalLightningEffectsManager initializing...
+[16:05:50] [INFO] [BlackMetalLightningEffectsManager] Lightning bolt drawer created (v10 - no shader, pure draw calls)
+[16:05:50] [INFO] [BlackMetalLightningEffectsManager] Connected to GameManager.enemy_killed signal
+[16:05:50] [INFO] [BlackMetalLightningEffectsManager] Starting shader warmup (Issue #343 pattern)...
+[16:05:50] [INFO] [ProgressManager] ProgressManager ready, loaded 21 entries
+[16:05:50] [INFO] [ReplayManager] ReplayManager ready (C# version loaded and _Ready called)
+[16:05:50] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[16:05:50] [INFO] [FlashbangPlayer] Flashbang player shader loaded successfully
+[16:05:50] [INFO] [FlashbangPlayer] Starting shader warmup (Issue #343 fix)...
+[16:05:50] [INFO] [FlashbangPlayer] FlashbangPlayerEffectsManager ready
+[16:05:50] [INFO] [FlashbangPlayer]   Duration range: 1.0-5.0 seconds
+[16:05:50] [INFO] [SceneLoader] SceneLoader initialized
+[16:05:50] [INFO] [PersistManager] Loading saved state from user://game_state.cfg
+[16:05:50] [INFO] [PersistManager] Restored unlocked weapon: makarov_pm
+[16:05:50] [INFO] [PersistManager] Restored unlocked weapon: silenced_pistol
+[16:05:50] [INFO] [PersistManager] Restored unlocked weapon: ak_gl
+[16:05:50] [INFO] [PersistManager] Restored kills_without_laser_sight: 246
+[16:05:50] [INFO] [PersistManager] Restored shots_fired_special_weapons: 336
+[16:05:50] [INFO] [PersistManager] Restored total_deaths: 52
+[16:05:50] [INFO] [PersistManager] Restored no_damage_levels_completed: 4
+[16:05:50] [INFO] [PersistManager] Restored levels_completed_rank_a_or_higher: 11
+[16:05:50] [INFO] [PersistManager] Restored levels_completed_rank_s: 0
+[16:05:50] [INFO] [PersistManager] Restored kills_through_wall: 10
+[16:05:50] [INFO] [PersistManager] Restored levels_completed_with_silenced_pistol: 1
+[16:05:50] [INFO] [GameManager] Weapon selected: sniper
+[16:05:50] [INFO] [PersistManager] Restored selected weapon: sniper
+[16:05:50] [INFO] [PersistManager] Restored unlocked grenade type: 0
+[16:05:50] [INFO] [GrenadeManager] Grenade type changed from Flashbang to F-1 Grenade
+[16:05:50] [INFO] [PersistManager] Restored selected grenade type: 2
+[16:05:50] [INFO] [PersistManager] Restored unlocked active item type: 0
+[16:05:50] [INFO] [PersistManager] Restored unlocked active item type: 11
+[16:05:50] [INFO] [ActiveItemManager] Active item changed from None to Extended Magazine
+[16:05:50] [INFO] [PersistManager] Restored selected active item type: 10
+[16:05:50] [INFO] [PersistManager] Loudspeaker progress restored: level 1, levels_completed=0
+[16:05:50] [INFO] [PersistManager] State loaded successfully
+[16:05:50] [INFO] [PersistManager] PersistManager ready
+[16:05:50] [INFO] [UnlockManager] UnlockManager ready
+[16:05:50] [INFO] [WeaponHintsSettings] WeaponHintsSettings initialized - mode: ALWAYS, weapons seen: ["makarov_pm", "revolver", "mini_uzi", "shotgun", "sniper", "m16", "silenced_pistol", "ak_gl"]
+[16:05:50] [INFO] [PerformanceSettings] PerformanceSettings initialized - particles: true, blood_decals: true, screen_shake: true, explosion_lights: true, warm_lights: true, ai: true
+[16:05:50] [INFO] [LocalizationSettings] Loaded 2 translation(s)
+[16:05:50] [INFO] [LocalizationSettings] LocalizationSettings initialized — locale: en
+[16:05:50] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_condition
+[16:05:50] [INFO] [UnlockNotificationManager] Connected to items_unlocked_by_kill_condition
+[16:05:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:50] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[16:05:50] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[16:05:50] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[16:05:50] [ENEMY] [Enemy1] Death animation component initialized
+[16:05:50] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[16:05:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:50] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[16:05:50] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[16:05:50] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[16:05:50] [ENEMY] [Enemy2] Death animation component initialized
+[16:05:50] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[16:05:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:50] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[16:05:50] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[16:05:50] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[16:05:50] [ENEMY] [Enemy3] Death animation component initialized
+[16:05:50] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[16:05:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:50] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[16:05:50] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[16:05:50] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[16:05:50] [ENEMY] [Enemy4] Death animation component initialized
+[16:05:50] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[16:05:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:50] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[16:05:50] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[16:05:50] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[16:05:50] [ENEMY] [Enemy5] Death animation component initialized
+[16:05:50] [ENEMY] [Enemy5] [Gunslinger] Enemy glow applied
+[16:05:50] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:50] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[16:05:50] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[16:05:50] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[16:05:50] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[16:05:50] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[16:05:50] [INFO] [Player.Weapon] GameManager weapon selection: sniper (SniperRifle)
+[16:05:50] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[16:05:50] [INFO] [Player.Weapon] Equipped SniperRifle (ammo: 12/5)
+[16:05:50] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[16:05:50] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[16:05:50] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[16:05:50] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[16:05:50] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[16:05:50] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[16:05:50] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[16:05:50] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[16:05:50] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[16:05:50] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[16:05:50] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[16:05:50] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[16:05:50] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[16:05:50] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[16:05:50] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[16:05:50] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[16:05:50] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[16:05:50] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[16:05:50] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[16:05:50] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[16:05:50] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[16:05:50] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[16:05:50] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[16:05:50] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[16:05:50] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[16:05:50] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[16:05:50] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[16:05:50] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[16:05:50] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[16:05:50] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[16:05:50] [INFO] [Player.Jammer] JammerHUD initialized
+[16:05:50] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[16:05:50] [INFO] [Player] Ready! Ammo: 12/5, Grenades: 1/3, Health: 3/4
+[16:05:50] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[16:05:50] [INFO] [BloodDecal] Blood puddle created at (640, 360) (added to group)
+[16:05:50] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[16:05:50] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[16:05:50] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[16:05:50] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[16:05:50] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[16:05:50] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[16:05:50] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[16:05:50] [INFO] [LabyrinthLevel] Setting up weapon: sniper
+[16:05:50] [INFO] [LabyrinthLevel] SniperRifle already equipped by C# Player - applying labyrinth ammo config
+[16:05:50] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for sniper
+[16:05:50] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): SniperRifle 12/72
+[16:05:50] [INFO] [GameManager] set_player() called with: <CharacterBody2D#87342188304> (class: CharacterBody2D)
+[16:05:50] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[16:05:50] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[16:05:50] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[16:05:50] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[16:05:50] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[16:05:50] [INFO] [ScoreManager] Level started with 5 enemies
+[16:05:50] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[16:05:51] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[16:05:51] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[16:05:51] [INFO] [ReplayManager] Replay data cleared
+[16:05:51] [INFO] [LabyrinthLevel] Previous replay data cleared
+[16:05:51] [INFO] [ReplayManager] Detected player weapon: Sniper Rifle (ASVK)
+[16:05:51] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[16:05:51] [INFO] [ReplayManager] Level: LabyrinthLevel
+[16:05:51] [INFO] [ReplayManager] Player: Player (valid: True)
+[16:05:51] [INFO] [ReplayManager] Enemies count: 5
+[16:05:51] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/asvk_topdown.png
+[16:05:51] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[16:05:51] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[16:05:51] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[16:05:51] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[16:05:51] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[16:05:51] [INFO] [LabyrinthLevel] Replay recording started successfully
+[16:05:51] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[16:05:51] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[16:05:51] [INFO] [CinemaEffects] Found player node: Player
+[16:05:51] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[16:05:51] [INFO] [PersistManager] Navigating to last played level: res://scenes/levels/RailwayStationLevel.tscn
+[16:05:51] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/RailwayStationLevel.tscn
+[16:05:51] [INFO] [UnlockManager] Reset condition-gated items to locked state
+[16:05:51] [INFO] [UnlockManager] Restored saved unlock for weapon: silenced_pistol
+[16:05:51] [INFO] [UnlockManager] Restored saved unlock for weapon: ak_gl
+[16:05:51] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[16:05:51] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[16:05:51] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[16:05:51] [ENEMY] [Enemy1] Registered as sound listener
+[16:05:51] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[16:05:51] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[16:05:51] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[16:05:51] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[16:05:51] [ENEMY] [Enemy2] Registered as sound listener
+[16:05:51] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[16:05:51] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[16:05:51] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[16:05:51] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[16:05:51] [ENEMY] [Enemy3] Registered as sound listener
+[16:05:51] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[16:05:51] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[16:05:51] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[16:05:51] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[16:05:51] [ENEMY] [Enemy4] Registered as sound listener
+[16:05:51] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[16:05:51] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[16:05:51] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[16:05:51] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[16:05:51] [ENEMY] [Enemy5] Registered as sound listener
+[16:05:51] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 1, behavior: GUARD
+[16:05:51] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[16:05:51] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[16:05:51] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(150,1000), corner_timer=0.00
+[16:05:51] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[16:05:51] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[16:05:51] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=146.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[16:05:51] [INFO] [Player] Detecting weapon pose (frame 3)...
+[16:05:51] [INFO] [Player] Detected weapon: ASVK Sniper Rifle (Sniper pose)
+[16:05:51] [INFO] [Player] Applied Sniper arm pose: Left=(28, 6), Right=(-3, 6)
+[16:05:51] [INFO] [PenultimateHit] Shader warmup complete in 1289 ms
+[16:05:51] [INFO] [LastChance] Shader warmup complete in 1288 ms
+[16:05:51] [INFO] [CinemaEffects] Cinema shader warmup complete in 1154 ms
+[16:05:51] [INFO] [BlackMetalEffectsManager] Shader warmup complete in 1145 ms
+[16:05:51] [INFO] [BlackMetalLightningEffectsManager] Shader warmup complete in 0 ms
+[16:05:51] [INFO] [FlashbangPlayer] Shader warmup complete in 1141 ms
+[16:05:51] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[16:05:51] [INFO] [SceneLoader] ERROR: Invalid resource (falling back to sync): res://scenes/levels/RailwayStationLevel.tscn
+[16:05:51] [INFO] [SceneLoader] Using synchronous load fallback
+[16:05:51] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[16:05:51] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[16:05:51] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[16:05:51] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[16:05:51] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[16:05:51] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:05:51] [INFO] [SceneLoader] Sync fallback scene changed successfully: res://scenes/levels/RailwayStationLevel.tscn
+[16:05:51] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] BloodyFeetComponent ready on NearTracks_MachineGunnerLeft
+[16:05:51] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[16:05:51] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:05:51] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[16:05:51] [INFO] [LastChance] Resetting all effects (scene change detected)
+[16:05:51] [INFO] [CinemaEffects] Scene changed to: RailwayStationLevel
+[16:05:51] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[16:05:51] [INFO] [BlackMetalEffectsManager] Scene changed to: RailwayStationLevel
+[16:05:51] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[16:05:51] [INFO] [PersistManager] Startup navigation complete — arrived at: res://scenes/levels/RailwayStationLevel.tscn
+[16:05:51] [INFO] [PersistManager] State saved to user://game_state.cfg
+[16:05:51] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/RailwayStationLevel.tscn
+[16:05:51] [ENEMY] [NearTracks_MachineGunnerLeft] Death animation component initialized
+[16:05:51] [ENEMY] [NearTracks_MachineGunnerLeft] [Gunslinger] Enemy glow applied
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] BloodyFeetComponent ready on NearTracks_MachineGunnerRight
+[16:05:51] [ENEMY] [NearTracks_MachineGunnerRight] Death animation component initialized
+[16:05:51] [ENEMY] [NearTracks_MachineGunnerRight] [Gunslinger] Enemy glow applied
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] BloodyFeetComponent ready on FarTracks_MachineGunnerLeft
+[16:05:51] [ENEMY] [FarTracks_MachineGunnerLeft] Death animation component initialized
+[16:05:51] [ENEMY] [FarTracks_MachineGunnerLeft] [Gunslinger] Enemy glow applied
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] BloodyFeetComponent ready on FarTracks_MachineGunnerRight
+[16:05:51] [ENEMY] [FarTracks_MachineGunnerRight] Death animation component initialized
+[16:05:51] [ENEMY] [FarTracks_MachineGunnerRight] [Gunslinger] Enemy glow applied
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] BloodyFeetComponent ready on CentralWalkway_ForceFieldLeft
+[16:05:51] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[16:05:51] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[16:05:51] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[16:05:51] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[16:05:51] [ENEMY] [CentralWalkway_ForceFieldLeft] Death animation component initialized
+[16:05:51] [ENEMY] [CentralWalkway_ForceFieldLeft] [Gunslinger] Enemy glow applied
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] BloodyFeetComponent ready on CentralWalkway_ForceFieldRight
+[16:05:51] [INFO] [ForceFieldEffect] Area2D setup with radius 35px
+[16:05:51] [INFO] [ForceFieldEffect] Shader loaded successfully (ring texture used as base)
+[16:05:51] [INFO] [ForceFieldEffect] Initialized with 8.0s charge
+[16:05:51] [INFO] [EnemyForceField] Setup complete (duration=4.0s recharge=5.0s)
+[16:05:51] [ENEMY] [CentralWalkway_ForceFieldRight] Death animation component initialized
+[16:05:51] [ENEMY] [CentralWalkway_ForceFieldRight] [Gunslinger] Enemy glow applied
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator1] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator1] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator1] BloodyFeetComponent ready on Exit_DroneOperator1
+[16:05:51] [ENEMY] [Exit_DroneOperator1] Death animation component initialized
+[16:05:51] [INFO] [DroneOperator] VR headset visual created
+[16:05:51] [INFO] [DroneOperator] Tablet visual created
+[16:05:51] [INFO] [DroneOperator] Setup complete
+[16:05:51] [ENEMY] [Exit_DroneOperator1] Found cover at (721.5328, 1104) (distance: 21.9, player at (2000, 3100))
+[16:05:51] [ENEMY] [Exit_DroneOperator1] [Gunslinger] Enemy glow applied
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator2] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator2] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator2] BloodyFeetComponent ready on Exit_DroneOperator2
+[16:05:51] [ENEMY] [Exit_DroneOperator2] Death animation component initialized
+[16:05:51] [INFO] [DroneOperator] VR headset visual created
+[16:05:51] [INFO] [DroneOperator] Tablet visual created
+[16:05:51] [INFO] [DroneOperator] Setup complete
+[16:05:51] [ENEMY] [Exit_DroneOperator2] Found cover at (1602.407, 1104) (distance: 4.7, player at (2000, 3100))
+[16:05:51] [ENEMY] [Exit_DroneOperator2] [Gunslinger] Enemy glow applied
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator3] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator3] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator3] BloodyFeetComponent ready on Exit_DroneOperator3
+[16:05:51] [ENEMY] [Exit_DroneOperator3] Death animation component initialized
+[16:05:51] [INFO] [DroneOperator] VR headset visual created
+[16:05:51] [INFO] [DroneOperator] Tablet visual created
+[16:05:51] [INFO] [DroneOperator] Setup complete
+[16:05:51] [ENEMY] [Exit_DroneOperator3] Found cover at (1944, 1104) (distance: 556.0, player at (2000, 3100))
+[16:05:51] [ENEMY] [Exit_DroneOperator3] [Gunslinger] Enemy glow applied
+[16:05:51] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator4] Footprint scene loaded
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator4] Found EnemyModel for facing direction
+[16:05:51] [INFO] [BloodyFeet:Exit_DroneOperator4] BloodyFeetComponent ready on Exit_DroneOperator4
+[16:05:51] [ENEMY] [Exit_DroneOperator4] Death animation component initialized
+[16:05:51] [INFO] [DroneOperator] VR headset visual created
+[16:05:51] [INFO] [DroneOperator] Tablet visual created
+[16:05:51] [INFO] [DroneOperator] Setup complete
+[16:05:51] [ENEMY] [Exit_DroneOperator4] Found cover at (1944, 1104) (distance: 1356.0, player at (2000, 3100))
+[16:05:52] [ENEMY] [Exit_DroneOperator4] [Gunslinger] Enemy glow applied
+[16:05:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:52] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Footprint scene loaded
+[16:05:52] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Found EnemyModel for facing direction
+[16:05:52] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] BloodyFeetComponent ready on Spawn_GasMaskEnemy
+[16:05:52] [ENEMY] [Spawn_GasMaskEnemy] Death animation component initialized
+[16:05:52] [INFO] [GasMaskGrenade] GasMaskGrenadeComponent ready: 4 grenades
+[16:05:52] [ENEMY] [Spawn_GasMaskEnemy] [Gunslinger] Enemy glow applied
+[16:05:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Footprint scene loaded
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Found EnemyModel for facing direction
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft1] BloodyFeetComponent ready on Platform_TeleporterLeft1
+[16:05:52] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft1
+[16:05:52] [ENEMY] [Platform_TeleporterLeft1] Death animation component initialized
+[16:05:52] [ENEMY] [Platform_TeleporterLeft1] [Gunslinger] Enemy glow applied
+[16:05:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Footprint scene loaded
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Found EnemyModel for facing direction
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft2] BloodyFeetComponent ready on Platform_TeleporterLeft2
+[16:05:52] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft2
+[16:05:52] [ENEMY] [Platform_TeleporterLeft2] Death animation component initialized
+[16:05:52] [ENEMY] [Platform_TeleporterLeft2] [Gunslinger] Enemy glow applied
+[16:05:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Footprint scene loaded
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Found EnemyModel for facing direction
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft3] BloodyFeetComponent ready on Platform_TeleporterLeft3
+[16:05:52] [INFO] [Teleporter] Component initialized on Platform_TeleporterLeft3
+[16:05:52] [ENEMY] [Platform_TeleporterLeft3] Death animation component initialized
+[16:05:52] [ENEMY] [Platform_TeleporterLeft3] [Gunslinger] Enemy glow applied
+[16:05:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight1] Footprint scene loaded
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight1] Found EnemyModel for facing direction
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight1] BloodyFeetComponent ready on Platform_TeleporterRight1
+[16:05:52] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight1
+[16:05:52] [ENEMY] [Platform_TeleporterRight1] Death animation component initialized
+[16:05:52] [ENEMY] [Platform_TeleporterRight1] [Gunslinger] Enemy glow applied
+[16:05:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight2] Footprint scene loaded
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight2] Found EnemyModel for facing direction
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight2] BloodyFeetComponent ready on Platform_TeleporterRight2
+[16:05:52] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight2
+[16:05:52] [ENEMY] [Platform_TeleporterRight2] Death animation component initialized
+[16:05:52] [ENEMY] [Platform_TeleporterRight2] [Gunslinger] Enemy glow applied
+[16:05:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight3] Footprint scene loaded
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight3] Found EnemyModel for facing direction
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight3] BloodyFeetComponent ready on Platform_TeleporterRight3
+[16:05:52] [INFO] [Teleporter] Component initialized on Platform_TeleporterRight3
+[16:05:52] [ENEMY] [Platform_TeleporterRight3] Death animation component initialized
+[16:05:52] [ENEMY] [Platform_TeleporterRight3] [Gunslinger] Enemy glow applied
+[16:05:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:52] [INFO] [BloodyFeet:Platform_ShieldRight] Footprint scene loaded
+[16:05:52] [INFO] [BloodyFeet:Platform_ShieldRight] Found EnemyModel for facing direction
+[16:05:52] [INFO] [BloodyFeet:Platform_ShieldRight] BloodyFeetComponent ready on Platform_ShieldRight
+[16:05:52] [INFO] [EnemyShield] SWAT riot shield visual created with collision area (top-down view)
+[16:05:52] [INFO] [EnemyShield] Setup complete (shield_hp=20, stun=1.0s)
+[16:05:52] [ENEMY] [Platform_ShieldRight] Death animation component initialized
+[16:05:52] [ENEMY] [Platform_ShieldRight] [Gunslinger] Enemy glow applied
+[16:05:52] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:05:52] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[16:05:52] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[16:05:52] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[16:05:52] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[16:05:52] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[16:05:52] [INFO] [Player.Weapon] GameManager weapon selection: sniper (SniperRifle)
+[16:05:52] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[16:05:52] [INFO] [Player.Weapon] Equipped SniperRifle (ammo: 12/5)
+[16:05:52] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[16:05:52] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[16:05:52] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[16:05:52] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[16:05:52] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[16:05:52] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[16:05:52] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[16:05:52] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[16:05:52] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[16:05:52] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[16:05:52] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[16:05:52] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[16:05:52] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[16:05:52] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[16:05:52] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[16:05:52] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[16:05:52] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[16:05:52] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[16:05:52] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[16:05:52] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[16:05:52] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[16:05:52] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[16:05:52] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[16:05:52] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[16:05:52] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[16:05:52] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[16:05:52] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[16:05:52] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[16:05:52] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[16:05:52] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[16:05:52] [INFO] [Player.Jammer] JammerHUD initialized
+[16:05:52] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[16:05:52] [INFO] [Player] Ready! Ammo: 12/5, Grenades: 1/3, Health: 3/4
+[16:05:52] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[16:05:52] [INFO] [RailwayStationLevel] Found Environment/Enemies node with 18 children
+[16:05:52] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'NearTracks_MachineGunnerRight': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerLeft': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'FarTracks_MachineGunnerRight': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldLeft': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'CentralWalkway_ForceFieldRight': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator1': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator2': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator3': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Exit_DroneOperator4': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Spawn_GasMaskEnemy': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft1': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft2': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterLeft3': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight1': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight2': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Platform_TeleporterRight3': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Child 'Platform_ShieldRight': script=true, has_died_signal=true
+[16:05:52] [INFO] [RailwayStationLevel] Enemy tracking complete: 18 enemies registered
+[16:05:52] [INFO] [RailwayStationLevel] Setting up weapon: sniper
+[16:05:52] [INFO] [RailwayStationLevel] SniperRifle already equipped by C# Player - skipping GDScript weapon swap
+[16:05:52] [INFO] [GameManager] set_player() called with: <CharacterBody2D#162185351486> (class: CharacterBody2D)
+[16:05:52] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[16:05:52] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[16:05:52] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[16:05:52] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[16:05:52] [INFO] [ScoreManager] Level started with 18 enemies
+[16:05:52] [INFO] [RailwayStationLevel] ReplayManager found as C# autoload
+[16:05:52] [INFO] [ReplayManager] Replay data cleared
+[16:05:52] [INFO] [ReplayManager] Detected player weapon: Sniper Rifle (ASVK)
+[16:05:52] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[16:05:52] [INFO] [ReplayManager] Level: RailwayStationLevel
+[16:05:52] [INFO] [ReplayManager] Player: Player (valid: True)
+[16:05:52] [INFO] [ReplayManager] Enemies count: 18
+[16:05:52] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/asvk_topdown.png
+[16:05:52] [INFO] [ReplayManager]   Enemy 0: NearTracks_MachineGunnerLeft
+[16:05:52] [INFO] [ReplayManager]   Enemy 1: NearTracks_MachineGunnerRight
+[16:05:52] [INFO] [ReplayManager]   Enemy 2: FarTracks_MachineGunnerLeft
+[16:05:52] [INFO] [ReplayManager]   Enemy 3: FarTracks_MachineGunnerRight
+[16:05:52] [INFO] [ReplayManager]   Enemy 4: CentralWalkway_ForceFieldLeft
+[16:05:52] [INFO] [ReplayManager]   Enemy 5: CentralWalkway_ForceFieldRight
+[16:05:52] [INFO] [ReplayManager]   Enemy 6: Exit_DroneOperator1
+[16:05:52] [INFO] [ReplayManager]   Enemy 7: Exit_DroneOperator2
+[16:05:52] [INFO] [ReplayManager]   Enemy 8: Exit_DroneOperator3
+[16:05:52] [INFO] [ReplayManager]   Enemy 9: Exit_DroneOperator4
+[16:05:52] [INFO] [ReplayManager]   Enemy 10: Spawn_GasMaskEnemy
+[16:05:52] [INFO] [ReplayManager]   Enemy 11: Platform_TeleporterLeft1
+[16:05:52] [INFO] [ReplayManager]   Enemy 12: Platform_TeleporterLeft2
+[16:05:52] [INFO] [ReplayManager]   Enemy 13: Platform_TeleporterLeft3
+[16:05:52] [INFO] [ReplayManager]   Enemy 14: Platform_TeleporterRight1
+[16:05:52] [INFO] [ReplayManager]   Enemy 15: Platform_TeleporterRight2
+[16:05:52] [INFO] [ReplayManager]   Enemy 16: Platform_TeleporterRight3
+[16:05:52] [INFO] [ReplayManager]   Enemy 17: Platform_ShieldRight
+[16:05:52] [INFO] [WeaponHintsComponent] Connected weapon signals for: sniper (node: SniperRifle)
+[16:05:52] [INFO] [WeaponHintsComponent] Hint added 'scope': [color=#ff4444][ПКМ][/color] Scope in
+[16:05:52] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: sniper
+[16:05:52] [INFO] [LevelInitFallback] GDScript _ready() already ran (enemies tracked: 18) - skipping fallback
+[16:05:52] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Blood detector created and attached to NearTracks_MachineGunnerLeft
+[16:05:52] [INFO] [BloodyFeet:NearTracks_MachineGunnerLeft] Snow surface detector created on NearTracks_MachineGunnerLeft
+[16:05:52] [INFO] [CinemaEffects] Found player node: Player
+[16:05:52] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[16:05:52] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerLeft (total: 1)
+[16:05:52] [ENEMY] [NearTracks_MachineGunnerLeft] Registered as sound listener
+[16:05:52] [ENEMY] [NearTracks_MachineGunnerLeft] Spawned at (300, 2670), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Blood detector created and attached to NearTracks_MachineGunnerRight
+[16:05:52] [INFO] [BloodyFeet:NearTracks_MachineGunnerRight] Snow surface detector created on NearTracks_MachineGunnerRight
+[16:05:52] [INFO] [SoundPropagation] Registered listener: NearTracks_MachineGunnerRight (total: 2)
+[16:05:52] [ENEMY] [NearTracks_MachineGunnerRight] Registered as sound listener
+[16:05:52] [ENEMY] [NearTracks_MachineGunnerRight] Spawned at (3700, 2670), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Blood detector created and attached to FarTracks_MachineGunnerLeft
+[16:05:52] [INFO] [BloodyFeet:FarTracks_MachineGunnerLeft] Snow surface detector created on FarTracks_MachineGunnerLeft
+[16:05:52] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerLeft (total: 3)
+[16:05:52] [ENEMY] [FarTracks_MachineGunnerLeft] Registered as sound listener
+[16:05:52] [ENEMY] [FarTracks_MachineGunnerLeft] Spawned at (300, 1890), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Blood detector created and attached to FarTracks_MachineGunnerRight
+[16:05:52] [INFO] [BloodyFeet:FarTracks_MachineGunnerRight] Snow surface detector created on FarTracks_MachineGunnerRight
+[16:05:52] [INFO] [SoundPropagation] Registered listener: FarTracks_MachineGunnerRight (total: 4)
+[16:05:52] [ENEMY] [FarTracks_MachineGunnerRight] Registered as sound listener
+[16:05:52] [ENEMY] [FarTracks_MachineGunnerRight] Spawned at (3700, 1890), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Blood detector created and attached to CentralWalkway_ForceFieldLeft
+[16:05:52] [INFO] [BloodyFeet:CentralWalkway_ForceFieldLeft] Snow surface detector created on CentralWalkway_ForceFieldLeft
+[16:05:52] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldLeft (total: 5)
+[16:05:52] [ENEMY] [CentralWalkway_ForceFieldLeft] Registered as sound listener
+[16:05:52] [ENEMY] [CentralWalkway_ForceFieldLeft] Spawned at (1700, 2300), hp: 2, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Blood detector created and attached to CentralWalkway_ForceFieldRight
+[16:05:52] [INFO] [BloodyFeet:CentralWalkway_ForceFieldRight] Snow surface detector created on CentralWalkway_ForceFieldRight
+[16:05:52] [INFO] [SoundPropagation] Registered listener: CentralWalkway_ForceFieldRight (total: 6)
+[16:05:52] [ENEMY] [CentralWalkway_ForceFieldRight] Registered as sound listener
+[16:05:52] [ENEMY] [CentralWalkway_ForceFieldRight] Spawned at (2300, 2300), hp: 2, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Exit_DroneOperator1] Blood detector created and attached to Exit_DroneOperator1
+[16:05:52] [INFO] [BloodyFeet:Exit_DroneOperator1] Snow surface detector created on Exit_DroneOperator1
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator1 (total: 7)
+[16:05:52] [ENEMY] [Exit_DroneOperator1] Registered as sound listener
+[16:05:52] [ENEMY] [Exit_DroneOperator1] Spawned at (700, 1100), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Exit_DroneOperator2] Blood detector created and attached to Exit_DroneOperator2
+[16:05:52] [INFO] [BloodyFeet:Exit_DroneOperator2] Snow surface detector created on Exit_DroneOperator2
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator2 (total: 8)
+[16:05:52] [ENEMY] [Exit_DroneOperator2] Registered as sound listener
+[16:05:52] [ENEMY] [Exit_DroneOperator2] Spawned at (1600, 1100), hp: 2, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Exit_DroneOperator3] Blood detector created and attached to Exit_DroneOperator3
+[16:05:52] [INFO] [BloodyFeet:Exit_DroneOperator3] Snow surface detector created on Exit_DroneOperator3
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator3 (total: 9)
+[16:05:52] [ENEMY] [Exit_DroneOperator3] Registered as sound listener
+[16:05:52] [ENEMY] [Exit_DroneOperator3] Spawned at (2500, 1100), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Exit_DroneOperator4] Blood detector created and attached to Exit_DroneOperator4
+[16:05:52] [INFO] [BloodyFeet:Exit_DroneOperator4] Snow surface detector created on Exit_DroneOperator4
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Exit_DroneOperator4 (total: 10)
+[16:05:52] [ENEMY] [Exit_DroneOperator4] Registered as sound listener
+[16:05:52] [ENEMY] [Exit_DroneOperator4] Spawned at (3300, 1100), hp: 2, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Blood detector created and attached to Spawn_GasMaskEnemy
+[16:05:52] [INFO] [BloodyFeet:Spawn_GasMaskEnemy] Snow surface detector created on Spawn_GasMaskEnemy
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Spawn_GasMaskEnemy (total: 11)
+[16:05:52] [ENEMY] [Spawn_GasMaskEnemy] Registered as sound listener
+[16:05:52] [ENEMY] [Spawn_GasMaskEnemy] Spawned at (900, 3075), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Blood detector created and attached to Platform_TeleporterLeft1
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft1] Snow surface detector created on Platform_TeleporterLeft1
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft1 (total: 12)
+[16:05:52] [ENEMY] [Platform_TeleporterLeft1] Registered as sound listener
+[16:05:52] [ENEMY] [Platform_TeleporterLeft1] Spawned at (200, 3500), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Blood detector created and attached to Platform_TeleporterLeft2
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft2] Snow surface detector created on Platform_TeleporterLeft2
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft2 (total: 13)
+[16:05:52] [ENEMY] [Platform_TeleporterLeft2] Registered as sound listener
+[16:05:52] [ENEMY] [Platform_TeleporterLeft2] Spawned at (400, 3500), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Blood detector created and attached to Platform_TeleporterLeft3
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterLeft3] Snow surface detector created on Platform_TeleporterLeft3
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterLeft3 (total: 14)
+[16:05:52] [ENEMY] [Platform_TeleporterLeft3] Registered as sound listener
+[16:05:52] [ENEMY] [Platform_TeleporterLeft3] Spawned at (600, 3500), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight1] Blood detector created and attached to Platform_TeleporterRight1
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight1] Snow surface detector created on Platform_TeleporterRight1
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight1 (total: 15)
+[16:05:52] [ENEMY] [Platform_TeleporterRight1] Registered as sound listener
+[16:05:52] [ENEMY] [Platform_TeleporterRight1] Spawned at (3400, 3500), hp: 1, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight2] Blood detector created and attached to Platform_TeleporterRight2
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight2] Snow surface detector created on Platform_TeleporterRight2
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight2 (total: 16)
+[16:05:52] [ENEMY] [Platform_TeleporterRight2] Registered as sound listener
+[16:05:52] [ENEMY] [Platform_TeleporterRight2] Spawned at (3600, 3500), hp: 2, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight3] Blood detector created and attached to Platform_TeleporterRight3
+[16:05:52] [INFO] [BloodyFeet:Platform_TeleporterRight3] Snow surface detector created on Platform_TeleporterRight3
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Platform_TeleporterRight3 (total: 17)
+[16:05:52] [ENEMY] [Platform_TeleporterRight3] Registered as sound listener
+[16:05:52] [ENEMY] [Platform_TeleporterRight3] Spawned at (3800, 3500), hp: 2, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Platform_ShieldRight] Blood detector created and attached to Platform_ShieldRight
+[16:05:52] [INFO] [BloodyFeet:Platform_ShieldRight] Snow surface detector created on Platform_ShieldRight
+[16:05:52] [INFO] [SoundPropagation] Registered listener: Platform_ShieldRight (total: 18)
+[16:05:52] [ENEMY] [Platform_ShieldRight] Registered as sound listener
+[16:05:52] [ENEMY] [Platform_ShieldRight] Spawned at (3600, 3650), hp: 2, behavior: GUARD
+[16:05:52] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[16:05:52] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[16:05:52] [INFO] [WeaponHintsComponent] Strikethrough setup 'scope': 1 lines
+[16:05:52] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=18
+[16:05:52] [ENEMY] [Spawn_GasMaskEnemy] ROT_CHANGE: none -> P1:visible, state=IDLE, target=1.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [Spawn_GasMaskEnemy] State: IDLE -> COMBAT
+[16:05:52] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[16:05:52] [ENEMY] [NearTracks_MachineGunnerRight] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=0.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [FarTracks_MachineGunnerLeft] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[16:05:52] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[16:05:52] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[16:05:52] [INFO] [DroneOperator] Reached cover, deploying drone in 0.5s
+[16:05:52] [ENEMY] [Spawn_GasMaskEnemy] Found cover at (753.3214, 3401.756) (distance: 369.4, player at (2000, 3100))
+[16:05:52] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=101.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [Platform_TeleporterRight1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [Platform_TeleporterRight2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [Platform_TeleporterRight3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [Platform_ShieldRight] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=191.3°, current=-90.0°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [INFO] [Player] Detecting weapon pose (frame 3)...
+[16:05:52] [INFO] [Player] Detected weapon: ASVK Sniper Rifle (Sniper pose)
+[16:05:52] [INFO] [Player] Applied Sniper arm pose: Left=(28, 6), Right=(-3, 6)
+[16:05:52] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[16:05:52] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[16:05:52] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[16:05:52] [INFO] [LastChance] Found player: Player
+[16:05:52] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[16:05:52] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[16:05:52] [INFO] [LastChance] Connected to player Died signal (C#)
+[16:05:52] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[16:05:52] [INFO] [ImpactEffects] Particle shader warmup complete: 7 effects warmed up in 2399 ms
+[16:05:52] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1025.446, 3052.118), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[16:05:52] [ENEMY] [NearTracks_MachineGunnerLeft] Heard gunshot at (1025.446, 3052.118), intensity=0.00, distance=820
+[16:05:52] [ENEMY] [Platform_TeleporterLeft2] Heard gunshot at (1025.446, 3052.118), intensity=0.00, distance=769
+[16:05:52] [ENEMY] [Platform_TeleporterLeft3] Heard gunshot at (1025.446, 3052.118), intensity=0.01, distance=618
+[16:05:52] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=14, self=1
+[16:05:52] [ENEMY] [Platform_TeleporterLeft2] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-14.0°, current=68.8°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [Platform_TeleporterLeft2] Found cover at (730.0936, 3427.389) (distance: 338.0, player at (2000, 3100))
+[16:05:52] [ENEMY] [Platform_TeleporterLeft3] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-15.9°, current=-56.3°, player=(2000,3100), corner_timer=0.00
+[16:05:52] [ENEMY] [Platform_TeleporterLeft3] Found cover at (724.6032, 3494.945) (distance: 124.7, player at (2000, 3100))
+[16:05:52] [ENEMY] [NearTracks_MachineGunnerLeft] ROT_CHANGE: none -> P2:combat_state, state=COMBAT, target=14.2°, current=90.0°, player=(2000,3100), corner_timer=0.00
+[16:05:53] [INFO] [Drone] _ready started
+[16:05:53] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[16:05:53] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[16:05:53] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[16:05:53] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[16:05:53] [INFO] [Drone] Initialized by operator: Exit_DroneOperator1
+[16:05:53] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[16:05:53] [INFO] [DroneOperator] Connected to drone.died signal
+[16:05:53] [INFO] [DroneOperator] Drone deployed at (700, 1084)
+[16:05:53] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[16:05:53] [INFO] [Drone] _ready started
+[16:05:53] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[16:05:53] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[16:05:53] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[16:05:53] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[16:05:53] [INFO] [Drone] Initialized by operator: Exit_DroneOperator2
+[16:05:53] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[16:05:53] [INFO] [DroneOperator] Connected to drone.died signal
+[16:05:53] [INFO] [DroneOperator] Drone deployed at (1600, 1060)
+[16:05:53] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[16:05:53] [INFO] [Drone] _ready started
+[16:05:53] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[16:05:53] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[16:05:53] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[16:05:53] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[16:05:53] [INFO] [Drone] Initialized by operator: Exit_DroneOperator3
+[16:05:53] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[16:05:53] [INFO] [DroneOperator] Connected to drone.died signal
+[16:05:53] [INFO] [DroneOperator] Drone deployed at (2500, 1084)
+[16:05:53] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[16:05:53] [INFO] [Drone] _ready started
+[16:05:53] [INFO] [Drone] NavigationAgent2D found and configured (avoidance=false)
+[16:05:53] [INFO] [Drone] Visual setup complete (quadcopter style, LED=green/searching)
+[16:05:53] [INFO] [Drone] _ready complete (state=SEARCHING spiral, player=Player, nav=found)
+[16:05:53] [INFO] [DroneOperator] Drone node created, script=res://scripts/objects/drone.gd
+[16:05:53] [INFO] [Drone] Initialized by operator: Exit_DroneOperator4
+[16:05:53] [INFO] [DroneOperator] Drone initialized via initialize_drone()
+[16:05:53] [INFO] [DroneOperator] Connected to drone.died signal
+[16:05:53] [INFO] [DroneOperator] Drone deployed at (3300, 1084)
+[16:05:53] [INFO] [DroneOperator] Phase: CONTROLLING (defenseless)
+[16:05:53] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1042.081, 3066.595), source=NEUTRAL (null), range=900, listeners=18
+[16:05:53] [ENEMY] [NearTracks_MachineGunnerLeft] Heard CASING_KICK at (1042.081, 3066.595), intensity=0.00, dist=841
+[16:05:53] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1042.081, 3066.595), intensity=1.00, dist=34
+[16:05:53] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (1042.081, 3066.595), intensity=0.00, dist=735
+[16:05:53] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1042.081, 3066.595), intensity=0.01, dist=582
+[16:05:53] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=14, self=0
+[16:05:53] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[16:05:53] [INFO] [GrenadeBase] Grenade created at (1121.331, 3056.829) (frozen)
+[16:05:53] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[16:05:53] [INFO] [GrenadeBase] LEGACY throw_grenade() called! Direction: (0.999909, -0.013523), Speed: 1352.8 (unfrozen)
+[16:05:53] [INFO] [GrenadeBase] NOTE: Using DRAG-BASED system. If velocity-based is expected, ensure grenade has throw_grenade_velocity_based() method.
+[16:05:53] [INFO] [GasMaskGrenade] Chemical grenade thrown at (2000, 3100) (remaining: 3)
+[16:05:53] [INFO] [GrenadeBase] Collision detected with Spawn_GasMaskEnemy (type: CharacterBody2D)
+[16:05:53] [WARN] [FPS] Drop detected: 1 fps (threshold: 30)
+[16:05:53] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1174.6, 3059.446), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[16:05:53] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[16:05:53] [ENEMY] [Platform_TeleporterLeft2] State: COMBAT -> PURSUING
+[16:05:53] [ENEMY] [Platform_TeleporterLeft3] State: COMBAT -> PURSUING
+[16:05:53] [INFO] [GrenadeBase] Collision detected with PlatformBench2 (type: StaticBody2D)
+[16:05:53] [INFO] [ChemicalGasGrenade] Hit obstacle 'PlatformBench2' — detonating on contact
+[16:05:53] [INFO] [ChemicalGasGrenade] Gas released at (1444.922, 3090.47)!
+[16:05:53] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(1444.922, 3090.47), source=NEUTRAL (ChemicalGasGrenade), range=1469, listeners=18
+[16:05:53] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard EXPLOSION at (1444.922, 3090.47), intensity=0.00, distance=831
+[16:05:53] [ENEMY] [CentralWalkway_ForceFieldRight] Heard EXPLOSION at (1444.922, 3090.47), intensity=0.00, distance=1164
+[16:05:53] [ENEMY] [Platform_TeleporterLeft1] Heard EXPLOSION at (1444.922, 3090.47), intensity=0.00, distance=1311
+[16:05:53] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=11, self=0
+[16:05:53] [INFO] [ChemicalGasGrenade] Spawning cloud with 5.62s grow-in matching sound
+[16:05:53] [INFO] [ChemicalCloud] _ready() at (1444.922, 3090.47)
+[16:05:53] [INFO] [ChemicalCloud] Particle system created
+[16:05:53] [INFO] [ChemicalCloud] Cloud spawned at (1444.922, 3090.47), radius=600, duration=20s
+[16:05:53] [INFO] [ChemicalGasGrenade] Chemical cloud spawned at (1444.922, 3090.47) (radius=600, duration=20s, grow_in=5.62s)
+[16:05:53] [ENEMY] [CentralWalkway_ForceFieldLeft] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=69.4°, current=56.2°, player=(2000,3100), corner_timer=0.00
+[16:05:53] [ENEMY] [CentralWalkway_ForceFieldLeft] Found cover at (1758.679, 2656.264) (distance: 361.1, player at (2000, 3100))
+[16:05:53] [ENEMY] [CentralWalkway_ForceFieldRight] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=110.6°, current=101.3°, player=(2000,3100), corner_timer=0.00
+[16:05:53] [ENEMY] [CentralWalkway_ForceFieldRight] Found cover at (2241.223, 2656.267) (distance: 361.1, player at (2000, 3100))
+[16:05:53] [ENEMY] [Platform_TeleporterLeft1] ROT_CHANGE: P5:idle_scan -> P2:combat_state, state=COMBAT, target=-12.5°, current=101.3°, player=(2000,3100), corner_timer=0.00
+[16:05:53] [ENEMY] [Platform_TeleporterLeft1] Found cover at (723.9988, 3413.163) (distance: 531.1, player at (2000, 3100))
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=18
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1187.986, 3079.153), source=NEUTRAL (null), range=900, listeners=18
+[16:05:53] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1187.986, 3079.153), intensity=1.00, dist=39
+[16:05:53] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (1187.986, 3079.153), intensity=0.00, dist=734
+[16:05:53] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1187.986, 3079.153), intensity=0.01, dist=575
+[16:05:53] [INFO] [SoundPropagation] Sound result: notified=3, out_of_range=15, self=0
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:53] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:54] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=18
+[16:05:55] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=18
+[16:05:56] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=18
+[16:05:57] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=18
+[16:05:57] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:57] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1323.753, 3066.774), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[16:05:57] [INFO] [SoundPropagation] Sound result: notified=2, out_of_range=15, self=1
+[16:05:57] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:57] [INFO] [SoundPropagation] Sound emitted: type=CASING_KICK, pos=(1303.441, 3082.908), source=NEUTRAL (null), range=900, listeners=18
+[16:05:57] [ENEMY] [CentralWalkway_ForceFieldLeft] Heard CASING_KICK at (1303.441, 3082.908), intensity=0.00, dist=797
+[16:05:57] [ENEMY] [Spawn_GasMaskEnemy] Heard CASING_KICK at (1303.441, 3082.908), intensity=1.00, dist=35
+[16:05:57] [ENEMY] [Platform_TeleporterLeft2] Heard CASING_KICK at (1303.441, 3082.908), intensity=0.00, dist=833
+[16:05:57] [ENEMY] [Platform_TeleporterLeft3] Heard CASING_KICK at (1303.441, 3082.908), intensity=0.01, dist=667
+[16:05:57] [INFO] [SoundPropagation] Sound result: notified=4, out_of_range=14, self=0
+[16:05:57] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:57] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:57] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:57] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [ENEMY] [CentralWalkway_ForceFieldLeft] State: COMBAT -> PURSUING
+[16:05:58] [ENEMY] [CentralWalkway_ForceFieldRight] State: COMBAT -> PURSUING
+[16:05:58] [ENEMY] [Platform_TeleporterLeft1] State: COMBAT -> PURSUING
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [ENEMY] [Platform_ShieldRight] SHIELD_TRACK: updated facing to -161.0° (interval=1.5s)
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [GrenadeBase] CCD enabled (mode: CAST_RAY) to prevent wall tunneling
+[16:05:58] [INFO] [GrenadeBase] Grenade created at (1449.163, 3056.611) (frozen)
+[16:05:58] [INFO] [GrenadeBase] Timer activated! 4.0 seconds until explosion
+[16:05:58] [INFO] [GrenadeBase] LEGACY throw_grenade() called! Direction: (0.984936, 0.172917), Speed: 1105.1 (unfrozen)
+[16:05:58] [INFO] [GrenadeBase] NOTE: Using DRAG-BASED system. If velocity-based is expected, ensure grenade has throw_grenade_velocity_based() method.
+[16:05:58] [INFO] [GasMaskGrenade] Chemical grenade thrown at (2000, 3100) (remaining: 2)
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [GrenadeBase] Collision detected with Spawn_GasMaskEnemy (type: CharacterBody2D)
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [GrenadeBase] Collision detected with PlatformBench2 (type: StaticBody2D)
+[16:05:58] [INFO] [ChemicalGasGrenade] Hit obstacle 'PlatformBench2' — detonating on contact
+[16:05:58] [INFO] [ChemicalGasGrenade] Gas released at (1484.106, 3077.597)!
+[16:05:58] [INFO] [SoundPropagation] Sound emitted: type=EXPLOSION, pos=(1484.106, 3077.597), source=NEUTRAL (ChemicalGasGrenade), range=1469, listeners=18
+[16:05:58] [INFO] [SoundPropagation] Sound result: notified=7, out_of_range=11, self=0
+[16:05:58] [INFO] [ChemicalGasGrenade] Spawning cloud with 5.62s grow-in matching sound
+[16:05:58] [INFO] [ChemicalCloud] _ready() at (1484.106, 3077.597)
+[16:05:58] [INFO] [ChemicalCloud] Particle system created
+[16:05:58] [INFO] [ChemicalCloud] Cloud spawned at (1484.106, 3077.597), radius=600, duration=20s
+[16:05:58] [INFO] [ChemicalGasGrenade] Chemical cloud spawned at (1484.106, 3077.597) (radius=600, duration=20s, grow_in=5.62s)
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=18
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [SoundPropagation] Sound emitted: type=GUNSHOT, pos=(1505.09, 3038.908), source=ENEMY (Spawn_GasMaskEnemy), range=840, listeners=18
+[16:05:58] [INFO] [SoundPropagation] Sound result: notified=1, out_of_range=16, self=1
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ScoreManager] Damage taken: 1 (total: 1)
+[16:05:58] [INFO] [Player] Spawning blood effect at (2000, 3100), dir=(0.9985136, 0.05450328), lethal=False (C#)
+[16:05:58] [INFO] [ImpactEffects] Blood decals scheduled: 15 to spawn at particle landing times
+[16:05:58] [INFO] [BloodDecal] Blood puddle created at (2059, 3103.275) (added to group)
+[16:05:58] [INFO] [PenultimateHit] Player damaged: 1.0 damage, current health: 2.0
+[16:05:58] [INFO] [LastChance] Player health updated (C# Damaged): 2.0
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [LastChance] Gunslinger mode - special last chance effect disabled (Issue #1727)
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (555px), no illusions spawned
+[16:05:58] [INFO] [ChemicalCloud] Player not in range (516px), no illusions spawned
+[16:05:58] [INFO] [ImpactEffects] [ImpactEffects] water_body group empty on scene 'RailwayStationLevel' — blood-in-water check unavailable (Issue #1578)
+[16:05:58] [INFO] [BloodDecal] Blood puddle created at (2067.714, 3142.797) (added to group)
+[16:05:58] [INFO] [BloodDecal] Blood puddle created at (2089.099, 3134.392) (added to group)
+[16:05:58] [INFO] [BloodDecal] Blood puddle created at (2110.176, 3140.951) (added to group)
+[16:05:58] [INFO] [BloodDecal] Blood puddle created at (2114.142, 3162.866) (added to group)
+[16:05:58] [INFO] [BloodDecal] Blood puddle created at (2134.889, 3184.062) (added to group)
+[16:05:59] [INFO] [BloodDecal] Blood puddle created at (2153.952, 3198.775) (added to group)
+[16:05:59] [INFO] [BloodDecal] Blood puddle created at (2089.63, 3201.514) (added to group)
+[16:05:59] [INFO] [BloodDecal] Blood puddle created at (2119.401, 3133.323) (added to group)
+[16:05:59] [INFO] [BloodDecal] Blood puddle created at (2111.045, 3224.746) (added to group)
+[16:05:59] [INFO] [BloodDecal] Blood puddle created at (2104.881, 3246.339) (added to group)
+[16:05:59] [INFO] [BloodDecal] Blood puddle created at (2107.885, 3249.474) (added to group)
+[16:05:59] [INFO] [BloodDecal] Blood puddle created at (2210.526, 3216.156) (added to group)
+[16:05:59] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=18
+[16:06:00] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=18
+[16:06:00] [INFO] [PersistManager] State saved to user://game_state.cfg
+[16:06:00] [INFO] [PersistManager] Last level saved: res://scenes/levels/LabyrinthLevel.tscn
+[16:06:00] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/LabyrinthLevel.tscn
+[16:06:01] [INFO] [SceneLoader] Background load started successfully
+[16:06:01] [INFO] [SceneLoader] Background load complete: res://scenes/levels/LabyrinthLevel.tscn
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Platform_ShieldRight (remaining: 17)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight3 (remaining: 16)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight2 (remaining: 15)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterRight1 (remaining: 14)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft3 (remaining: 13)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft2 (remaining: 12)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Platform_TeleporterLeft1 (remaining: 11)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Spawn_GasMaskEnemy (remaining: 10)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator4 (remaining: 9)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator3 (remaining: 8)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator2 (remaining: 7)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: Exit_DroneOperator1 (remaining: 6)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: CentralWalkway_ForceFieldRight (remaining: 5)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: CentralWalkway_ForceFieldLeft (remaining: 4)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerRight (remaining: 3)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: FarTracks_MachineGunnerLeft (remaining: 2)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerRight (remaining: 1)
+[16:06:01] [INFO] [SoundPropagation] Unregistered listener: NearTracks_MachineGunnerLeft (remaining: 0)
+[16:06:01] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:06:01] [INFO] [SceneLoader] Scene changed successfully
+[16:06:01] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[16:06:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:01] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[16:06:01] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[16:06:01] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[16:06:01] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[16:06:01] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:06:01] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[16:06:01] [INFO] [LastChance] Resetting all effects (scene change detected)
+[16:06:01] [INFO] [CinemaEffects] Scene changed to: LabyrinthLevel
+[16:06:01] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[16:06:01] [INFO] [BlackMetalEffectsManager] Scene changed to: LabyrinthLevel
+[16:06:01] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[16:06:01] [INFO] [PersistManager] State saved to user://game_state.cfg
+[16:06:01] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/LabyrinthLevel.tscn
+[16:06:01] [ENEMY] [Enemy1] Death animation component initialized
+[16:06:01] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[16:06:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:01] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[16:06:01] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[16:06:01] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[16:06:01] [ENEMY] [Enemy2] Death animation component initialized
+[16:06:01] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[16:06:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:01] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[16:06:01] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[16:06:01] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[16:06:01] [ENEMY] [Enemy3] Death animation component initialized
+[16:06:01] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[16:06:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:01] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[16:06:01] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[16:06:01] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[16:06:01] [ENEMY] [Enemy4] Death animation component initialized
+[16:06:01] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[16:06:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:01] [INFO] [BloodyFeet:Enemy5] Footprint scene loaded
+[16:06:01] [INFO] [BloodyFeet:Enemy5] Found EnemyModel for facing direction
+[16:06:01] [INFO] [BloodyFeet:Enemy5] BloodyFeetComponent ready on Enemy5
+[16:06:01] [ENEMY] [Enemy5] Death animation component initialized
+[16:06:01] [ENEMY] [Enemy5] [Gunslinger] Enemy glow applied
+[16:06:01] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:01] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[16:06:01] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[16:06:01] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[16:06:01] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[16:06:01] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[16:06:01] [INFO] [Player.Weapon] GameManager weapon selection: sniper (SniperRifle)
+[16:06:01] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[16:06:01] [INFO] [Player.Weapon] Equipped SniperRifle (ammo: 12/5)
+[16:06:01] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[16:06:01] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[16:06:01] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[16:06:01] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[16:06:01] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[16:06:01] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[16:06:01] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[16:06:01] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[16:06:01] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[16:06:01] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[16:06:01] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[16:06:01] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[16:06:01] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[16:06:01] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[16:06:01] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[16:06:01] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[16:06:01] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[16:06:01] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[16:06:01] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[16:06:01] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[16:06:01] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[16:06:01] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[16:06:01] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[16:06:01] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[16:06:01] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[16:06:01] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[16:06:01] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[16:06:01] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[16:06:01] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[16:06:01] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[16:06:01] [INFO] [Player.Jammer] JammerHUD initialized
+[16:06:01] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[16:06:01] [INFO] [Player] Ready! Ammo: 12/5, Grenades: 1/3, Health: 2/4
+[16:06:01] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[16:06:01] [INFO] [LabyrinthLevel] Found Environment/Enemies node with 5 children
+[16:06:01] [INFO] [LabyrinthLevel] Child 'Enemy1': script=true, has_died_signal=true
+[16:06:01] [INFO] [LabyrinthLevel] Child 'Enemy2': script=true, has_died_signal=true
+[16:06:01] [INFO] [LabyrinthLevel] Child 'Enemy3': script=true, has_died_signal=true
+[16:06:01] [INFO] [LabyrinthLevel] Child 'Enemy4': script=true, has_died_signal=true
+[16:06:01] [INFO] [LabyrinthLevel] Child 'Enemy5': script=true, has_died_signal=true
+[16:06:01] [INFO] [LabyrinthLevel] Enemy tracking complete: 5 enemies registered
+[16:06:01] [INFO] [LabyrinthLevel] Setting up weapon: sniper
+[16:06:01] [INFO] [LabyrinthLevel] SniperRifle already equipped by C# Player - applying labyrinth ammo config
+[16:06:01] [INFO] [LabyrinthLevel] Re-applied auto-reload magazine reduction after ammo config for sniper
+[16:06:01] [INFO] [LabyrinthLevel] HUD ammo refreshed (post level ammo config): SniperRifle 12/72
+[16:06:01] [INFO] [GameManager] set_player() called with: <CharacterBody2D#412954402332> (class: CharacterBody2D)
+[16:06:01] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[16:06:01] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[16:06:01] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[16:06:01] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[16:06:01] [INFO] [LabyrinthLevel] Camera2D limits set — top=48 bottom=1128 left=48 right=1968 — Issue #1682
+[16:06:01] [INFO] [ScoreManager] Level started with 5 enemies
+[16:06:01] [INFO] [ScoreManager] Custom rank thresholds set: S=0.70 A+=0.55 A=0.38 B=0.22 C=0.12 D=0.06
+[16:06:01] [INFO] [LabyrinthLevel] ReplayManager found as C# autoload - verified OK
+[16:06:01] [INFO] [LabyrinthLevel] Starting replay recording - Player: Player, Enemies count: 5
+[16:06:01] [INFO] [ReplayManager] Replay data cleared
+[16:06:01] [INFO] [LabyrinthLevel] Previous replay data cleared
+[16:06:01] [INFO] [ReplayManager] Detected player weapon: Sniper Rifle (ASVK)
+[16:06:01] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[16:06:01] [INFO] [ReplayManager] Level: LabyrinthLevel
+[16:06:01] [INFO] [ReplayManager] Player: Player (valid: True)
+[16:06:01] [INFO] [ReplayManager] Enemies count: 5
+[16:06:01] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/asvk_topdown.png
+[16:06:01] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[16:06:01] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[16:06:01] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[16:06:01] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[16:06:01] [INFO] [ReplayManager]   Enemy 4: Enemy5
+[16:06:01] [INFO] [LabyrinthLevel] Replay recording started successfully
+[16:06:01] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[16:06:01] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[16:06:01] [INFO] [CinemaEffects] Found player node: Player
+[16:06:01] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[16:06:01] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[16:06:01] [ENEMY] [Enemy1] Registered as sound listener
+[16:06:01] [ENEMY] [Enemy1] Spawned at (400, 300), hp: 1, behavior: GUARD
+[16:06:01] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[16:06:01] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[16:06:01] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[16:06:01] [ENEMY] [Enemy2] Registered as sound listener
+[16:06:01] [ENEMY] [Enemy2] Spawned at (900, 950), hp: 1, behavior: GUARD
+[16:06:01] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[16:06:01] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[16:06:01] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[16:06:01] [ENEMY] [Enemy3] Registered as sound listener
+[16:06:01] [ENEMY] [Enemy3] Spawned at (1200, 1000), hp: 1, behavior: PATROL
+[16:06:01] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[16:06:01] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[16:06:01] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[16:06:01] [ENEMY] [Enemy4] Registered as sound listener
+[16:06:01] [ENEMY] [Enemy4] Spawned at (1650, 650), hp: 1, behavior: GUARD
+[16:06:01] [INFO] [BloodyFeet:Enemy5] Blood detector created and attached to Enemy5
+[16:06:01] [INFO] [BloodyFeet:Enemy5] Snow surface detector created on Enemy5
+[16:06:01] [INFO] [SoundPropagation] Registered listener: Enemy5 (total: 5)
+[16:06:01] [ENEMY] [Enemy5] Registered as sound listener
+[16:06:01] [ENEMY] [Enemy5] Spawned at (1500, 300), hp: 2, behavior: GUARD
+[16:06:01] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[16:06:01] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[16:06:01] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=5
+[16:06:01] [ENEMY] [Enemy3] Patrol points snapped to navmesh (Issue #1216)
+[16:06:01] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=56.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[16:06:01] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(150,1000), corner_timer=0.00
+[16:06:01] [ENEMY] [Enemy5] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=236.3°, current=0.0°, player=(150,1000), corner_timer=0.00
+[16:06:01] [INFO] [Player] Detecting weapon pose (frame 3)...
+[16:06:01] [INFO] [Player] Detected weapon: ASVK Sniper Rifle (Sniper pose)
+[16:06:01] [INFO] [Player] Applied Sniper arm pose: Left=(28, 6), Right=(-3, 6)
+[16:06:01] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[16:06:01] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[16:06:01] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[16:06:01] [INFO] [LastChance] Found player: Player
+[16:06:01] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[16:06:01] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[16:06:01] [INFO] [LastChance] Connected to player Died signal (C#)
+[16:06:01] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[16:06:02] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=5
+[16:06:03] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[16:06:03] [ENEMY] [Enemy3] ROT_CHANGE: none -> P3:corner, state=IDLE, target=-90.0°, current=0.0°, player=(150,1000), corner_timer=0.30
+[16:06:03] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-54.4°, player=(150,1000), corner_timer=-0.02
+[16:06:03] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[16:06:03] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-51.6°, player=(150,1000), corner_timer=0.30
+[16:06:03] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=5
+[16:06:03] [ENEMY] [Enemy3] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=-90.0°, player=(150,1000), corner_timer=-0.02
+[16:06:03] [ENEMY] [Enemy3] PATROL corner check: angle -90.0°
+[16:06:03] [ENEMY] [Enemy3] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=-87.1°, player=(150,1000), corner_timer=0.30
+[16:06:04] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=5
+[16:06:05] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=5
+[16:06:06] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=5
+[16:06:07] [INFO] [ReplayManager] Recording frame 360 (6,0s): player_valid=True, enemies=5
+[16:06:08] [INFO] [ReplayManager] Recording frame 420 (7,0s): player_valid=True, enemies=5
+[16:06:09] [INFO] [PersistManager] State saved to user://game_state.cfg
+[16:06:09] [INFO] [PersistManager] Last level saved: res://scenes/levels/BuildingLevel.tscn
+[16:06:09] [INFO] [SceneLoader] Starting background load for: res://scenes/levels/BuildingLevel.tscn
+[16:06:09] [INFO] [ReplayManager] Recording frame 480 (8,0s): player_valid=True, enemies=5
+[16:06:09] [INFO] [SceneLoader] Background load started successfully
+[16:06:09] [INFO] [SceneLoader] Background load complete: res://scenes/levels/BuildingLevel.tscn
+[16:06:09] [INFO] [SoundPropagation] Unregistered listener: Enemy5 (remaining: 4)
+[16:06:09] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[16:06:09] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[16:06:09] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[16:06:09] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[16:06:09] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:06:09] [INFO] [SceneLoader] Scene changed successfully
+[16:06:09] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[16:06:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:09] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[16:06:09] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[16:06:09] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[16:06:09] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[16:06:09] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:06:09] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[16:06:09] [INFO] [LastChance] Resetting all effects (scene change detected)
+[16:06:09] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[16:06:09] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[16:06:09] [INFO] [BlackMetalEffectsManager] Scene changed to: BuildingLevel
+[16:06:09] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[16:06:09] [INFO] [PersistManager] State saved to user://game_state.cfg
+[16:06:09] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/BuildingLevel.tscn
+[16:06:09] [ENEMY] [Enemy1] Death animation component initialized
+[16:06:09] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[16:06:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:09] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[16:06:09] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[16:06:09] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[16:06:09] [ENEMY] [Enemy2] Death animation component initialized
+[16:06:09] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[16:06:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:09] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[16:06:09] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[16:06:09] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[16:06:09] [ENEMY] [Enemy3] Death animation component initialized
+[16:06:09] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[16:06:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:09] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[16:06:09] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[16:06:09] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[16:06:09] [ENEMY] [Enemy4] Death animation component initialized
+[16:06:09] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[16:06:09] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:10] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[16:06:10] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[16:06:10] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[16:06:10] [ENEMY] [Grenadier] Death animation component initialized
+[16:06:10] [ENEMY] [Grenadier] [Gunslinger] Enemy glow applied
+[16:06:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:10] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[16:06:10] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[16:06:10] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[16:06:10] [ENEMY] [Enemy6] Death animation component initialized
+[16:06:10] [ENEMY] [Enemy6] [Gunslinger] Enemy glow applied
+[16:06:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:10] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[16:06:10] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[16:06:10] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[16:06:10] [ENEMY] [Enemy7] Death animation component initialized
+[16:06:10] [ENEMY] [Enemy7] [Gunslinger] Enemy glow applied
+[16:06:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:10] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[16:06:10] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[16:06:10] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[16:06:10] [ENEMY] [Enemy8] Death animation component initialized
+[16:06:10] [ENEMY] [Enemy8] [Gunslinger] Enemy glow applied
+[16:06:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:10] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[16:06:10] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[16:06:10] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[16:06:10] [ENEMY] [Enemy9] Death animation component initialized
+[16:06:10] [ENEMY] [Enemy9] [Gunslinger] Enemy glow applied
+[16:06:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:10] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[16:06:10] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[16:06:10] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[16:06:10] [ENEMY] [Enemy10] Death animation component initialized
+[16:06:10] [ENEMY] [Enemy10] [Gunslinger] Enemy glow applied
+[16:06:10] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:10] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[16:06:10] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[16:06:10] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[16:06:10] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[16:06:10] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[16:06:10] [INFO] [Player.Weapon] GameManager weapon selection: sniper (SniperRifle)
+[16:06:10] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[16:06:10] [INFO] [Player.Weapon] Equipped SniperRifle (ammo: 12/5)
+[16:06:10] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[16:06:10] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[16:06:10] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[16:06:10] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[16:06:10] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[16:06:10] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[16:06:10] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[16:06:10] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[16:06:10] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[16:06:10] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[16:06:10] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[16:06:10] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[16:06:10] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[16:06:10] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[16:06:10] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[16:06:10] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[16:06:10] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[16:06:10] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[16:06:10] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[16:06:10] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[16:06:10] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[16:06:10] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[16:06:10] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[16:06:10] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[16:06:10] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[16:06:10] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[16:06:10] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[16:06:10] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[16:06:10] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[16:06:10] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[16:06:10] [INFO] [Player.Jammer] JammerHUD initialized
+[16:06:10] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[16:06:10] [INFO] [Player] Ready! Ammo: 12/5, Grenades: 1/3, Health: 4/4
+[16:06:10] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[16:06:10] [INFO] [WeaponHintsComponent] Connected weapon signals for: sniper (node: SniperRifle)
+[16:06:10] [INFO] [WeaponHintsComponent] Hint added 'scope': [color=#ff4444][ПКМ][/color] Scope in
+[16:06:10] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: sniper
+[16:06:10] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[16:06:10] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[16:06:10] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[16:06:10] [INFO] [CinemaEffects] Found player node: Player
+[16:06:10] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[16:06:10] [ENEMY] [Enemy1] Registered as sound listener
+[16:06:10] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 1, behavior: GUARD
+[16:06:10] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[16:06:10] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[16:06:10] [ENEMY] [Enemy2] Registered as sound listener
+[16:06:10] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 1, behavior: GUARD
+[16:06:10] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[16:06:10] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[16:06:10] [ENEMY] [Enemy3] Registered as sound listener
+[16:06:10] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 2, behavior: GUARD
+[16:06:10] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[16:06:10] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[16:06:10] [ENEMY] [Enemy4] Registered as sound listener
+[16:06:10] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 1, behavior: GUARD
+[16:06:10] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[16:06:10] [INFO] [BloodyFeet:Grenadier] Snow surface detector created on Grenadier
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[16:06:10] [ENEMY] [Grenadier] Registered as sound listener
+[16:06:10] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 1, behavior: GUARD
+[16:06:10] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[16:06:10] [INFO] [BloodyFeet:Enemy6] Snow surface detector created on Enemy6
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[16:06:10] [ENEMY] [Enemy6] Registered as sound listener
+[16:06:10] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 1, behavior: GUARD
+[16:06:10] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[16:06:10] [INFO] [BloodyFeet:Enemy7] Snow surface detector created on Enemy7
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[16:06:10] [ENEMY] [Enemy7] Registered as sound listener
+[16:06:10] [ENEMY] [Enemy7] Spawned at (1700, 870), hp: 2, behavior: PATROL
+[16:06:10] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[16:06:10] [INFO] [BloodyFeet:Enemy8] Snow surface detector created on Enemy8
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[16:06:10] [ENEMY] [Enemy8] Registered as sound listener
+[16:06:10] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 1, behavior: GUARD
+[16:06:10] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[16:06:10] [INFO] [BloodyFeet:Enemy9] Snow surface detector created on Enemy9
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[16:06:10] [ENEMY] [Enemy9] Registered as sound listener
+[16:06:10] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 1, behavior: GUARD
+[16:06:10] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[16:06:10] [INFO] [BloodyFeet:Enemy10] Snow surface detector created on Enemy10
+[16:06:10] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[16:06:10] [ENEMY] [Enemy10] Registered as sound listener
+[16:06:10] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 1, behavior: PATROL
+[16:06:10] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[16:06:10] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[16:06:10] [INFO] [WeaponHintsComponent] Strikethrough setup 'scope': 1 lines
+[16:06:10] [INFO] [LevelInitFallback] ConfigureBuildingCameraLimits: limits set — left=64 top=64 right=2464 bottom=2064 — Issue #1684
+[16:06:10] [INFO] [LevelInitFallback] GDScript _ready() did NOT execute - performing C# fallback initialization
+[16:06:10] [INFO] [LevelInitFallback] Полигон loaded (C# fallback) - Tactical Combat Arena
+[16:06:10] [INFO] [LevelInitFallback] Found Environment/Enemies node with 10 children
+[16:06:10] [INFO] [LevelInitFallback] Child 'Enemy1': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Child 'Enemy2': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Child 'Enemy3': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Child 'Enemy4': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Child 'Grenadier': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Child 'Enemy6': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Child 'Enemy7': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Child 'Enemy8': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Child 'Enemy9': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Child 'Enemy10': has_died_signal=True
+[16:06:10] [INFO] [LevelInitFallback] Enemy tracking complete: 10 enemies registered
+[16:06:10] [INFO] [LevelInitFallback] Realistic visibility component added to player (night mode)
+[16:06:10] [INFO] [GameManager] set_player() called with: <CharacterBody2D#479056628718> (class: CharacterBody2D)
+[16:06:10] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[16:06:10] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[16:06:10] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[16:06:10] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[16:06:10] [INFO] [LevelInitFallback] HUD ammo refreshed (fallback initial weapon setup): SniperRifle 12/72
+[16:06:10] [INFO] [LevelInitFallback] Re-applied auto-reload magazine reduction after fallback ammo config for SniperRifle
+[16:06:10] [INFO] [LevelInitFallback] HUD ammo refreshed (post fallback level ammo config): SniperRifle 12/72
+[16:06:10] [INFO] [LevelInitFallback] HUD ammo refreshed (post fallback debug UI setup): SniperRifle 12/72
+[16:06:10] [INFO] [ScoreManager] Level started with 10 enemies
+[16:06:10] [INFO] [LevelInitFallback] ScoreManager initialized with 10 enemies
+[16:06:10] [INFO] [LevelInitFallback] Exit zone created at position (120, 1250)
+[16:06:10] [INFO] [ReplayManager] Replay data cleared
+[16:06:10] [INFO] [ReplayManager] Detected player weapon: Sniper Rifle (ASVK)
+[16:06:10] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[16:06:10] [INFO] [ReplayManager] Level: BuildingLevel
+[16:06:10] [INFO] [ReplayManager] Player: Player (valid: True)
+[16:06:10] [INFO] [ReplayManager] Enemies count: 10
+[16:06:10] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/asvk_topdown.png
+[16:06:10] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[16:06:10] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[16:06:10] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[16:06:10] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[16:06:10] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[16:06:10] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[16:06:10] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[16:06:10] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[16:06:10] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[16:06:10] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[16:06:10] [INFO] [LevelInitFallback] Replay recording started with 10 enemies
+[16:06:10] [INFO] [LevelInitFallback] Weapon hints component already exists - skipping fallback setup
+[16:06:10] [INFO] [LevelInitFallback] GDScript properties synced
+[16:06:10] [INFO] [LevelInitFallback] Warm ceiling lights placed in all rooms (C# fallback)
+[16:06:10] [INFO] [LevelInitFallback] Baking navigation mesh (C# fallback)...
+[16:06:10] [INFO] [LevelInitFallback] Navigation mesh baked successfully (C# fallback) — poly_count=97, vertex_count=138
+[16:06:10] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[16:06:10] [ENEMY] [Enemy7] Patrol points snapped to navmesh (Issue #1216)
+[16:06:10] [ENEMY] [Enemy10] Patrol points snapped to navmesh (Issue #1216)
+[16:06:10] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=326.3°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:10] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=202.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:10] [ENEMY] [Enemy3] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=123.7°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:10] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=292.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:10] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=303.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:10] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:10] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=180.0°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:10] [INFO] [Player] Detecting weapon pose (frame 3)...
+[16:06:10] [INFO] [Player] Detected weapon: ASVK Sniper Rifle (Sniper pose)
+[16:06:10] [INFO] [Player] Applied Sniper arm pose: Left=(28, 6), Right=(-3, 6)
+[16:06:10] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[16:06:10] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[16:06:10] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[16:06:10] [INFO] [LastChance] Found player: Player
+[16:06:10] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[16:06:10] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[16:06:10] [INFO] [LastChance] Connected to player Died signal (C#)
+[16:06:10] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[16:06:11] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[16:06:11] [INFO] [PauseMenu] Armory button pressed
+[16:06:11] [INFO] [PauseMenu] Creating new armory menu instance
+[16:06:11] [INFO] [PauseMenu] armory_menu_scene resource path: res://scenes/ui/ArmoryMenu.tscn
+[16:06:11] [INFO] [PauseMenu] Instance created, class: CanvasLayer, name: ArmoryMenu
+[16:06:11] [INFO] [PauseMenu] Script attached: res://scripts/ui/armory_menu.gd
+[16:06:11] [INFO] [PauseMenu] back_pressed signal exists on instance
+[16:06:11] [INFO] [PauseMenu] back_pressed signal connected
+[16:06:11] [INFO] [ArmoryMenu] weapon=sniper caliber_name=12.7x108mm
+[16:06:11] [INFO] [PauseMenu] Armory menu instance added as child, is_inside_tree: true
+[16:06:11] [INFO] [PauseMenu] _populate_weapon_grid method exists
+[16:06:12] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[16:06:13] [INFO] [ArmoryMenu] weapon=ak_gl caliber_name=7.62x39mm
+[16:06:13] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[16:06:14] [INFO] [PersistManager] State saved to user://game_state.cfg
+[16:06:14] [INFO] [WeaponHintsComponent] All hints dismissed immediately
+[16:06:14] [INFO] [WeaponHintsComponent] Weapon node not found on player for: ak_gl — hints not connected to actions
+[16:06:14] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[16:06:14] [INFO] [GameManager] Weapon selected: ak_gl
+[16:06:14] [INFO] [GameManager] restart_scene() — starting scene reload
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Enemy10 (remaining: 9)
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Enemy9 (remaining: 8)
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Enemy8 (remaining: 7)
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Enemy7 (remaining: 6)
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Enemy6 (remaining: 5)
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Grenadier (remaining: 4)
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Enemy4 (remaining: 3)
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Enemy3 (remaining: 2)
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Enemy2 (remaining: 1)
+[16:06:14] [INFO] [SoundPropagation] Unregistered listener: Enemy1 (remaining: 0)
+[16:06:14] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:06:14] [INFO] [NavMeshMonitor] NavigationRegion2D added: NavigationRegion2D
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Enemy1] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Enemy1] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Enemy1] BloodyFeetComponent ready on Enemy1
+[16:06:14] [INFO] [HitEffects] 0.8x slow expired — restoring time_scale to 1.0
+[16:06:14] [INFO] [ImpactEffects] Scene changed - clearing all stale effect references
+[16:06:14] [INFO] [PenultimateHit] Resetting all effects (scene change detected)
+[16:06:14] [INFO] [LastChance] Resetting all effects (scene change detected)
+[16:06:14] [INFO] [CinemaEffects] Scene changed to: BuildingLevel
+[16:06:14] [INFO] [PowerFantasy] Resetting all effects (scene change detected)
+[16:06:14] [INFO] [BlackMetalEffectsManager] Scene changed to: BuildingLevel
+[16:06:14] [INFO] [FlashbangPlayer] Resetting flashbang player effects (scene change)
+[16:06:14] [INFO] [PersistManager] State saved to user://game_state.cfg
+[16:06:14] [INFO] [PersistManager] Auto-saved current level on scene change: res://scenes/levels/BuildingLevel.tscn
+[16:06:14] [ENEMY] [Enemy1] Death animation component initialized
+[16:06:14] [ENEMY] [Enemy1] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Enemy2] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Enemy2] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Enemy2] BloodyFeetComponent ready on Enemy2
+[16:06:14] [ENEMY] [Enemy2] Death animation component initialized
+[16:06:14] [ENEMY] [Enemy2] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Enemy3] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Enemy3] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Enemy3] BloodyFeetComponent ready on Enemy3
+[16:06:14] [ENEMY] [Enemy3] Death animation component initialized
+[16:06:14] [ENEMY] [Enemy3] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Enemy4] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Enemy4] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Enemy4] BloodyFeetComponent ready on Enemy4
+[16:06:14] [ENEMY] [Enemy4] Death animation component initialized
+[16:06:14] [ENEMY] [Enemy4] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Grenadier] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Grenadier] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Grenadier] BloodyFeetComponent ready on Grenadier
+[16:06:14] [ENEMY] [Grenadier] Death animation component initialized
+[16:06:14] [ENEMY] [Grenadier] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Enemy6] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Enemy6] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Enemy6] BloodyFeetComponent ready on Enemy6
+[16:06:14] [ENEMY] [Enemy6] Death animation component initialized
+[16:06:14] [ENEMY] [Enemy6] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Enemy7] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Enemy7] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Enemy7] BloodyFeetComponent ready on Enemy7
+[16:06:14] [ENEMY] [Enemy7] Death animation component initialized
+[16:06:14] [ENEMY] [Enemy7] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Enemy8] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Enemy8] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Enemy8] BloodyFeetComponent ready on Enemy8
+[16:06:14] [ENEMY] [Enemy8] Death animation component initialized
+[16:06:14] [ENEMY] [Enemy8] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Enemy9] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Enemy9] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Enemy9] BloodyFeetComponent ready on Enemy9
+[16:06:14] [ENEMY] [Enemy9] Death animation component initialized
+[16:06:14] [ENEMY] [Enemy9] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Enemy10] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Enemy10] Found EnemyModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Enemy10] BloodyFeetComponent ready on Enemy10
+[16:06:14] [ENEMY] [Enemy10] Death animation component initialized
+[16:06:14] [ENEMY] [Enemy10] [Gunslinger] Enemy glow applied
+[16:06:14] [INFO] [BloodyFeet:?] BloodyFeetComponent initializing...
+[16:06:14] [INFO] [BloodyFeet:Player] Footprint scene loaded
+[16:06:14] [INFO] [BloodyFeet:Player] Found PlayerModel for facing direction
+[16:06:14] [INFO] [BloodyFeet:Player] BloodyFeetComponent ready on Player
+[16:06:14] [INFO] [Player.Grenade] Grenade scene loaded from GrenadeManager: F-1 Grenade
+[16:06:14] [INFO] [Player.Grenade] Normal level - starting with 1 grenade
+[16:06:14] [INFO] [Player.Weapon] GameManager weapon selection: ak_gl (AKGL)
+[16:06:14] [INFO] [Player.Weapon] Removed current weapon: MakarovPM
+[16:06:14] [INFO] [Player.Weapon] Equipped AKGL (ammo: 75/30)
+[16:06:14] [INFO] [Player.Init] Body sprite found at position: (-4, 0)
+[16:06:14] [INFO] [Player.Init] Head sprite found at position: (-6, -2)
+[16:06:14] [INFO] [Player.Init] Left arm sprite found at position: (24, 6)
+[16:06:14] [INFO] [Player.Init] Right arm sprite found at position: (-2, 6)
+[16:06:14] [INFO] [Player.Debug] Connected to GameManager, debug mode: False
+[16:06:14] [INFO] [Player.Debug] Connected to GameManager, invincibility mode: False
+[16:06:14] [INFO] [Player.Flashlight] No flashlight selected in ActiveItemManager
+[16:06:14] [INFO] [Player.TeleportBracers] No teleport bracers selected in ActiveItemManager
+[16:06:14] [INFO] [Player.Homing] No homing bullets selected in ActiveItemManager
+[16:06:14] [INFO] [Player.BffPendant] No BFF pendant selected in ActiveItemManager
+[16:06:14] [INFO] [Player.InvisibilitySuit] No invisibility suit selected in ActiveItemManager
+[16:06:14] [INFO] [Player.BreakerBullets] Breaker bullets not selected in ActiveItemManager
+[16:06:14] [INFO] [Player.DrillingBullets] Drilling bullets not selected in ActiveItemManager
+[16:06:14] [INFO] [Player.CombatDisposition] Combat Disposition not selected in ActiveItemManager
+[16:06:14] [INFO] [Player.ForceField] Force field not selected in ActiveItemManager
+[16:06:14] [INFO] [Player.TrajectoryGlasses] Checking trajectory glasses...
+[16:06:14] [INFO] [Player.TrajectoryGlasses] No trajectory glasses selected in ActiveItemManager
+[16:06:14] [INFO] [Player.BreachingCharges] Checking breaching charges...
+[16:06:14] [INFO] [Player.BreachingCharges] No breaching charges selected in ActiveItemManager
+[16:06:14] [INFO] [Player.ArmoredSkin] Checking armored skin...
+[16:06:14] [INFO] [Player.ArmoredSkin] No armored skin selected in ActiveItemManager
+[16:06:14] [INFO] [Player.ItemVisual] Visual applied for item type: 10
+[16:06:14] [INFO] [Player.Loudspeaker] Checking loudspeaker...
+[16:06:14] [INFO] [Player.Loudspeaker] No loudspeaker selected in ActiveItemManager
+[16:06:14] [INFO] [Player.AutoReload] Auto-reload not selected in ActiveItemManager
+[16:06:14] [INFO] [Player.RecoilCompensator] Recoil compensator not selected in ActiveItemManager
+[16:06:14] [INFO] [Player.ExperimentalSample] Experimental sample not selected
+[16:06:14] [INFO] [Player.FineMotorSkills] Fine motor skills not selected in ActiveItemManager
+[16:06:14] [INFO] [Player.Dash] No dash selected in ActiveItemManager
+[16:06:14] [INFO] [Player.GrenadeBag] No grenade bag selected in ActiveItemManager
+[16:06:14] [INFO] [Player.Jammer] JammerHUD initialized
+[16:06:14] [INFO] [Player.ItemPickup] Connected to ActiveItemManager.active_item_changed
+[16:06:14] [INFO] [Player] Ready! Ammo: 75/30, Grenades: 1/3, Health: 3/4
+[16:06:14] [INFO] [Player.Grenade] Throwing system: VELOCITY-BASED (v2.0 - mouse velocity at release)
+[16:06:14] [INFO] [WeaponHintsComponent] Connected weapon signals for: ak_gl (node: AKGL)
+[16:06:14] [INFO] [WeaponHintsComponent] Hint sequence started for weapon: ak_gl
+[16:06:14] [INFO] [WeaponHintsComponent] Auto-setup from exported NodePaths
+[16:06:14] [INFO] [BloodyFeet:Enemy1] Blood detector created and attached to Enemy1
+[16:06:14] [INFO] [BloodyFeet:Enemy1] Snow surface detector created on Enemy1
+[16:06:14] [INFO] [CinemaEffects] Found player node: Player
+[16:06:14] [INFO] [CinemaEffects] Connected to player 'Died' signal (C# naming)
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Enemy1 (total: 1)
+[16:06:14] [ENEMY] [Enemy1] Registered as sound listener
+[16:06:14] [ENEMY] [Enemy1] Spawned at (300, 350), hp: 1, behavior: GUARD
+[16:06:14] [INFO] [BloodyFeet:Enemy2] Blood detector created and attached to Enemy2
+[16:06:14] [INFO] [BloodyFeet:Enemy2] Snow surface detector created on Enemy2
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Enemy2 (total: 2)
+[16:06:14] [ENEMY] [Enemy2] Registered as sound listener
+[16:06:14] [ENEMY] [Enemy2] Spawned at (400, 550), hp: 2, behavior: GUARD
+[16:06:14] [INFO] [BloodyFeet:Enemy3] Blood detector created and attached to Enemy3
+[16:06:14] [INFO] [BloodyFeet:Enemy3] Snow surface detector created on Enemy3
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Enemy3 (total: 3)
+[16:06:14] [ENEMY] [Enemy3] Registered as sound listener
+[16:06:14] [ENEMY] [Enemy3] Spawned at (700, 750), hp: 1, behavior: GUARD
+[16:06:14] [INFO] [BloodyFeet:Enemy4] Blood detector created and attached to Enemy4
+[16:06:14] [INFO] [BloodyFeet:Enemy4] Snow surface detector created on Enemy4
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Enemy4 (total: 4)
+[16:06:14] [ENEMY] [Enemy4] Registered as sound listener
+[16:06:14] [ENEMY] [Enemy4] Spawned at (800, 900), hp: 2, behavior: GUARD
+[16:06:14] [INFO] [BloodyFeet:Grenadier] Blood detector created and attached to Grenadier
+[16:06:14] [INFO] [BloodyFeet:Grenadier] Snow surface detector created on Grenadier
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Grenadier (total: 5)
+[16:06:14] [ENEMY] [Grenadier] Registered as sound listener
+[16:06:14] [ENEMY] [Grenadier] Spawned at (1700, 350), hp: 1, behavior: GUARD
+[16:06:14] [INFO] [BloodyFeet:Enemy6] Blood detector created and attached to Enemy6
+[16:06:14] [INFO] [BloodyFeet:Enemy6] Snow surface detector created on Enemy6
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Enemy6 (total: 6)
+[16:06:14] [ENEMY] [Enemy6] Registered as sound listener
+[16:06:14] [ENEMY] [Enemy6] Spawned at (1950, 450), hp: 2, behavior: GUARD
+[16:06:14] [INFO] [BloodyFeet:Enemy7] Blood detector created and attached to Enemy7
+[16:06:14] [INFO] [BloodyFeet:Enemy7] Snow surface detector created on Enemy7
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Enemy7 (total: 7)
+[16:06:14] [ENEMY] [Enemy7] Registered as sound listener
+[16:06:14] [ENEMY] [Enemy7] Spawned at (1700, 870), hp: 2, behavior: PATROL
+[16:06:14] [INFO] [BloodyFeet:Enemy8] Blood detector created and attached to Enemy8
+[16:06:14] [INFO] [BloodyFeet:Enemy8] Snow surface detector created on Enemy8
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Enemy8 (total: 8)
+[16:06:14] [ENEMY] [Enemy8] Registered as sound listener
+[16:06:14] [ENEMY] [Enemy8] Spawned at (1900, 1450), hp: 2, behavior: GUARD
+[16:06:14] [INFO] [BloodyFeet:Enemy9] Blood detector created and attached to Enemy9
+[16:06:14] [INFO] [BloodyFeet:Enemy9] Snow surface detector created on Enemy9
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Enemy9 (total: 9)
+[16:06:14] [ENEMY] [Enemy9] Registered as sound listener
+[16:06:14] [ENEMY] [Enemy9] Spawned at (2100, 1550), hp: 2, behavior: GUARD
+[16:06:14] [INFO] [BloodyFeet:Enemy10] Blood detector created and attached to Enemy10
+[16:06:14] [INFO] [BloodyFeet:Enemy10] Snow surface detector created on Enemy10
+[16:06:14] [INFO] [SoundPropagation] Registered listener: Enemy10 (total: 10)
+[16:06:14] [ENEMY] [Enemy10] Registered as sound listener
+[16:06:14] [ENEMY] [Enemy10] Spawned at (1200, 1550), hp: 2, behavior: PATROL
+[16:06:14] [INFO] [BloodyFeet:Player] Blood detector created and attached to Player
+[16:06:14] [INFO] [BloodyFeet:Player] Snow surface detector created on Player
+[16:06:14] [INFO] [LevelInitFallback] ConfigureBuildingCameraLimits: limits set — left=64 top=64 right=2464 bottom=2064 — Issue #1684
+[16:06:14] [INFO] [LevelInitFallback] GDScript _ready() did NOT execute - performing C# fallback initialization
+[16:06:14] [INFO] [LevelInitFallback] Полигон loaded (C# fallback) - Tactical Combat Arena
+[16:06:14] [INFO] [LevelInitFallback] Found Environment/Enemies node with 10 children
+[16:06:14] [INFO] [LevelInitFallback] Child 'Enemy1': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Child 'Enemy2': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Child 'Enemy3': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Child 'Enemy4': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Child 'Grenadier': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Child 'Enemy6': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Child 'Enemy7': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Child 'Enemy8': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Child 'Enemy9': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Child 'Enemy10': has_died_signal=True
+[16:06:14] [INFO] [LevelInitFallback] Enemy tracking complete: 10 enemies registered
+[16:06:14] [INFO] [LevelInitFallback] Realistic visibility component added to player (night mode)
+[16:06:14] [INFO] [GameManager] set_player() called with: <CharacterBody2D#563966121976> (class: CharacterBody2D)
+[16:06:14] [INFO] [GameManager] set_player: player_alive reset to true (new player registered)
+[16:06:14] [INFO] [GameManager] set_player: has_signal('Died')=true, has_signal('died')=false
+[16:06:14] [INFO] [GameManager] Connected to player 'Died' signal (C# naming)
+[16:06:14] [INFO] [GameManager] set_player: initial collision_layer=1 (poll expects 0 on death)
+[16:06:14] [INFO] [LevelInitFallback] HUD ammo refreshed (fallback initial weapon setup): AKGL 75/450
+[16:06:14] [INFO] [LevelInitFallback] BuildingLevel: Power Fantasy mode - AKGL magazines multiplied by 4x
+[16:06:14] [INFO] [LevelInitFallback] BuildingLevel: AKGL magazines reinitialized to 8 (C# fallback)
+[16:06:14] [INFO] [LevelInitFallback] HUD ammo refreshed (level-specific fallback ammo config): AKGL 75/525
+[16:06:14] [INFO] [LevelInitFallback] Re-applied auto-reload magazine reduction after fallback ammo config for AKGL
+[16:06:14] [INFO] [LevelInitFallback] HUD ammo refreshed (post fallback level ammo config): AKGL 75/525
+[16:06:14] [INFO] [LevelInitFallback] HUD ammo refreshed (post fallback debug UI setup): AKGL 75/525
+[16:06:14] [INFO] [ScoreManager] Level started with 10 enemies
+[16:06:14] [INFO] [LevelInitFallback] ScoreManager initialized with 10 enemies
+[16:06:14] [INFO] [LevelInitFallback] Exit zone created at position (120, 1250)
+[16:06:14] [INFO] [ReplayManager] Replay data cleared
+[16:06:14] [INFO] [ReplayManager] Detected player weapon: AK-GL
+[16:06:14] [INFO] [ReplayManager] === REPLAY RECORDING STARTED ===
+[16:06:14] [INFO] [ReplayManager] Level: BuildingLevel
+[16:06:14] [INFO] [ReplayManager] Player: Player (valid: True)
+[16:06:14] [INFO] [ReplayManager] Enemies count: 10
+[16:06:14] [INFO] [ReplayManager] Detected weapon texture: res://assets/sprites/weapons/ak_gl_topdown.png
+[16:06:14] [INFO] [ReplayManager]   Enemy 0: Enemy1
+[16:06:14] [INFO] [ReplayManager]   Enemy 1: Enemy2
+[16:06:14] [INFO] [ReplayManager]   Enemy 2: Enemy3
+[16:06:14] [INFO] [ReplayManager]   Enemy 3: Enemy4
+[16:06:14] [INFO] [ReplayManager]   Enemy 4: Grenadier
+[16:06:14] [INFO] [ReplayManager]   Enemy 5: Enemy6
+[16:06:14] [INFO] [ReplayManager]   Enemy 6: Enemy7
+[16:06:14] [INFO] [ReplayManager]   Enemy 7: Enemy8
+[16:06:14] [INFO] [ReplayManager]   Enemy 8: Enemy9
+[16:06:14] [INFO] [ReplayManager]   Enemy 9: Enemy10
+[16:06:14] [INFO] [LevelInitFallback] Replay recording started with 10 enemies
+[16:06:14] [INFO] [LevelInitFallback] Weapon hints component already exists - skipping fallback setup
+[16:06:14] [INFO] [LevelInitFallback] GDScript properties synced
+[16:06:14] [INFO] [LevelInitFallback] Warm ceiling lights placed in all rooms (C# fallback)
+[16:06:14] [INFO] [LevelInitFallback] Baking navigation mesh (C# fallback)...
+[16:06:14] [INFO] [LevelInitFallback] Navigation mesh baked successfully (C# fallback) — poly_count=97, vertex_count=138
+[16:06:14] [INFO] [ReplayManager] Recording frame 0 (0,0s): player_valid=True, enemies=10
+[16:06:14] [ENEMY] [Enemy7] Patrol points snapped to navmesh (Issue #1216)
+[16:06:14] [ENEMY] [Enemy10] Patrol points snapped to navmesh (Issue #1216)
+[16:06:14] [ENEMY] [Enemy1] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=33.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:14] [ENEMY] [Enemy2] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:14] [ENEMY] [Enemy4] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=168.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:14] [ENEMY] [Enemy6] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=337.5°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:14] [ENEMY] [Enemy8] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=78.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:14] [ENEMY] [Enemy9] ROT_CHANGE: none -> P5:idle_scan, state=IDLE, target=258.8°, current=0.0°, player=(450,1250), corner_timer=0.00
+[16:06:14] [INFO] [Player] Detecting weapon pose (frame 3)...
+[16:06:14] [INFO] [Player] Detected weapon: AK + GL (Rifle pose)
+[16:06:14] [INFO] [Player] Applied Rifle arm pose: Left=(24, 6), Right=(-2, 6)
+[16:06:14] [INFO] [PenultimateHit] Found player: Player (class: CharacterBody2D)
+[16:06:14] [INFO] [PenultimateHit] Connected to player Damaged signal (C#)
+[16:06:14] [INFO] [PenultimateHit] Connected to player Died signal (C#)
+[16:06:14] [INFO] [LastChance] Found player: Player
+[16:06:14] [INFO] [LastChance] Connected to ThreatSphere threat_detected signal
+[16:06:14] [INFO] [LastChance] Connected to player Damaged signal (C#)
+[16:06:14] [INFO] [LastChance] Connected to player Died signal (C#)
+[16:06:14] [INFO] [CinemaEffects] Cinema effect now enabled (after 1 frames delay)
+[16:06:15] [INFO] [ReplayManager] Recording frame 60 (1,0s): player_valid=True, enemies=10
+[16:06:15] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[16:06:15] [ENEMY] [Enemy7] ROT_CHANGE: none -> P3:corner, state=IDLE, target=90.0°, current=0.0°, player=(450,918), corner_timer=0.30
+[16:06:15] [ENEMY] [Enemy10] ROT_CHANGE: none -> P4:velocity, state=IDLE, target=0.0°, current=0.0°, player=(450,918), corner_timer=0.00
+[16:06:16] [ENEMY] [Enemy10] PATROL corner check: angle 90.0°
+[16:06:16] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=0.0°, player=(450,858), corner_timer=0.30
+[16:06:16] [ENEMY] [Enemy7] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=54.4°, player=(450,856), corner_timer=-0.02
+[16:06:16] [ENEMY] [Enemy7] PATROL corner check: angle 90.0°
+[16:06:16] [ENEMY] [Enemy7] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=90.0°, current=51.6°, player=(450,856), corner_timer=0.30
+[16:06:16] [INFO] [ReplayManager] Recording frame 120 (2,0s): player_valid=True, enemies=10
+[16:06:16] [ENEMY] [Enemy10] ROT_CHANGE: P3:corner -> P4:velocity, state=IDLE, target=0.0°, current=54.4°, player=(450,855), corner_timer=-0.02
+[16:06:16] [ENEMY] [Enemy10] PATROL corner check: angle -90.0°
+[16:06:16] [ENEMY] [Enemy10] ROT_CHANGE: P4:velocity -> P3:corner, state=IDLE, target=-90.0°, current=51.6°, player=(450,855), corner_timer=0.30
+[16:06:17] [INFO] [ReplayManager] Recording frame 180 (3,0s): player_valid=True, enemies=10
+[16:06:18] [INFO] [ReplayManager] Recording frame 240 (4,0s): player_valid=True, enemies=10
+[16:06:19] [INFO] [ReplayManager] Recording frame 300 (5,0s): player_valid=True, enemies=10
+[16:06:20] [INFO] ------------------------------------------------------------
+[16:06:20] [INFO] GAME LOG ENDED: 2026-05-03T16:06:20
+[16:06:20] [INFO] ============================================================

--- a/scripts/autoload/music_manager.gd
+++ b/scripts/autoload/music_manager.gd
@@ -210,6 +210,7 @@ func _sync_to_current_scene() -> void:
 	_current_scene_path = path
 	_connected_exit_zones.clear()
 	_exit_zones_connected = _connect_exit_zones(scene)
+	set_pause_muffle_enabled(false)
 	_play_track_for_path(path)
 
 

--- a/scripts/autoload/music_manager.gd
+++ b/scripts/autoload/music_manager.gd
@@ -36,6 +36,15 @@ const LEVEL_MUSIC: Dictionary = {
 ## Name of the audio bus that the music slider in sound settings drives.
 const MUSIC_BUS: String = "Music"
 
+## Cutoff used for the pause-screen muffled/underwater effect.
+const PAUSE_MUFFLED_CUTOFF_HZ: float = 650.0
+
+## Filter slope for the pause-screen muffled effect.
+const PAUSE_MUFFLED_DB: int = AudioEffectFilter.FILTER_24DB
+
+## Resonance used to keep the low-passed pause music heavy without whistling.
+const PAUSE_MUFFLED_RESONANCE: float = 0.45
+
 ## Credit text drawn in the bottom-left of the GUI.
 const CREDIT_TEXT: String = "music by Instrumental Healthcare"
 
@@ -63,9 +72,13 @@ var _exit_zones_connected: bool = false
 ## we can reconnect to the new exit zone instances (Issue #1929).
 var _connected_exit_zones: Array = []
 
+## Index of the low-pass effect installed on the Music bus for pause muffling.
+var _pause_muffle_effect_index: int = -1
+
 
 func _ready() -> void:
 	_ensure_music_bus()
+	_ensure_pause_muffle_effect()
 	_create_player()
 	_create_credit_label()
 
@@ -100,6 +113,31 @@ func _ensure_music_bus() -> void:
 	var sound_settings: Node = get_node_or_null("/root/SoundSettings")
 	if sound_settings and sound_settings.has_method("_apply_music_volume"):
 		sound_settings._apply_music_volume()
+
+
+## Adds a disabled low-pass filter to the Music bus. PauseMenu enables it while
+## visible, giving the music a strong underwater-like muffled tone without
+## affecting SFX routed through other buses.
+func _ensure_pause_muffle_effect() -> void:
+	var bus_idx := AudioServer.get_bus_index(MUSIC_BUS)
+	if bus_idx < 0:
+		return
+
+	for effect_idx in range(AudioServer.get_bus_effect_count(bus_idx)):
+		var existing := AudioServer.get_bus_effect(bus_idx, effect_idx)
+		if existing is AudioEffectLowPassFilter and existing.resource_name == "PauseMuffleLowPass":
+			_pause_muffle_effect_index = effect_idx
+			AudioServer.set_bus_effect_enabled(bus_idx, effect_idx, false)
+			return
+
+	var filter := AudioEffectLowPassFilter.new()
+	filter.resource_name = "PauseMuffleLowPass"
+	filter.cutoff_hz = PAUSE_MUFFLED_CUTOFF_HZ
+	filter.db = PAUSE_MUFFLED_DB
+	filter.resonance = PAUSE_MUFFLED_RESONANCE
+	AudioServer.add_bus_effect(bus_idx, filter)
+	_pause_muffle_effect_index = AudioServer.get_bus_effect_count(bus_idx) - 1
+	AudioServer.set_bus_effect_enabled(bus_idx, _pause_muffle_effect_index, false)
 
 
 func _create_player() -> void:
@@ -250,6 +288,37 @@ func _find_exit_zones(node: Node) -> Array:
 func _on_exit_zone_activated() -> void:
 	if _player and _player.playing:
 		_player.stop()
+
+
+## Public API: toggles the pause-screen muffled music effect.
+func set_pause_muffle_enabled(enabled: bool) -> void:
+	var bus_idx := AudioServer.get_bus_index(MUSIC_BUS)
+	if bus_idx < 0:
+		return
+	if _pause_muffle_effect_index < 0 or _pause_muffle_effect_index >= AudioServer.get_bus_effect_count(bus_idx):
+		_ensure_pause_muffle_effect()
+	if _pause_muffle_effect_index >= 0 and _pause_muffle_effect_index < AudioServer.get_bus_effect_count(bus_idx):
+		AudioServer.set_bus_effect_enabled(bus_idx, _pause_muffle_effect_index, enabled)
+
+
+## Public API: returns whether the pause-screen muffled music effect is active.
+func is_pause_muffle_enabled() -> bool:
+	var bus_idx := AudioServer.get_bus_index(MUSIC_BUS)
+	if bus_idx < 0:
+		return false
+	if _pause_muffle_effect_index < 0 or _pause_muffle_effect_index >= AudioServer.get_bus_effect_count(bus_idx):
+		return false
+	return AudioServer.is_bus_effect_enabled(bus_idx, _pause_muffle_effect_index)
+
+
+## Public API: returns the installed pause low-pass effect for tests/debugging.
+func get_pause_muffle_effect() -> AudioEffect:
+	var bus_idx := AudioServer.get_bus_index(MUSIC_BUS)
+	if bus_idx < 0:
+		return null
+	if _pause_muffle_effect_index < 0 or _pause_muffle_effect_index >= AudioServer.get_bus_effect_count(bus_idx):
+		return null
+	return AudioServer.get_bus_effect(bus_idx, _pause_muffle_effect_index)
 
 
 ## Public API: returns the currently mapped music path for a scene, or

--- a/scripts/autoload/music_manager.gd
+++ b/scripts/autoload/music_manager.gd
@@ -75,6 +75,10 @@ var _connected_exit_zones: Array = []
 ## Index of the low-pass effect installed on the Music bus for pause muffling.
 var _pause_muffle_effect_index: int = -1
 
+## Current scene instance tracked separately from its path. Reloading or
+## restarting a level keeps the same path but replaces the scene object.
+var _current_scene_instance: Node = null
+
 
 func _ready() -> void:
 	_ensure_music_bus()
@@ -186,6 +190,9 @@ func _sync_to_current_scene() -> void:
 		return
 	var path: String = scene.scene_file_path
 	if path == _current_scene_path:
+		if scene != _current_scene_instance:
+			_current_scene_instance = scene
+			set_pause_muffle_enabled(false)
 		# When the same level is restarted (e.g. after player death), the scene
 		# path does not change but all nodes are freed and recreated. Detect
 		# this by checking whether the previously connected exit zone nodes are
@@ -208,6 +215,7 @@ func _sync_to_current_scene() -> void:
 		return
 
 	_current_scene_path = path
+	_current_scene_instance = scene
 	_connected_exit_zones.clear()
 	_exit_zones_connected = _connect_exit_zones(scene)
 	set_pause_muffle_enabled(false)

--- a/scripts/ui/pause_menu.gd
+++ b/scripts/ui/pause_menu.gd
@@ -92,6 +92,7 @@ func toggle_pause() -> void:
 ## Pauses the game and shows the menu.
 func pause_game() -> void:
 	get_tree().paused = true
+	_set_music_pause_muffle_enabled(true)
 	# Show cursor for menu interaction (still confined to window)
 	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
 
@@ -119,6 +120,7 @@ func pause_game() -> void:
 ## Resumes the game and hides the menu.
 func resume_game() -> void:
 	get_tree().paused = false
+	_set_music_pause_muffle_enabled(false)
 	# Hide cursor again for gameplay (confined and hidden)
 	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED_HIDDEN)
 	hide()
@@ -230,6 +232,7 @@ func _on_levels_back() -> void:
 func _on_training_pressed() -> void:
 	# Load the tutorial level directly
 	get_tree().paused = false
+	_set_music_pause_muffle_enabled(false)
 	# Restore hidden cursor for gameplay (confined and hidden)
 	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED_HIDDEN)
 
@@ -246,6 +249,7 @@ func _on_training_pressed() -> void:
 func _on_roguelike_pressed() -> void:
 	# Load the roguelike level directly (Issue #1061)
 	get_tree().paused = false
+	_set_music_pause_muffle_enabled(false)
 	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED_HIDDEN)
 
 	var roguelike_path: String = "res://scenes/levels/RoguelikeLevel.tscn"
@@ -263,6 +267,7 @@ func _on_roguelike_pressed() -> void:
 func _on_arena_pressed() -> void:
 	# Load the Arena level directly (same pattern as Training button).
 	get_tree().paused = false
+	_set_music_pause_muffle_enabled(false)
 	Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED_HIDDEN)
 
 	var arena_path: String = "res://scenes/levels/ArenaLevel.tscn"
@@ -275,7 +280,14 @@ func _on_arena_pressed() -> void:
 
 func _on_quit_pressed() -> void:
 	get_tree().paused = false
+	_set_music_pause_muffle_enabled(false)
 	get_tree().quit()
+
+
+func _set_music_pause_muffle_enabled(enabled: bool) -> void:
+	var music_manager: Node = get_node_or_null("/root/MusicManager")
+	if music_manager and music_manager.has_method("set_pause_muffle_enabled"):
+		music_manager.set_pause_muffle_enabled(enabled)
 
 
 ## Refresh the armory button state:

--- a/tests/unit/test_music_manager.gd
+++ b/tests/unit/test_music_manager.gd
@@ -132,6 +132,36 @@ func test_sync_to_new_scene_disables_pause_muffle() -> void:
 		"Pause muffle effect should be disabled when a new level scene becomes current")
 
 
+func test_sync_to_reloaded_same_scene_disables_pause_muffle_without_restarting_music() -> void:
+	# Regression for owner feedback after commit 40bfff67: applying a weapon
+	# from the armory can restart the current level, replacing the scene
+	# instance while keeping the same scene_file_path. That must clear the
+	# global pause bus effect without replaying the music track.
+	var old_scene := Node2D.new()
+	old_scene.name = "LabyrinthLevel"
+	old_scene.scene_file_path = "res://scenes/levels/LabyrinthLevel.tscn"
+	add_child_autofree(old_scene)
+
+	var new_scene := Node2D.new()
+	new_scene.name = "LabyrinthLevel"
+	new_scene.scene_file_path = "res://scenes/levels/LabyrinthLevel.tscn"
+	add_child_autofree(new_scene)
+
+	manager.set_pause_muffle_enabled(true)
+	manager._current_scene_path = new_scene.scene_file_path
+	manager._current_scene_instance = old_scene
+	get_tree().current_scene = new_scene
+
+	manager._sync_to_current_scene()
+
+	assert_false(manager.is_pause_muffle_enabled(),
+		"Pause muffle effect should be disabled when the same level is restarted")
+	assert_eq(manager._current_scene_path, new_scene.scene_file_path,
+		"Scene path should remain cached so music playback is not restarted on same-level reload")
+	assert_eq(manager._current_scene_instance, new_scene,
+		"MusicManager should track the replacement scene instance after same-level reload")
+
+
 func test_credit_label_is_present_with_correct_text() -> void:
 	var canvas: CanvasLayer = manager.get_node("MusicCreditCanvas")
 	assert_not_null(canvas, "Credit canvas should be created")

--- a/tests/unit/test_music_manager.gd
+++ b/tests/unit/test_music_manager.gd
@@ -112,6 +112,26 @@ func test_set_pause_muffle_enabled_toggles_bus_effect() -> void:
 		"Pause muffle effect should be disabled when the pause menu closes")
 
 
+func test_sync_to_new_scene_disables_pause_muffle() -> void:
+	# Regression for PR #1932 owner feedback: choosing another level from the
+	# paused Levels menu routes through SceneLoader, so PauseMenu is freed by
+	# the scene change before it can resume the game itself. MusicManager must
+	# clear the global bus effect whenever the current scene changes.
+	manager.set_pause_muffle_enabled(true)
+	manager._current_scene_path = "res://scenes/levels/LabyrinthLevel.tscn"
+
+	var scene := Node2D.new()
+	scene.name = "BuildingLevel"
+	scene.scene_file_path = "res://scenes/levels/BuildingLevel.tscn"
+	add_child_autofree(scene)
+	get_tree().current_scene = scene
+
+	manager._sync_to_current_scene()
+
+	assert_false(manager.is_pause_muffle_enabled(),
+		"Pause muffle effect should be disabled when a new level scene becomes current")
+
+
 func test_credit_label_is_present_with_correct_text() -> void:
 	var canvas: CanvasLayer = manager.get_node("MusicCreditCanvas")
 	assert_not_null(canvas, "Credit canvas should be created")

--- a/tests/unit/test_music_manager.gd
+++ b/tests/unit/test_music_manager.gd
@@ -90,6 +90,28 @@ func test_audio_player_routes_through_music_bus() -> void:
 		"Music should keep playing while the game is paused")
 
 
+func test_music_bus_has_pause_low_pass_filter() -> void:
+	var effect := manager.get_pause_muffle_effect()
+	assert_not_null(effect,
+		"MusicManager should install a low-pass filter for pause muffling")
+	assert_true(effect is AudioEffectLowPassFilter,
+		"Pause muffle effect should be an AudioEffectLowPassFilter")
+	assert_almost_eq(effect.cutoff_hz, MUSIC_MANAGER.PAUSE_MUFFLED_CUTOFF_HZ, 0.01,
+		"Pause muffle filter should start at the muffled cutoff")
+	assert_false(manager.is_pause_muffle_enabled(),
+		"Pause muffle effect should start disabled during gameplay")
+
+
+func test_set_pause_muffle_enabled_toggles_bus_effect() -> void:
+	manager.set_pause_muffle_enabled(true)
+	assert_true(manager.is_pause_muffle_enabled(),
+		"Pause muffle effect should be enabled when the pause menu opens")
+
+	manager.set_pause_muffle_enabled(false)
+	assert_false(manager.is_pause_muffle_enabled(),
+		"Pause muffle effect should be disabled when the pause menu closes")
+
+
 func test_credit_label_is_present_with_correct_text() -> void:
 	var canvas: CanvasLayer = manager.get_node("MusicCreditCanvas")
 	assert_not_null(canvas, "Credit canvas should be created")


### PR DESCRIPTION
Fixes Jhon-Crow/godot-topdown-MVP#1931

## Summary

Adds a strong pause-screen music muffle effect by installing a disabled `AudioEffectLowPassFilter` on the existing `Music` audio bus and enabling it only while `PauseMenu` is visible. The filter uses a 650 Hz cutoff with a 24 dB slope to create the requested underwater-like muted sound without affecting SFX buses or restarting music playback.

Also adds the requested case-study research and solution analysis under `docs/case-studies/issue-1931/README.md`, plus downloaded owner feedback logs under `docs/case-studies/issue-1931/artifacts/`.

## Follow-up Fixes From Review

Owner feedback first reported that the effect stayed enabled after switching levels from the pause screen. Root cause: level selection goes through `LevelsMenu -> SceneLoader.load_level()`, which changes scenes without calling `PauseMenu.resume_game()`, while the low-pass effect lives globally on the `AudioServer` Music bus.

`MusicManager._sync_to_current_scene()` now disables the pause muffle whenever the active scene path changes, so cleanup works for direct PauseMenu buttons, LevelsMenu selections, SceneLoader transitions, startup navigation, and direct scene-change fallbacks.

Owner feedback then confirmed level switching was fixed but reported that the effect stayed enabled after choosing a weapon in the armory. Root cause: armory apply can restart/reload the current level through `GameManager.restart_scene()`, keeping the same `scene_file_path`; the previous follow-up intentionally skipped same-path reloads to avoid restarting music.

`MusicManager` now tracks the current scene instance separately from the current scene path. If the same path is represented by a replacement scene object, it clears the pause muffle but still returns before replaying the track. This covers armory apply, death restart, score-screen restart, quick restart, and other same-level reloads while preserving seamless music playback.

## Implementation

- `MusicManager` creates and tracks a `PauseMuffleLowPass` bus effect.
- `PauseMenu` enables the effect when pausing and disables it when resuming, mode changes, or quitting.
- `MusicManager` clears the effect on any current-scene path change.
- `MusicManager` also clears the effect on same-path scene instance replacement.
- Added regression tests covering filter installation, toggle behavior, scene-switch cleanup, and same-level restart cleanup.
- Extended the case study with both owner feedback logs, timelines, root-cause analysis, and selected fixes.

## Verification

- `dotnet build` passes with existing warnings.
- `git diff --check` passes.
- Added GUT coverage in `tests/unit/test_music_manager.gd` for the new pause muffle behavior, level-switch cleanup, and armory/same-level restart cleanup.

Note: the local container does not include a `godot` executable, so the GUT suite could not be run locally here; CI should run it after this push.
