### PR TITLE
Разрешить громкость музыки до 200%

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-03T22:27:50.230Z for PR creation at branch issue-1947-f944f65f02c7 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1947

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-03T22:27:50.230Z for PR creation at branch issue-1947-f944f65f02c7 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1947

--- a/scenes/ui/SoundMenu.tscn
+++ b/scenes/ui/SoundMenu.tscn
@@ -89,12 +89,12 @@ custom_minimum_size = Vector2(250, 30)
 layout_mode = 2
 size_flags_horizontal = 3
 min_value = 0.0
-max_value = 100.0
+max_value = 200.0
 step = 1.0
 value = 100.0
 
 [node name="MusicValueLabel" type="Label" parent="MenuContainer/PanelContainer/MarginContainer/VBoxContainer/MusicContainer"]
-custom_minimum_size = Vector2(45, 0)
+custom_minimum_size = Vector2(55, 0)
 layout_mode = 2
 text = "100%"
 horizontal_alignment = 2

--- a/scripts/autoload/sound_settings.gd
+++ b/scripts/autoload/sound_settings.gd
@@ -5,8 +5,8 @@ extends Node
 ## - Effects volume (громкость эффектов): controls all sound effects
 ## - Music volume (громкость музыки): controls background music
 ##
-## Volumes are stored as linear values [0.0, 1.0] and converted to dB for
-## Godot's audio bus system. Settings are persisted to disk.
+## Volumes are stored as linear values and converted to dB for Godot's audio
+## bus system. Settings are persisted to disk.
 
 ## Signal emitted when any sound setting changes.
 signal settings_changed
@@ -14,7 +14,7 @@ signal settings_changed
 ## Linear volume for sound effects [0.0, 1.0]. Default is full volume.
 var effects_volume: float = 1.0
 
-## Linear volume for music [0.0, 1.0]. Default is full volume.
+## Linear volume for music [0.0, 2.0]. Default is full volume.
 var music_volume: float = 1.0
 
 ## Whether pause-screen music muffling is enabled. Default preserves existing behaviour.
@@ -35,6 +35,12 @@ const MIN_VOLUME_DB: float = -80.0
 ## Maximum volume in dB (full volume).
 const MAX_VOLUME_DB: float = 0.0
 
+## Maximum linear volume for effects (100%).
+const MAX_EFFECTS_VOLUME: float = 1.0
+
+## Maximum linear volume for music (200%).
+const MAX_MUSIC_VOLUME: float = 2.0
+
 
 func _ready() -> void:
 	_load_settings()
@@ -46,7 +52,7 @@ func _ready() -> void:
 ## Sets the effects volume.
 ## @param volume: Linear volume value [0.0, 1.0].
 func set_effects_volume(volume: float) -> void:
-	volume = clamp(volume, 0.0, 1.0)
+	volume = clamp(volume, 0.0, MAX_EFFECTS_VOLUME)
 	if not is_equal_approx(effects_volume, volume):
 		effects_volume = volume
 		_apply_effects_volume()
@@ -61,9 +67,9 @@ func get_effects_volume() -> float:
 
 
 ## Sets the music volume.
-## @param volume: Linear volume value [0.0, 1.0].
+## @param volume: Linear volume value [0.0, 2.0].
 func set_music_volume(volume: float) -> void:
-	volume = clamp(volume, 0.0, 1.0)
+	volume = clamp(volume, 0.0, MAX_MUSIC_VOLUME)
 	if not is_equal_approx(music_volume, volume):
 		music_volume = volume
 		_apply_music_volume()
@@ -72,7 +78,7 @@ func set_music_volume(volume: float) -> void:
 		_log_to_file("Music volume set to %.2f" % volume)
 
 
-## Gets the current music volume as a linear value [0.0, 1.0].
+## Gets the current music volume as a linear value [0.0, 2.0].
 func get_music_volume() -> float:
 	return music_volume
 
@@ -95,7 +101,7 @@ func is_music_muffle_enabled() -> bool:
 	return music_muffle_enabled
 
 
-## Converts a linear volume [0.0, 1.0] to decibels.
+## Converts a linear volume to decibels.
 ## Returns MIN_VOLUME_DB for zero volume (silence).
 func linear_to_db(linear: float) -> float:
 	if linear <= 0.0:
@@ -148,8 +154,8 @@ func _load_settings() -> void:
 		music_volume = config.get_value("sound", "music_volume", 1.0)
 		music_muffle_enabled = config.get_value("sound", "music_muffle_enabled", true)
 		# Clamp values in case the file was edited manually
-		effects_volume = clamp(effects_volume, 0.0, 1.0)
-		music_volume = clamp(music_volume, 0.0, 1.0)
+		effects_volume = clamp(effects_volume, 0.0, MAX_EFFECTS_VOLUME)
+		music_volume = clamp(music_volume, 0.0, MAX_MUSIC_VOLUME)
 	else:
 		effects_volume = 1.0
 		music_volume = 1.0

--- a/tests/unit/test_sound_menu.gd
+++ b/tests/unit/test_sound_menu.gd
@@ -24,7 +24,7 @@ class MockSoundSettings:
 		return effects_volume
 
 	func set_music_volume(volume: float) -> void:
-		music_volume = clamp(volume, 0.0, 1.0)
+		music_volume = clamp(volume, 0.0, 2.0)
 		settings_changed_count += 1
 
 	func get_music_volume() -> float:
@@ -46,6 +46,7 @@ class MockSoundSettings:
 class MockSoundMenu:
 	## Simulated slider values (0..100)
 	var effects_slider_value: float = 100.0
+	## Music slider supports up to 200% volume.
 	var music_slider_value: float = 100.0
 	var music_muffle_button_pressed: bool = true
 
@@ -163,6 +164,14 @@ func test_on_music_volume_changed_updates_settings() -> void:
 		"SoundSettings music volume should be 0.40 when slider is at 40")
 
 
+func test_on_music_volume_changed_accepts_200_percent() -> void:
+	menu.on_music_volume_changed(200.0, sound_settings)
+	assert_almost_eq(sound_settings.get_music_volume(), 2.0, 0.001,
+		"SoundSettings music volume should be 2.0 when slider is at 200")
+	assert_eq(menu.music_value_text, "200%",
+		"Music label should show '200%%' after slider change to 200")
+
+
 func test_on_effects_volume_changed_updates_label() -> void:
 	menu.on_effects_volume_changed(60.0, sound_settings)
 	assert_eq(menu.effects_value_text, "60%",
@@ -236,3 +245,12 @@ func test_different_effects_and_music_volumes_displayed_correctly() -> void:
 		"Effects label should show 60%%")
 	assert_eq(menu.music_value_text, "40%",
 		"Music label should show 40%%")
+
+
+func test_update_ui_displays_music_200_percent() -> void:
+	sound_settings.music_volume = 2.0
+	menu.update_ui(sound_settings)
+	assert_eq(menu.music_slider_value, 200.0,
+		"Music slider should be 200 when music volume is 2.0")
+	assert_eq(menu.music_value_text, "200%",
+		"Music label should show 200%%")

--- a/tests/unit/test_sound_settings.gd
+++ b/tests/unit/test_sound_settings.gd
@@ -29,8 +29,11 @@ class MockSoundSettings:
 	## Maximum volume in dB (full volume).
 	const MAX_VOLUME_DB: float = 0.0
 
+	const MAX_EFFECTS_VOLUME: float = 1.0
+	const MAX_MUSIC_VOLUME: float = 2.0
+
 	func set_effects_volume(volume: float) -> void:
-		volume = clamp(volume, 0.0, 1.0)
+		volume = clamp(volume, 0.0, MAX_EFFECTS_VOLUME)
 		if not is_equal_approx(effects_volume, volume):
 			effects_volume = volume
 			settings_changed_count += 1
@@ -39,7 +42,7 @@ class MockSoundSettings:
 		return effects_volume
 
 	func set_music_volume(volume: float) -> void:
-		volume = clamp(volume, 0.0, 1.0)
+		volume = clamp(volume, 0.0, MAX_MUSIC_VOLUME)
 		if not is_equal_approx(music_volume, volume):
 			music_volume = volume
 			settings_changed_count += 1
@@ -145,9 +148,15 @@ func test_set_music_volume_stores_value() -> void:
 
 
 func test_set_music_volume_clamps_above_max() -> void:
+	settings.set_music_volume(2.5)
+	assert_eq(settings.get_music_volume(), settings.MAX_MUSIC_VOLUME,
+		"Music volume above 2.0 should be clamped to 2.0")
+
+
+func test_set_music_volume_accepts_200_percent() -> void:
 	settings.set_music_volume(2.0)
-	assert_eq(settings.get_music_volume(), 1.0,
-		"Music volume above 1.0 should be clamped to 1.0")
+	assert_eq(settings.get_music_volume(), 2.0,
+		"Music volume should support 2.0 (200%%)")
 
 
 func test_set_music_volume_clamps_below_min() -> void:
@@ -221,6 +230,12 @@ func test_linear_to_db_full_volume_is_zero_db() -> void:
 		"Full volume (1.0) should convert to 0.0 dB")
 
 
+func test_linear_to_db_double_volume_is_plus_6db() -> void:
+	var db := settings.linear_to_db(2.0)
+	assert_almost_eq(db, 6.02, 0.1,
+		"200%% volume should convert to approximately +6 dB")
+
+
 func test_linear_to_db_zero_volume_is_silence() -> void:
 	var db := settings.linear_to_db(0.0)
 	assert_eq(db, settings.MIN_VOLUME_DB,
@@ -260,7 +275,7 @@ func test_effects_volume_accepts_all_valid_percentages() -> void:
 
 
 func test_music_volume_accepts_all_valid_percentages() -> void:
-	for i in range(0, 101, 10):
+	for i in range(0, 201, 10):
 		settings.set_music_volume(i / 100.0)
 		assert_almost_eq(settings.get_music_volume(), i / 100.0, 0.001,
 			"Music volume %d%% should be accepted" % i)


### PR DESCRIPTION
## Summary
- Расширяет ползунок громкости музыки в настройках со 100% до 200%.
- Разрешает `SoundSettings` хранить и применять `music_volume = 2.0`, что даёт примерно +6 dB через существующую `linear_to_db` конвертацию.
- Оставляет громкость эффектов ограниченной 100%.

## Tests
- `dotnet build` (passes; existing warnings remain)
- Static checks mirrored from architecture workflow: script size, component `class_name`, and snake_case GDScript filenames
- Not run: GUT tests locally, because `godot` is not installed in this environment

Fixes Jhon-Crow/godot-topdown-MVP#1947