### PR TITLE
Fix breaker bullets after fallback weapon swaps

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-03T22:55:30.275Z for PR creation at branch issue-1949-3ccfee3c833c for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1949

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-03T22:55:30.275Z for PR creation at branch issue-1949-3ccfee3c833c for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1949

--- a/Scripts/Characters/Player.ActiveItems.cs
+++ b/Scripts/Characters/Player.ActiveItems.cs
@@ -1522,10 +1522,23 @@ public partial class Player
         _breakerBulletsActive = true;
         LogToFile("[Player.BreakerBullets] Breaker bullets active — bullets will detonate 95px before walls, with enemy proximity fuse (40px arming distance)");
 
-        // Set breaker bullet flag on current weapon so all spawned bullets get the flag
-        if (CurrentWeapon != null)
+        SyncBreakerBulletsToCurrentWeapon();
+    }
+
+    /// <summary>
+    /// Propagates the passive breaker-bullet state to the currently equipped weapon.
+    /// Some C# fallback levels replace the default weapon after InitBreakerBullets() runs.
+    /// </summary>
+    private void SyncBreakerBulletsToCurrentWeapon()
+    {
+        if (CurrentWeapon == null)
         {
-            CurrentWeapon.IsBreakerBulletActive = true;
+            return;
+        }
+
+        CurrentWeapon.IsBreakerBulletActive = _breakerBulletsActive;
+        if (_breakerBulletsActive)
+        {
             LogToFile($"[Player.BreakerBullets] Set IsBreakerBulletActive on weapon: {CurrentWeapon.Name}");
         }
     }

--- a/Scripts/Characters/Player.cs
+++ b/Scripts/Characters/Player.cs
@@ -2973,11 +2973,8 @@ public partial class Player : BaseCharacter
 
         CurrentWeapon = weapon;
 
-        // Propagate breaker bullets flag to new weapon (Issue #678)
-        if (_breakerBulletsActive)
-        {
-            CurrentWeapon.IsBreakerBulletActive = true;
-        }
+        // Propagate breaker bullets flag to new weapon (Issue #678, #1949)
+        SyncBreakerBulletsToCurrentWeapon();
 
         // Propagate Combat Disposition bonuses to new weapon (Issue #1047)
         // This ensures the penalty persists when the weapon is swapped during a run.
@@ -3120,6 +3117,8 @@ public partial class Player : BaseCharacter
             AddChild(weapon);
             LogToFile($"[Player.Weapon] [trace] AddChild({weaponNodeName}) returned (entered tree)");
             CurrentWeapon = weapon;
+            // Apply passive item flags after deferred fallback weapon replacement (Issue #1949).
+            SyncBreakerBulletsToCurrentWeapon();
             // Issue #1774: WeaponData may be null here on first load (C# GlobalClass resource
             // registration race). BaseWeapon._Ready() will have scheduled DeferredReadyInit().
             // LabyrinthLevel._configure_labyrinth_weapon_ammo() handles ammo setup with explicit

--- a/docs/case-studies/issue-1949/README.md
+++ b/docs/case-studies/issue-1949/README.md
@@ -1,0 +1,47 @@
+# Issue 1949: Breaker bullets lost on fallback weapon selection
+
+## Issue
+
+Breaker bullets stopped behaving as breaker bullets on Building, Double Corridor,
+City, Decadence, Labyrinth Complex, and Sewer. The player still had Breaker
+Bullets selected, but shots from the selected weapon behaved like normal bullets.
+
+## Evidence
+
+The attached session log is preserved at:
+
+- `docs/case-studies/issue-1949/game_log_20260504_015203.txt`
+
+The log shows the passive item loading correctly, then being applied only to the
+startup weapon:
+
+- `ActiveItemManager` restores and selects Breaker Bullets.
+- Each affected scene logs `Set IsBreakerBulletActive on weapon: MakarovPM`.
+- The same scene then applies the selected weapon later, for example `ak_gl
+  (AKGL)`, through `ApplySelectedWeaponFromGameManager`.
+- Before this fix there was no second breaker sync after `CurrentWeapon = weapon`
+  in the deferred selected-weapon path.
+
+An online/repository search did not reveal a map collision-data difference that
+explained the failure. The decisive pattern came from the local log: the maps
+all replace the default weapon after active-item initialization.
+
+## Root Cause
+
+`InitBreakerBullets()` set `CurrentWeapon.IsBreakerBulletActive` during player
+startup. On the affected C# fallback levels, `CurrentWeapon` was still the
+default `MakarovPM` at that point. The deferred GameManager weapon selection
+then replaced `CurrentWeapon` with the selected weapon, but did not propagate the
+passive breaker-bullet flag to that new weapon.
+
+## Fix
+
+`Player` now uses a shared `SyncBreakerBulletsToCurrentWeapon()` helper:
+
+- `InitBreakerBullets()` applies the passive state through the helper.
+- `EquipWeapon()` reapplies it when weapons are swapped normally.
+- `ApplySelectedWeaponFromGameManager()` reapplies it immediately after the
+  deferred fallback assigns the selected weapon to `CurrentWeapon`.
+
+The regression test `test_csharp_deferred_weapon_selection_keeps_breaker_bullets_active`
+guards the C# fallback contract that caused the map-specific failure.

--- a/tests/unit/test_breaker_bullet.gd
+++ b/tests/unit/test_breaker_bullet.gd
@@ -860,3 +860,23 @@ func test_csharp_breaker_shrapnel_uses_pool_fallback_when_scene_missing() -> voi
 		"C# breaker shrapnel should instantiate from the refreshed fallback scene when the pool misses")
 	assert_eq(body.find("var shrapnelScene = GetShrapnelScene();\n        if (shrapnelScene == null)\n        {\n            return;\n        }"), -1,
 		"C# breaker shrapnel must not skip spawning just because the PackedScene cache is null")
+
+
+func test_csharp_deferred_weapon_selection_keeps_breaker_bullets_active() -> void:
+	# Issue #1949: affected C# fallback maps first initialize breaker bullets on the
+	# default MakarovPM, then ApplySelectedWeaponFromGameManager replaces the weapon.
+	# The replacement path must reapply passive item flags to the new weapon.
+	var player_source := _read_text_file("res://Scripts/Characters/Player.cs")
+	var active_items_source := _read_text_file("res://Scripts/Characters/Player.ActiveItems.cs")
+	var equip_body := _extract_csharp_method(player_source, "public void EquipWeapon(BaseWeapon weapon)")
+	var deferred_body := _extract_csharp_method(player_source, "private void ApplySelectedWeaponFromGameManager()")
+	var sync_body := _extract_csharp_method(active_items_source, "private void SyncBreakerBulletsToCurrentWeapon()")
+
+	assert_true(active_items_source.contains("SyncBreakerBulletsToCurrentWeapon();"),
+		"InitBreakerBullets should use the shared sync helper")
+	assert_true(equip_body.contains("SyncBreakerBulletsToCurrentWeapon();"),
+		"EquipWeapon should propagate breaker bullets to every newly equipped weapon")
+	assert_true(deferred_body.contains("CurrentWeapon = weapon;\n            // Apply passive item flags after deferred fallback weapon replacement (Issue #1949).\n            SyncBreakerBulletsToCurrentWeapon();"),
+		"Deferred GameManager weapon replacement should sync breaker bullets after assigning CurrentWeapon")
+	assert_true(sync_body.contains("CurrentWeapon.IsBreakerBulletActive = _breakerBulletsActive;"),
+		"The sync helper should copy the passive item flag to the current C# weapon")


### PR DESCRIPTION
## Summary
- fixes Breaker Bullets being applied only to the startup MakarovPM before C# fallback levels replace it with the selected weapon
- adds a shared C# sync helper and calls it from startup, normal EquipWeapon, and deferred GameManager weapon selection
- adds a regression test for the deferred weapon-selection contract and documents the attached log analysis

## Reproduction
1. Select Breaker Bullets and a non-default weapon such as AKGL.
2. Load affected maps such as Building, City, Decadence, Labyrinth Complex, or Sewer.
3. Before this fix, logs show Breaker Bullets synced to MakarovPM, then the selected weapon is equipped later without the breaker flag.

## Tests
- dotnet build GodotTopDownTemplate.sln
- Added `test_csharp_deferred_weapon_selection_keeps_breaker_bullets_active` in `tests/unit/test_breaker_bullet.gd`

Note: GUT could not be run locally in this container because no Godot executable is available on PATH.


Fixes Jhon-Crow/godot-topdown-MVP#1949