### PR TITLE
Make unlock sparks linger longer

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-03T16:31:10.712Z for PR creation at branch issue-1943-fdf0cabf3a9c for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1943

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-03T16:31:10.712Z for PR creation at branch issue-1943-fdf0cabf3a9c for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1943

--- a/scripts/ui/armory_menu.gd
+++ b/scripts/ui/armory_menu.gd
@@ -215,16 +215,17 @@ const UNLOCK_SPARK_DISTANCE_MIN: float = 70.0
 const UNLOCK_SPARK_DISTANCE_MAX: float = 140.0
 
 ## Vertical arc range for unlock sparks before gravity pulls them downward.
-const UNLOCK_SPARK_ARC_HEIGHT_MIN: float = 40.0
-const UNLOCK_SPARK_ARC_HEIGHT_MAX: float = 90.0
+const UNLOCK_SPARK_ARC_HEIGHT_MIN: float = 24.0
+const UNLOCK_SPARK_ARC_HEIGHT_MAX: float = 58.0
 
 ## Gravity-like downward fall range for unlock sparks.
-const UNLOCK_SPARK_GRAVITY_FALL_MIN: float = 50.0
-const UNLOCK_SPARK_GRAVITY_FALL_MAX: float = 110.0
+const UNLOCK_SPARK_GRAVITY_FALL_MIN: float = 86.0
+const UNLOCK_SPARK_GRAVITY_FALL_MAX: float = 165.0
 
-## Longer lifetime keeps the heavier spark burst readable.
-const UNLOCK_SPARK_DURATION_MIN: float = 0.70
-const UNLOCK_SPARK_DURATION_MAX: float = 1.05
+## Longer lifetime lets sparks linger, fall slowly, and shrink out.
+const UNLOCK_SPARK_DURATION_MIN: float = 1.45
+const UNLOCK_SPARK_DURATION_MAX: float = 2.10
+const UNLOCK_SPARK_CLEANUP_PADDING: float = 0.18
 
 ## Fan spread for sparks: upward hemisphere from upper-left to upper-right.
 ## In Godot screen coords up=-Y so center is -PI/2; fan half-width ~80°.
@@ -2280,23 +2281,23 @@ func _emit_unlock_sparks(slot: PanelContainer) -> void:
 		var target_scale := Vector2(rng.randf_range(0.08, 0.22), rng.randf_range(0.08, 0.22))
 		var duration := rng.randf_range(UNLOCK_SPARK_DURATION_MIN, UNLOCK_SPARK_DURATION_MAX)
 		var movement_tween := create_tween()
-		movement_tween.tween_property(spark, "position", arc_peak, duration * 0.40) \
+		movement_tween.tween_property(spark, "position", arc_peak, duration * 0.30) \
 			.set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUAD)
-		movement_tween.tween_property(spark, "position", target_position, duration * 0.60) \
-			.set_ease(Tween.EASE_IN).set_trans(Tween.TRANS_QUAD)
+		movement_tween.tween_property(spark, "position", target_position, duration * 0.70) \
+			.set_ease(Tween.EASE_IN_OUT).set_trans(Tween.TRANS_SINE)
 
 		var spark_tween := create_tween()
 		spark_tween.set_parallel(true)
 		spark_tween.tween_property(spark, "scale", target_scale, duration) \
-			.set_ease(Tween.EASE_IN)
-		spark_tween.tween_property(outer_glow, "color:a", 0.0, duration) \
+			.set_ease(Tween.EASE_IN_OUT).set_trans(Tween.TRANS_SINE)
+		spark_tween.tween_property(outer_glow, "color:a", 0.0, duration * 0.92) \
 			.set_ease(Tween.EASE_IN).set_delay(duration * 0.05)
-		spark_tween.tween_property(inner_glow, "color:a", 0.0, duration) \
+		spark_tween.tween_property(inner_glow, "color:a", 0.0, duration * 0.88) \
 			.set_ease(Tween.EASE_IN).set_delay(duration * 0.10)
-		spark_tween.tween_property(core, "color:a", 0.0, duration) \
+		spark_tween.tween_property(core, "color:a", 0.0, duration * 0.82) \
 			.set_ease(Tween.EASE_IN).set_delay(duration * 0.15)
 
-	var cleanup_timer := get_tree().create_timer(1.15)
+	var cleanup_timer := get_tree().create_timer(UNLOCK_SPARK_DURATION_MAX + UNLOCK_SPARK_CLEANUP_PADDING)
 	cleanup_timer.timeout.connect(func():
 		if is_instance_valid(spark_layer):
 			spark_layer.queue_free()

--- a/tests/unit/test_armory_menu.gd
+++ b/tests/unit/test_armory_menu.gd
@@ -1153,12 +1153,16 @@ func test_unlock_sparks_arc_downward_and_glow() -> void:
 	if source.is_empty():
 		return
 
-	assert_true(source.contains("const UNLOCK_SPARK_ARC_HEIGHT_MIN: float = 40.0"),
-		"Unlock sparks should launch upward before falling into a gravity-like arc")
-	assert_true(source.contains("const UNLOCK_SPARK_GRAVITY_FALL_MAX: float = 110.0"),
+	assert_true(source.contains("const UNLOCK_SPARK_ARC_HEIGHT_MIN: float = 24.0"),
+		"Unlock sparks should use a lower launch arc so the longer fall reads as slow drifting")
+	assert_true(source.contains("const UNLOCK_SPARK_GRAVITY_FALL_MAX: float = 165.0"),
 		"Unlock sparks should visibly fall downward after the initial burst")
-	assert_true(source.contains("const UNLOCK_SPARK_DURATION_MIN: float = 0.70"),
-		"Unlock sparks should move slower than the original quick straight burst")
+	assert_true(source.contains("const UNLOCK_SPARK_DURATION_MIN: float = 1.45"),
+		"Unlock sparks should linger much longer after the card opens")
+	assert_true(source.contains("const UNLOCK_SPARK_DURATION_MAX: float = 2.10"),
+		"Unlock sparks should have enough lifetime to fall slowly while shrinking")
+	assert_true(source.contains("const UNLOCK_SPARK_CLEANUP_PADDING: float = 0.18"),
+		"Unlock spark cleanup should be tied to the configured maximum lifetime")
 	assert_true(source.contains("UnlockSparkGlowOuter"),
 		"Unlock sparks should include a soft outer glow for a realistic ember effect")
 	assert_true(source.contains("UnlockSparkGlowInner"),
@@ -1167,10 +1171,16 @@ func test_unlock_sparks_arc_downward_and_glow() -> void:
 		"Unlock sparks should include a bright core inside the glow")
 	assert_true(source.contains("movement_tween.tween_property(spark, \"position\", target_position"),
 		"Unlock sparks should animate in two position phases to create an arc")
+	assert_true(source.contains("duration * 0.70"),
+		"Unlock sparks should spend most of their lifetime in the slow downward fall")
+	assert_true(source.contains("Tween.EASE_IN_OUT).set_trans(Tween.TRANS_SINE)"),
+		"Unlock sparks should use smoother slow fall and shrink easing")
 	assert_true(source.contains("var core_size := Vector2(core_width, core_height)"),
 		"Unlock sparks should build their visible particle from a tiny 1x1 to 1x3 core")
 	assert_true(source.contains("var halo_diameter: float = max_core_axis * glow_scale"),
 		"Unlock spark glow sizing should use explicit float typing for Godot 4.3 script loading")
+	assert_true(source.contains("UNLOCK_SPARK_DURATION_MAX + UNLOCK_SPARK_CLEANUP_PADDING"),
+		"Unlock spark layer should not be removed before the longer fade completes")
 	assert_false(source.contains("var halo_diameter := max(core_size.x, core_size.y)"),
 		"Unlock spark glow sizing should avoid Variant max() inference that can break exported Godot 4.3 builds")
 	assert_false(source.contains("var streak_ratio :="),


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/godot-topdown-MVP#1943.

Makes the armory unlock-card sparks linger longer after the reveal, drift downward more slowly, and shrink out while fading instead of disappearing quickly.

## Changes

- Extends unlock spark lifetime from ~0.7-1.05s to ~1.45-2.10s.
- Lowers the initial arc and increases the downward fall distance so sparks read as slow falling embers.
- Uses smoother sine easing for the downward motion and shrink-out.
- Ties spark layer cleanup to the configured max duration so particles are not removed early.
- Updates armory menu source assertions to cover the longer fall/shrink behavior.

## Verification

- `git diff --check`
- `dotnet build` passes with existing warnings

Note: full GUT execution was not run locally because no `godot` executable is available on PATH in this workspace.
