### PR TITLE
Сделать музыку на карте ЖД Станция тише

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-04T00:56:29.301Z for PR creation at branch issue-1951-d03f7afc4d97 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1951

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-04T00:56:29.301Z for PR creation at branch issue-1951-d03f7afc4d97 for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1951

--- a/scripts/autoload/music_manager.gd
+++ b/scripts/autoload/music_manager.gd
@@ -33,6 +33,12 @@ const LEVEL_MUSIC: Dictionary = {
 	"res://scenes/levels/RailwayStationLevel.tscn": "res://assets/audio/music/railway-station(fixed).mp3",
 }
 
+## Per-level music volume multipliers. Values are linear gain applied on top
+## of the global Music bus slider. Unlisted levels use normal volume.
+const LEVEL_VOLUME_MULTIPLIERS: Dictionary = {
+	"res://scenes/levels/RailwayStationLevel.tscn": 0.8,
+}
+
 ## Name of the audio bus that the music slider in sound settings drives.
 const MUSIC_BUS: String = "Music"
 
@@ -230,6 +236,7 @@ func _play_track_for_path(scene_path: String) -> void:
 	if not LEVEL_MUSIC.has(scene_path):
 		_player.stop()
 		_player.stream = null
+		_player.volume_linear = 1.0
 		return
 
 	var music_path: String = LEVEL_MUSIC[scene_path]
@@ -238,6 +245,7 @@ func _play_track_for_path(scene_path: String) -> void:
 		push_warning("[MusicManager] Failed to load music: %s" % music_path)
 		_player.stop()
 		_player.stream = null
+		_player.volume_linear = 1.0
 		return
 
 	# Looping is enforced in `_on_player_finished` so it works for both
@@ -249,6 +257,7 @@ func _play_track_for_path(scene_path: String) -> void:
 		stream.loop = true
 
 	_player.stream = stream
+	_player.volume_linear = get_volume_multiplier_for_scene(scene_path)
 	_player.play()
 
 
@@ -339,6 +348,12 @@ func get_pause_muffle_effect() -> AudioEffect:
 ## an empty string if none. Used by tests and external integrations.
 func get_music_path_for_scene(scene_path: String) -> String:
 	return LEVEL_MUSIC.get(scene_path, "")
+
+
+## Public API: returns the per-scene linear volume multiplier, or normal
+## volume when the scene has no override.
+func get_volume_multiplier_for_scene(scene_path: String) -> float:
+	return LEVEL_VOLUME_MULTIPLIERS.get(scene_path, 1.0)
 
 
 ## Public API: returns true when the music player is currently playing.

--- a/tests/unit/test_music_manager.gd
+++ b/tests/unit/test_music_manager.gd
@@ -213,6 +213,20 @@ func test_get_music_path_for_unknown_scene_returns_empty() -> void:
 		"Unknown scenes should return an empty music path")
 
 
+func test_railway_station_music_is_twenty_percent_quieter() -> void:
+	var multiplier: float = manager.get_volume_multiplier_for_scene(
+		"res://scenes/levels/RailwayStationLevel.tscn")
+	assert_almost_eq(multiplier, 0.8, 0.001,
+		"Railway Station music should play at 80% of normal level volume")
+
+
+func test_levels_without_volume_override_use_normal_music_volume() -> void:
+	var multiplier: float = manager.get_volume_multiplier_for_scene(
+		"res://scenes/levels/LabyrinthLevel.tscn")
+	assert_almost_eq(multiplier, 1.0, 0.001,
+		"Levels without explicit overrides should keep normal music volume")
+
+
 func test_exit_zone_activation_stops_music() -> void:
 	# Verify the handler stops the player. Set up a stream and assert that
 	# after calling the handler the player.stream is unchanged (we only
@@ -231,12 +245,15 @@ func test_exit_zone_activation_stops_music() -> void:
 func test_play_track_for_unknown_path_clears_stream() -> void:
 	var player: AudioStreamPlayer = manager.get_node("MusicStreamPlayer")
 	player.stream = _make_dummy_stream()
+	player.volume_linear = 0.8
 
 	manager._play_track_for_path("res://scenes/levels/Nonexistent.tscn")
 	assert_null(player.stream,
 		"Player stream should be cleared when scene has no music mapping")
 	assert_false(player.playing,
 		"Player should be stopped when scene has no music mapping")
+	assert_almost_eq(player.volume_linear, 1.0, 0.001,
+		"Player volume should reset to normal when scene has no music mapping")
 
 
 func test_source_skips_replay_when_scene_path_unchanged() -> void:


### PR DESCRIPTION
Fixes Jhon-Crow/godot-topdown-MVP#1951

## Summary
- Added per-level music volume multipliers in MusicManager.
- Set RailwayStationLevel music to 0.8 linear volume, making it 20% quieter while preserving the global Music slider behavior.
- Added regression coverage for the Railway Station override and default 1.0 volume on other levels.

## Testing
- `git diff --check`
- GUT not run locally: Godot executable is not available on PATH in this environment.