### PR TITLE
Add music muffle sound setting

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-03T13:28:50.756Z for PR creation at branch issue-1935-a83434fecd73 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1935

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-03T13:28:50.756Z for PR creation at branch issue-1935-a83434fecd73 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1935

--- a/resources/translations/translations.csv
+++ b/resources/translations/translations.csv
@@ -21,6 +21,8 @@ BACK,Back,Назад
 SOUND_SETTINGS_TITLE,Sound Settings,Настройки звука
 EFFECTS_VOLUME,Effects Volume,Громкость эффектов
 MUSIC_VOLUME,Music Volume,Громкость музыки
+MUSIC_MUFFLE,Music Muffle,Глушение музыки
+ENABLED,Enabled,Включено
 GAMEPLAY_SETTINGS_TITLE,Gameplay Settings,Настройки геймплея
 BLOOD_AMOUNT,Blood Amount,Количество крови
 WEAPON_HINTS,Weapon Hints,Подсказки оружия

--- a/scenes/ui/SoundMenu.tscn
+++ b/scenes/ui/SoundMenu.tscn
@@ -102,6 +102,22 @@ horizontal_alignment = 2
 [node name="HSeparator3" type="HSeparator" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
+[node name="MusicMuffleLabel" type="Label" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "MUSIC_MUFFLE"
+
+[node name="MusicMuffleContainer" type="HBoxContainer" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="MusicMuffleCheckButton" type="CheckButton" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer/MusicMuffleContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+button_pressed = true
+text = "ENABLED"
+
+[node name="HSeparator4" type="HSeparator" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
 [node name="BackButton" type="Button" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer"]
 custom_minimum_size = Vector2(200, 40)
 layout_mode = 2

--- a/scripts/autoload/music_manager.gd
+++ b/scripts/autoload/music_manager.gd
@@ -304,6 +304,11 @@ func set_pause_muffle_enabled(enabled: bool) -> void:
 	var bus_idx := AudioServer.get_bus_index(MUSIC_BUS)
 	if bus_idx < 0:
 		return
+	if enabled:
+		var sound_settings: Node = get_node_or_null("/root/SoundSettings")
+		if sound_settings and sound_settings.has_method("is_music_muffle_enabled") \
+				and not sound_settings.is_music_muffle_enabled():
+			enabled = false
 	if _pause_muffle_effect_index < 0 or _pause_muffle_effect_index >= AudioServer.get_bus_effect_count(bus_idx):
 		_ensure_pause_muffle_effect()
 	if _pause_muffle_effect_index >= 0 and _pause_muffle_effect_index < AudioServer.get_bus_effect_count(bus_idx):

--- a/scripts/autoload/sound_settings.gd
+++ b/scripts/autoload/sound_settings.gd
@@ -17,6 +17,9 @@ var effects_volume: float = 1.0
 ## Linear volume for music [0.0, 1.0]. Default is full volume.
 var music_volume: float = 1.0
 
+## Whether pause-screen music muffling is enabled. Default preserves existing behaviour.
+var music_muffle_enabled: bool = true
+
 ## Name of the audio bus used for sound effects.
 const EFFECTS_BUS: String = "Effects"
 
@@ -36,7 +39,8 @@ const MAX_VOLUME_DB: float = 0.0
 func _ready() -> void:
 	_load_settings()
 	_apply_volumes()
-	_log_to_file("SoundSettings initialized - effects: %.2f, music: %.2f" % [effects_volume, music_volume])
+	_log_to_file("SoundSettings initialized - effects: %.2f, music: %.2f, muffle: %s"
+			% [effects_volume, music_volume, str(music_muffle_enabled)])
 
 
 ## Sets the effects volume.
@@ -71,6 +75,24 @@ func set_music_volume(volume: float) -> void:
 ## Gets the current music volume as a linear value [0.0, 1.0].
 func get_music_volume() -> float:
 	return music_volume
+
+
+## Sets whether pause-screen music muffling is enabled.
+func set_music_muffle_enabled(enabled: bool) -> void:
+	if music_muffle_enabled != enabled:
+		music_muffle_enabled = enabled
+		settings_changed.emit()
+		_save_settings()
+		if not enabled:
+			var music_manager: Node = get_node_or_null("/root/MusicManager")
+			if music_manager and music_manager.has_method("set_pause_muffle_enabled"):
+				music_manager.set_pause_muffle_enabled(false)
+		_log_to_file("Music muffle enabled set to %s" % str(enabled))
+
+
+## Returns true when pause-screen music muffling is enabled.
+func is_music_muffle_enabled() -> bool:
+	return music_muffle_enabled
 
 
 ## Converts a linear volume [0.0, 1.0] to decibels.
@@ -111,6 +133,7 @@ func _save_settings() -> void:
 	var config := ConfigFile.new()
 	config.set_value("sound", "effects_volume", effects_volume)
 	config.set_value("sound", "music_volume", music_volume)
+	config.set_value("sound", "music_muffle_enabled", music_muffle_enabled)
 	var error := config.save(SETTINGS_PATH)
 	if error != OK:
 		push_warning("SoundSettings: Failed to save settings: " + str(error))
@@ -123,12 +146,14 @@ func _load_settings() -> void:
 	if error == OK:
 		effects_volume = config.get_value("sound", "effects_volume", 1.0)
 		music_volume = config.get_value("sound", "music_volume", 1.0)
+		music_muffle_enabled = config.get_value("sound", "music_muffle_enabled", true)
 		# Clamp values in case the file was edited manually
 		effects_volume = clamp(effects_volume, 0.0, 1.0)
 		music_volume = clamp(music_volume, 0.0, 1.0)
 	else:
 		effects_volume = 1.0
 		music_volume = 1.0
+		music_muffle_enabled = true
 
 
 ## Logs a message via FileLogger if available.

--- a/scripts/ui/sound_menu.gd
+++ b/scripts/ui/sound_menu.gd
@@ -13,6 +13,7 @@ signal back_pressed
 @onready var effects_value_label: Label = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/EffectsContainer/EffectsValueLabel
 @onready var music_slider: HSlider = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/MusicContainer/MusicSlider
 @onready var music_value_label: Label = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/MusicContainer/MusicValueLabel
+@onready var music_muffle_check_button: CheckButton = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/MusicMuffleContainer/MusicMuffleCheckButton
 @onready var back_button: Button = $MenuContainer/PanelContainer/MarginContainer/VBoxContainer/BackButton
 
 
@@ -22,10 +23,13 @@ func _ready() -> void:
 			"Effects Volume")
 	_setup_row_hover($MenuContainer/PanelContainer/MarginContainer/VBoxContainer/MusicContainer,
 			"Music Volume")
+	_setup_row_hover($MenuContainer/PanelContainer/MarginContainer/VBoxContainer/MusicMuffleContainer,
+			"Music Muffle")
 
 	# Connect button and slider signals
 	effects_slider.value_changed.connect(_on_effects_volume_changed)
 	music_slider.value_changed.connect(_on_music_volume_changed)
+	music_muffle_check_button.toggled.connect(_on_music_muffle_toggled)
 	back_button.pressed.connect(_on_back_pressed)
 
 	# Update sliders from current settings
@@ -56,6 +60,11 @@ func _update_ui() -> void:
 	music_slider.set_block_signals(false)
 	music_value_label.text = "%d%%" % int(sound_settings.get_music_volume() * 100.0)
 
+	if sound_settings.has_method("is_music_muffle_enabled"):
+		music_muffle_check_button.set_block_signals(true)
+		music_muffle_check_button.button_pressed = sound_settings.is_music_muffle_enabled()
+		music_muffle_check_button.set_block_signals(false)
+
 
 func _on_effects_volume_changed(value: float) -> void:
 	var sound_settings: Node = get_node_or_null("/root/SoundSettings")
@@ -69,6 +78,12 @@ func _on_music_volume_changed(value: float) -> void:
 	if sound_settings:
 		sound_settings.set_music_volume(value / 100.0)
 	music_value_label.text = "%d%%" % int(value)
+
+
+func _on_music_muffle_toggled(enabled: bool) -> void:
+	var sound_settings: Node = get_node_or_null("/root/SoundSettings")
+	if sound_settings and sound_settings.has_method("set_music_muffle_enabled"):
+		sound_settings.set_music_muffle_enabled(enabled)
 
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/tests/unit/test_music_manager.gd
+++ b/tests/unit/test_music_manager.gd
@@ -9,6 +9,15 @@ extends GutTest
 const MUSIC_MANAGER = preload("res://scripts/autoload/music_manager.gd")
 
 
+class MockSoundSettingsNode:
+	extends Node
+
+	var music_muffle_enabled: bool = true
+
+	func is_music_muffle_enabled() -> bool:
+		return music_muffle_enabled
+
+
 # ============================================================================
 # Mapping Tests (no node required)
 # ============================================================================
@@ -58,6 +67,7 @@ func test_main_levels_are_mapped() -> void:
 
 
 var manager: Node = null
+var _mock_sound_settings: Node = null
 
 
 func before_each() -> void:
@@ -65,6 +75,12 @@ func before_each() -> void:
 	add_child_autofree(manager)
 	# Allow _ready() to run.
 	await get_tree().process_frame
+
+
+func after_each() -> void:
+	if is_instance_valid(_mock_sound_settings):
+		_mock_sound_settings.queue_free()
+		_mock_sound_settings = null
 
 
 ## Build a tiny, valid AudioStream for tests. AudioStreamGenerator works in
@@ -110,6 +126,18 @@ func test_set_pause_muffle_enabled_toggles_bus_effect() -> void:
 	manager.set_pause_muffle_enabled(false)
 	assert_false(manager.is_pause_muffle_enabled(),
 		"Pause muffle effect should be disabled when the pause menu closes")
+
+
+func test_set_pause_muffle_enabled_respects_sound_settings_toggle() -> void:
+	_mock_sound_settings = MockSoundSettingsNode.new()
+	_mock_sound_settings.name = "SoundSettings"
+	_mock_sound_settings.music_muffle_enabled = false
+	get_tree().root.add_child(_mock_sound_settings)
+
+	manager.set_pause_muffle_enabled(true)
+
+	assert_false(manager.is_pause_muffle_enabled(),
+		"Pause muffle effect should stay disabled when SoundSettings toggle is off")
 
 
 func test_sync_to_new_scene_disables_pause_muffle() -> void:

--- a/tests/unit/test_sound_menu.gd
+++ b/tests/unit/test_sound_menu.gd
@@ -13,6 +13,7 @@ extends GutTest
 class MockSoundSettings:
 	var effects_volume: float = 1.0
 	var music_volume: float = 1.0
+	var music_muffle_enabled: bool = true
 	var settings_changed_count: int = 0
 
 	func set_effects_volume(volume: float) -> void:
@@ -29,6 +30,13 @@ class MockSoundSettings:
 	func get_music_volume() -> float:
 		return music_volume
 
+	func set_music_muffle_enabled(enabled: bool) -> void:
+		music_muffle_enabled = enabled
+		settings_changed_count += 1
+
+	func is_music_muffle_enabled() -> bool:
+		return music_muffle_enabled
+
 
 # ============================================================================
 # Mock SoundMenu logic (mirrors sound_menu.gd logic)
@@ -39,6 +47,7 @@ class MockSoundMenu:
 	## Simulated slider values (0..100)
 	var effects_slider_value: float = 100.0
 	var music_slider_value: float = 100.0
+	var music_muffle_button_pressed: bool = true
 
 	## Simulated label texts
 	var effects_value_text: String = "100%"
@@ -52,6 +61,7 @@ class MockSoundMenu:
 		effects_value_text = "%d%%" % int(effects_slider_value)
 		music_slider_value = sound_settings.get_music_volume() * 100.0
 		music_value_text = "%d%%" % int(music_slider_value)
+		music_muffle_button_pressed = sound_settings.is_music_muffle_enabled()
 
 	func on_effects_volume_changed(value: float, sound_settings: MockSoundSettings) -> void:
 		sound_settings.set_effects_volume(value / 100.0)
@@ -60,6 +70,9 @@ class MockSoundMenu:
 	func on_music_volume_changed(value: float, sound_settings: MockSoundSettings) -> void:
 		sound_settings.set_music_volume(value / 100.0)
 		music_value_text = "%d%%" % int(value)
+
+	func on_music_muffle_toggled(enabled: bool, sound_settings: MockSoundSettings) -> void:
+		sound_settings.set_music_muffle_enabled(enabled)
 
 	func on_back_pressed() -> void:
 		back_pressed_count += 1
@@ -126,6 +139,13 @@ func test_update_ui_sets_music_label_text() -> void:
 		"Music label should show '30%%' when slider is 30")
 
 
+func test_update_ui_sets_music_muffle_toggle() -> void:
+	sound_settings.music_muffle_enabled = false
+	menu.update_ui(sound_settings)
+	assert_false(menu.music_muffle_button_pressed,
+		"Music muffle toggle should reflect SoundSettings")
+
+
 # ============================================================================
 # Slider Change Tests
 # ============================================================================
@@ -169,6 +189,12 @@ func test_on_music_volume_changed_mutes_to_zero() -> void:
 		"Music volume should be muted (0.0) when slider is at 0")
 	assert_eq(menu.music_value_text, "0%",
 		"Music label should show '0%%' when muted")
+
+
+func test_on_music_muffle_toggled_updates_settings() -> void:
+	menu.on_music_muffle_toggled(false, sound_settings)
+	assert_false(sound_settings.is_music_muffle_enabled(),
+		"SoundSettings music muffle should be disabled when toggle is off")
 
 
 # ============================================================================

--- a/tests/unit/test_sound_settings.gd
+++ b/tests/unit/test_sound_settings.gd
@@ -17,6 +17,9 @@ class MockSoundSettings:
 	## Linear volume for music [0.0, 1.0].
 	var music_volume: float = 1.0
 
+	## Whether pause-screen music muffling is enabled.
+	var music_muffle_enabled: bool = true
+
 	## Track emitted signals
 	var settings_changed_count: int = 0
 
@@ -43,6 +46,14 @@ class MockSoundSettings:
 
 	func get_music_volume() -> float:
 		return music_volume
+
+	func set_music_muffle_enabled(enabled: bool) -> void:
+		if music_muffle_enabled != enabled:
+			music_muffle_enabled = enabled
+			settings_changed_count += 1
+
+	func is_music_muffle_enabled() -> bool:
+		return music_muffle_enabled
 
 	func linear_to_db(linear: float) -> float:
 		if linear <= 0.0:
@@ -74,6 +85,11 @@ func test_default_effects_volume_is_full() -> void:
 func test_default_music_volume_is_full() -> void:
 	assert_eq(settings.get_music_volume(), 1.0,
 		"Default music volume should be 1.0 (100%)")
+
+
+func test_default_music_muffle_is_enabled() -> void:
+	assert_true(settings.is_music_muffle_enabled(),
+		"Music muffle should be enabled by default to preserve existing pause behavior")
 
 
 # ============================================================================
@@ -150,6 +166,24 @@ func test_set_music_volume_no_signal_when_same() -> void:
 	settings.set_music_volume(1.0)  # Already 1.0 by default
 	assert_eq(settings.settings_changed_count, 0,
 		"settings_changed should NOT be emitted when value does not change")
+
+
+func test_set_music_muffle_enabled_stores_value() -> void:
+	settings.set_music_muffle_enabled(false)
+	assert_false(settings.is_music_muffle_enabled(),
+		"Music muffle setting should store false when disabled")
+
+
+func test_set_music_muffle_enabled_emits_signal_on_change() -> void:
+	settings.set_music_muffle_enabled(false)
+	assert_eq(settings.settings_changed_count, 1,
+		"settings_changed should be emitted when music muffle setting changes")
+
+
+func test_set_music_muffle_enabled_no_signal_when_same() -> void:
+	settings.set_music_muffle_enabled(true)  # Already true by default
+	assert_eq(settings.settings_changed_count, 0,
+		"settings_changed should NOT be emitted when music muffle setting does not change")
 
 
 # ============================================================================


### PR DESCRIPTION
Fixes Jhon-Crow/godot-topdown-MVP#1935

## Summary
- Added a persisted sound setting for pause-screen music muffling, enabled by default to preserve existing behavior.
- Added a Sound Settings checkbox that lets players disable the muffle effect so music is never muffled while paused.
- Made MusicManager respect the setting before enabling the pause low-pass filter, and immediately clear the effect when the setting is turned off.
- Added English/Russian translation keys and regression coverage for settings, sound menu logic, and MusicManager behavior.

## Reproduction
1. Open the game with the pause muffle feature from PR #1932.
2. Disable the new Music Muffle option in Sound Settings.
3. Pause gameplay.
4. Music should continue normally without the low-pass muffle effect.

## Tests
- `dotnet build --configuration Debug` passes with existing warnings.
- `godot --headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/unit/test_sound_settings.gd,res://tests/unit/test_sound_menu.gd -gexit` could not be run locally because `godot` is not installed/on PATH in this workspace.
