### PR TITLE
Fix breaker bullets reacting to RPG rockets

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-04T01:42:09.631Z for PR creation at branch issue-1955-8326df464e2f for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1955

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-04T01:42:09.631Z for PR creation at branch issue-1955-8326df464e2f for issue https://github.com/Jhon-Crow/godot-topdown-MVP/issues/1955

--- a/Scripts/Projectiles/BreakerDetonation.cs
+++ b/Scripts/Projectiles/BreakerDetonation.cs
@@ -7,7 +7,7 @@ namespace GodotTopDownTemplate.Projectiles;
 /// Static helper for breaker bullet detonation logic (Issue #678).
 /// Shared by Bullet.cs and ShotgunPellet.cs to avoid code duplication.
 ///
-/// Breaker bullets detonate 95px before hitting a wall or alive enemy,
+/// Breaker bullets detonate 95px before hitting a wall, alive enemy, or RPG rocket,
 /// dealing 1 damage in a 15px radius and spawning shrapnel in a forward cone.
 /// </summary>
 public static class BreakerDetonation
@@ -90,8 +90,8 @@ public static class BreakerDetonation
 
     /// <summary>
     /// Checks if a wall is within detonation distance ahead (straight raycast), or if an alive
-    /// enemy is within the shrapnel cone sector (Issue #1634: proximity fuse should detonate early
-    /// when an enemy enters the sector of future shrapnel to maximise shrapnel hit chance).
+    /// enemy/RPG rocket is within the shrapnel cone sector (Issue #1634: proximity fuse should
+    /// detonate early when a target enters the sector of future shrapnel).
     /// </summary>
     /// <param name="projectile">The bullet/pellet Area2D node.</param>
     /// <param name="direction">Normalized direction of travel.</param>
@@ -142,12 +142,16 @@ public static class BreakerDetonation
             }
         }
 
-        // 2. Cone sector check for enemies (Issue #1634).
-        // Gated by arming distance: the enemy-cone fuse only activates after ArmingDistance pixels,
-        // preventing immediate detonation when enemies are close to the player at fire time.
+        // 2. Cone sector check for enemies and RPG rockets (Issues #1634, #1955).
+        // Gated by arming distance: the cone fuse only activates after ArmingDistance pixels,
+        // preventing immediate detonation when targets are close to the player at fire time.
         if (distanceTraveled >= ArmingDistance)
         {
             if (CheckEnemyInShrapnelCone(projectile, direction, damage, damageMultiplier, shooterId))
+            {
+                return true;
+            }
+            if (CheckRpgRocketInShrapnelCone(projectile, direction, damage, damageMultiplier, shooterId))
             {
                 return true;
             }
@@ -173,7 +177,6 @@ public static class BreakerDetonation
         var tree = projectile.GetTree();
         if (tree == null) return false;
 
-        float cosHalfAngle = Mathf.Cos(Mathf.DegToRad(ShrapnelHalfAngle));
         var enemies = tree.GetNodesInGroup("enemies");
 
         foreach (var enemy in enemies)
@@ -181,25 +184,62 @@ public static class BreakerDetonation
             if (enemy is not Node2D enemyNode) continue;
             if (!enemyNode.HasMethod("is_alive") || !enemyNode.Call("is_alive").AsBool()) continue;
 
-            var toEnemy = enemyNode.GlobalPosition - projectile.GlobalPosition;
-            float dist = toEnemy.Length();
-            if (dist > DetonationDistance) continue;
-
-            // Dot product of normalized vectors equals cos(angle_between).
-            // Enemy is in cone if cos(angle) >= cos(half_angle).
-            if (dist > 0f && (toEnemy / dist).Dot(direction) >= cosHalfAngle)
+            if (TargetInShrapnelCone(projectile, direction, enemyNode.GlobalPosition))
             {
-                // Only detonate if there is no wall between the bullet and the enemy.
-                // Without this check, bullets detonate against enemies through walls.
-                if (!HasLineOfSight(projectile, projectile.GlobalPosition, enemyNode.GlobalPosition))
-                    continue;
-
                 Detonate(projectile, direction, damage, damageMultiplier, shooterId);
                 return true;
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Returns true (and triggers detonation) if any RPG rocket is within the shrapnel cone sector.
+    /// Issue #1955: proximity-fuse bullets should detonate before RPG rockets too.
+    /// </summary>
+    private static bool CheckRpgRocketInShrapnelCone(
+        Area2D projectile,
+        Vector2 direction,
+        float damage,
+        float damageMultiplier,
+        ulong shooterId)
+    {
+        var tree = projectile.GetTree();
+        if (tree == null) return false;
+
+        var rockets = tree.GetNodesInGroup("rpg_rockets");
+
+        foreach (var rocket in rockets)
+        {
+            if (rocket is not Node2D rocketNode) continue;
+            if (rocketNode == projectile) continue;
+
+            if (TargetInShrapnelCone(projectile, direction, rocketNode.GlobalPosition))
+            {
+                Detonate(projectile, direction, damage, damageMultiplier, shooterId);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns true when a target point is in the breaker cone with clear line of sight.
+    /// </summary>
+    private static bool TargetInShrapnelCone(Area2D projectile, Vector2 direction, Vector2 targetPosition)
+    {
+        var toTarget = targetPosition - projectile.GlobalPosition;
+        float dist = toTarget.Length();
+        if (dist > DetonationDistance || dist <= 0f) return false;
+
+        float cosHalfAngle = Mathf.Cos(Mathf.DegToRad(ShrapnelHalfAngle));
+        if ((toTarget / dist).Dot(direction) < cosHalfAngle) return false;
+
+        // Only detonate if there is no wall between the bullet and target.
+        // Without this check, bullets detonate against targets through walls.
+        return HasLineOfSight(projectile, projectile.GlobalPosition, targetPosition);
     }
 
     /// <summary>

--- a/scripts/projectiles/bullet.gd
+++ b/scripts/projectiles/bullet.gd
@@ -1612,7 +1612,7 @@ func _has_line_of_sight_to_target(target_pos: Vector2) -> bool:
 # ============================================================================
 
 
-## Checks if a wall is within BREAKER_DETONATION_DISTANCE ahead, or if an alive enemy
+## Checks if a wall is within BREAKER_DETONATION_DISTANCE ahead, or if an alive enemy/RPG rocket
 ## is within the shrapnel cone sector (Issue #1634: proximity fuse should detonate early
 ## when an enemy enters the sector of future shrapnel to maximise shrapnel hit chance).
 ## @return: True if detonation occurred, false otherwise.
@@ -1649,6 +1649,8 @@ func _check_breaker_detonation() -> bool:
 	if _breaker_distance_traveled >= BREAKER_ARMING_DISTANCE:
 		if _check_enemy_in_shrapnel_cone():
 			return true
+		if _check_rpg_rocket_in_shrapnel_cone():
+			return true
 
 	return false  # Nothing triggering detonation
 
@@ -1660,7 +1662,6 @@ func _check_breaker_detonation() -> bool:
 ## Optimization: uses dot product comparison instead of acos for the angle check.
 ## LOS check prevents premature detonation against enemies through walls (Issue #1634).
 func _check_enemy_in_shrapnel_cone() -> bool:
-	var cos_half_angle := cos(deg_to_rad(BREAKER_SHRAPNEL_HALF_ANGLE))
 	var enemies := get_tree().get_nodes_in_group("enemies")
 	for enemy in enemies:
 		if not (enemy is Node2D):
@@ -1668,23 +1669,48 @@ func _check_enemy_in_shrapnel_cone() -> bool:
 		var enemy_node := enemy as Node2D
 		if not (enemy_node.has_method("is_alive") and enemy_node.is_alive()):
 			continue
-		var to_enemy: Vector2 = enemy_node.global_position - global_position
-		var dist: float = to_enemy.length()
-		if dist > BREAKER_DETONATION_DISTANCE:
-			continue
-		# Dot product of normalized vectors: equals cos(angle_between).
-		# If cos(angle) >= cos(half_angle), the angle is within the cone.
-		if dist > 0.0 and (to_enemy / dist).dot(direction) >= cos_half_angle:
-			# Only detonate if there is no wall between the bullet and the enemy.
-			# Without this check, bullets detonate against enemies through walls.
-			if not _breaker_has_line_of_sight(global_position, enemy_node.global_position):
-				continue
+		var dist: float = global_position.distance_to(enemy_node.global_position)
+		if _breaker_target_in_shrapnel_cone(enemy_node.global_position):
 			if _debug_breaker:
 				FileLogger.info("[Bullet.Breaker] Enemy %s in shrapnel cone at distance %.1f, detonating" % [
 					enemy_node.name, dist])
 			_breaker_detonate(global_position)
 			return true
 	return false
+
+
+## Returns true if any RPG rocket is within the armed shrapnel cone sector.
+## Issue #1955: proximity-fuse bullets should detonate before RPG rockets too.
+func _check_rpg_rocket_in_shrapnel_cone() -> bool:
+	var rockets := get_tree().get_nodes_in_group("rpg_rockets")
+	for rocket in rockets:
+		if not (rocket is Node2D):
+			continue
+		if rocket == self or not is_instance_valid(rocket):
+			continue
+		var rocket_node := rocket as Node2D
+		var dist: float = global_position.distance_to(rocket_node.global_position)
+		if _breaker_target_in_shrapnel_cone(rocket_node.global_position):
+			if _debug_breaker:
+				FileLogger.info("[Bullet.Breaker] RPG rocket %s in shrapnel cone at distance %.1f, detonating" % [
+					rocket_node.name, dist])
+			_breaker_detonate(global_position)
+			return true
+	return false
+
+
+## Returns true when a target point is in the breaker cone with clear line of sight.
+func _breaker_target_in_shrapnel_cone(target_pos: Vector2) -> bool:
+	var to_target: Vector2 = target_pos - global_position
+	var dist: float = to_target.length()
+	if dist > BREAKER_DETONATION_DISTANCE or dist <= 0.0:
+		return false
+	var cos_half_angle := cos(deg_to_rad(BREAKER_SHRAPNEL_HALF_ANGLE))
+	if (to_target / dist).dot(direction) < cos_half_angle:
+		return false
+	# Only detonate if there is no wall between the bullet and target.
+	# Without this check, bullets detonate against targets through walls.
+	return _breaker_has_line_of_sight(global_position, target_pos)
 
 
 ## Triggers the breaker bullet detonation: explosion damage + shrapnel cone.

--- a/tests/unit/test_breaker_bullet.gd
+++ b/tests/unit/test_breaker_bullet.gd
@@ -72,19 +72,35 @@ class MockBreakerBullet:
 		# Arming distance guard: cone fuse only triggers after bullet travels BREAKER_ARMING_DISTANCE
 		if distance_traveled < BREAKER_ARMING_DISTANCE:
 			return false
+		if _is_target_in_shrapnel_cone(enemy_pos, has_line_of_sight):
+			_breaker_detonate()
+			return true
+		return false
+
+	## Simulate the RPG rocket cone fuse check added in Issue #1955.
+	func check_rpg_rocket_in_shrapnel_cone(rocket_pos: Vector2, has_line_of_sight: bool = true, distance_traveled: float = BREAKER_ARMING_DISTANCE) -> bool:
+		if not is_breaker_bullet:
+			return false
+		if distance_traveled < BREAKER_ARMING_DISTANCE:
+			return false
+		if _is_target_in_shrapnel_cone(rocket_pos, has_line_of_sight):
+			_breaker_detonate()
+			return true
+		return false
+
+	func _is_target_in_shrapnel_cone(target_pos: Vector2, has_line_of_sight: bool = true) -> bool:
 		var cos_half_angle := cos(deg_to_rad(BREAKER_SHRAPNEL_HALF_ANGLE))
-		var to_enemy := enemy_pos - global_position
-		var dist := to_enemy.length()
+		var to_target := target_pos - global_position
+		var dist := to_target.length()
 		if dist > BREAKER_DETONATION_DISTANCE:
 			return false
 		if dist <= 0.0:
 			return false
-		if (to_enemy / dist).dot(direction) < cos_half_angle:
+		if (to_target / dist).dot(direction) < cos_half_angle:
 			return false
 		# Only detonate if there is no wall blocking line of sight (Issue #1634 fix)
 		if not has_line_of_sight:
 			return false
-		_breaker_detonate()
 		return true
 
 	## Trigger breaker detonation.
@@ -675,6 +691,40 @@ func test_detonates_via_cone_after_arming() -> void:
 
 	assert_true(result, "Should detonate via cone after bullet has traveled the arming distance")
 	assert_true(bullet.has_detonated())
+
+
+func test_detonates_when_rpg_rocket_ahead_in_cone_after_arming() -> void:
+	# Issue #1955: proximity-fuse bullets must react to RPG rockets, not only enemies.
+	bullet.direction = Vector2.RIGHT
+	bullet.global_position = Vector2.ZERO
+	var rocket_pos := Vector2(70.0, 0.0)
+
+	var result := bullet.check_rpg_rocket_in_shrapnel_cone(rocket_pos, true, MockBreakerBullet.BREAKER_ARMING_DISTANCE)
+
+	assert_true(result, "Should detonate when an RPG rocket is directly ahead within range")
+	assert_true(bullet.has_detonated())
+
+
+func test_does_not_detonate_for_rpg_rocket_before_arming() -> void:
+	bullet.direction = Vector2.RIGHT
+	bullet.global_position = Vector2.ZERO
+	var rocket_pos := Vector2(70.0, 0.0)
+
+	var result := bullet.check_rpg_rocket_in_shrapnel_cone(rocket_pos, true, 0.0)
+
+	assert_false(result, "Should not detonate on an RPG rocket before the cone fuse arms")
+	assert_false(bullet.has_detonated())
+
+
+func test_does_not_detonate_for_rpg_rocket_when_wall_blocks_los() -> void:
+	bullet.direction = Vector2.RIGHT
+	bullet.global_position = Vector2.ZERO
+	var rocket_pos := Vector2(70.0, 0.0)
+
+	var result := bullet.check_rpg_rocket_in_shrapnel_cone(rocket_pos, false, MockBreakerBullet.BREAKER_ARMING_DISTANCE)
+
+	assert_false(result, "Should not detonate on an RPG rocket through a wall")
+	assert_false(bullet.has_detonated())
 
 
 func test_wall_check_still_works_before_arming() -> void:


### PR DESCRIPTION
## Summary
- Extends breaker/proximity-fuse bullet cone detection to include RPG rockets in both GDScript and C# projectile paths.
- Reuses the same distance, cone-angle, arming-distance, and line-of-sight rules already used for enemy proximity detonation.
- Adds regression coverage for RPG rockets ahead of the bullet, pre-arming behavior, and blocked line of sight.

Fixes Jhon-Crow/godot-topdown-MVP#1955

## Reproduction
1. Equip/select breaker bullets (`Пули с превзрывателем`).
2. Fire toward an incoming RPG rocket.
3. Before this change, the breaker cone fuse ignored the RPG rocket and did not detonate before it.

## Verification
- `python -m pytest tests/test_red_dot_cursor.py tests/test_laser_feedback_followup.py` passed.
- `dotnet build` passed with existing warnings only.
- `git diff --check` passed.
- Attempted focused GUT run with Godot 4.3 mono: `--headless -s addons/gut/gut_cmdln.gd -gtest=res://tests/unit/test_breaker_bullet.gd,res://tests/unit/test_rpg_rocket_bullet_hit.gd -gexit`. The local run exited before focused results because the project currently triggers existing headless import/autoload/test-collection parse errors unrelated to this change.
